### PR TITLE
Constrain lxml dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     # Datasets and IO
     "datasets>=2.14",
     "ir-datasets>=0.5.5",
+    "lxml>=6.1.0",
     # Lexical retrieval
     "bm25s>=0.2",
     # Dense retrieval

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -31,6 +31,7 @@ PyYAML==6.0.3
 # --- Datasets and IO ---
 datasets==4.5.0
 ir_datasets==0.5.11
+lxml==6.1.0
 
 # --- Lexical retrieval ---
 bm25s==0.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pyyaml>=6.0
 # Datasets and IO
 datasets>=2.14
 ir-datasets>=0.5.5            # official MS MARCO Passage corpus + dev/small
+lxml>=6.1.0                   # constrain XML/HTML parsing dependency to patched releases
 
 # Lexical retrieval
 bm25s>=0.2                    # primary backend for the official Week 2 baseline


### PR DESCRIPTION
Summary:
- add an explicit lxml lower bound to the runtime and development dependency lists
- pin lxml 6.1.0 in the reproducibility lockfile

Validation:
- ruff check src tests experiments scripts
- python scripts/check_headline_metrics.py
- dependency lxml constraint check

Note:
- local pytest collection runs with PYTHONPATH=src, but the local Anaconda environment is missing bm25s/faiss and exposes a Windows path separator assertion; full pytest is left to the Linux CI environment.