### PR TITLE
Add RAG evaluation workflow docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results pipeline-dry-run serve-dev clean-pycache reproduce-baseline
+.PHONY: help install test test-slow lint check-results pipeline-dry-run rag-eval-dry-run serve-dev clean-pycache reproduce-baseline
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -18,6 +18,7 @@ help:
 	@echo "  make lint                 -- ruff check on src/, tests/, experiments/, scripts/"
 	@echo "  make check-results        -- verify metadata.json headline metrics against RESULTS.md"
 	@echo "  make pipeline-dry-run     -- print the config-driven experiment plan"
+	@echo "  make rag-eval-dry-run     -- print the research evaluation workflow plan"
 	@echo "  make serve-dev            -- start the optional FastAPI generation service"
 	@echo "  make reproduce-baseline   -- re-run + verify the W2 BM25 baseline (~30 min CPU laptop)"
 
@@ -62,6 +63,9 @@ check-results:
 
 pipeline-dry-run:
 	$(PYTHON) scripts/run_pipeline.py --dry-run
+
+rag-eval-dry-run:
+	rag-eval run --config configs/baseline.yaml --dry-run
 
 serve-dev:
 	mgq-serve --host 127.0.0.1 --port 8000

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ The repository includes runnable code plus written analysis artifacts:
 - [`RESULTS.md`](RESULTS.md) — headline metrics, statistical intervals, and interpretation limits.
 - [`REPRODUCIBILITY.md`](REPRODUCIBILITY.md) — setup, checks, run artifacts, and reproduction commands.
 - [`docs/experiments.md`](docs/experiments.md) — stage-by-stage experiment narrative and caveats.
+- [`docs/architecture.md`](docs/architecture.md) — module boundaries and artifact flow.
+- [`docs/evaluation_protocol.md`](docs/evaluation_protocol.md) — reproducible evaluation contract.
+- [`docs/failure_taxonomy.md`](docs/failure_taxonomy.md) — regression and grounding error taxonomy.
 - [`docs/retrieval_lift_analysis.md`](docs/retrieval_lift_analysis.md) — query-level reranker lift analysis protocol.
+- [`notebooks/rag_eval_demo.ipynb`](notebooks/rag_eval_demo.ipynb) — lightweight evaluation workflow demo.
 - [`reports/internship_report/report.pdf`](reports/internship_report/report.pdf) — frozen internship report snapshot.
 
 ## Engineering surface
@@ -61,6 +65,10 @@ auditing the experiments:
   → rerank → generation → paired-bootstrap → generator-capacity sequence.
   `python scripts/run_pipeline.py --dry-run` prints the executable plan without
   loading data or models.
+- **Research evaluation workflow.** `rag-eval run --config configs/baseline.yaml`
+  builds the end-to-end BM25, dense, rerank, paired generation, bootstrap, and
+  grounding plan from the baseline config. Use `--dry-run` to inspect the
+  command sequence before touching data or models.
 - **CI and automation.** The GitHub Actions workflow runs unit tests, linting,
   and manifest/reproduction checks; the local mirror is `make test` and
   `make lint`.
@@ -95,6 +103,7 @@ auditing the experiments:
 - **`scripts/`** — analyses, ablations, validation, integration smokes that read `experiments/` outputs.
 - **`src/`** — importable library code backing both.
 - **`docs/`** — experiment narratives and reproducibility notes.
+- **`notebooks/`** — lightweight demos for inspecting the workflow without running heavy jobs.
 - **`reports/acl_findings/`** — ACL-Findings-style experimental report draft.
 - **`reports/internship_report/`** — frozen v1.0 PDF + sources.
 - **`metadata.json`** — project metadata summarising dataset scale, pipeline stages,

--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -99,3 +99,30 @@ reranker:
   # min and ``--resume`` picks up from the next chunk. Smaller =
   # more durable but more file-flush overhead.
   chunk_size: 200
+
+# Research evaluation workflow facade. `rag-eval run --config configs/baseline.yaml`
+# reads this section to build an auditable BM25 -> dense -> rerank -> generation
+# -> bootstrap -> grounding plan without duplicating stage logic.
+rag_eval:
+  stages:
+    - bm25_retrieval
+    - dense_retrieval
+    - cross_encoder_rerank
+    - retrieval_lift_analysis
+    - generation_bm25
+    - generation_reranked
+    - paired_bootstrap_ci
+    - grounding_audit
+  num_eval_queries: 9999
+  bm25_generation_dir: outputs/week03_generation_bm25_full
+  reranker_output_dir: outputs/week05_reranker_full
+  reranker_resume: true
+  reranked_generation_dir: outputs/week03_generation_reranked_full
+  bootstrap_output_dir: outputs/week03_generation_bootstrap_full
+  retrieval_lift_output_dir: outputs/week05_retrieval_lift_analysis
+  grounding_output_dir: outputs/week07_grounding
+  bootstrap_resamples: 10000
+  grounding_nli_pairs: 0
+  tracking:
+    backend: jsonl
+    output_dir: outputs/rag_eval_tracking

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,131 @@
+# Architecture
+
+This repository is built around one research question: how much of a
+retrieval-augmented QA gain is caused by better passage selection, and how
+much is caused by the generator's own behaviour?
+
+The codebase is intentionally split into three layers:
+
+```text
+configs/                   experiment choices and output locations
+        |
+        v
+experiments/ + rag-eval     stage runners and orchestration
+        |
+        v
+src/msmarco_genqa/          reusable retrieval, reranking, generation, and evaluation code
+        |
+        v
+outputs/                   run.tsv, predictions.jsonl, metrics.json, manifests
+        |
+        v
+scripts/ + docs/ + reports/ analysis, audit, written interpretation
+```
+
+The separation matters. The runners are allowed to be operational and
+command-line friendly; the library modules should stay importable,
+deterministic where possible, and easy to unit test without downloading MS
+MARCO or model weights.
+
+## Core Boundaries
+
+### Data Loading
+
+`src/msmarco_genqa/data/msmarco.py` owns access to the official MS MARCO
+Passage corpus and dev/small query/qrel structures. Downstream code should
+not invent local dataset formats unless it writes a clear adapter.
+
+Large data lives under `data/` and is gitignored. The repository records
+configuration, code, metrics, and provenance, not the corpus itself.
+
+### Retrieval
+
+Retrieval modules produce TREC-style `run.tsv` files. A retrieval run is the
+contract between the ranking layer and every downstream experiment.
+
+Important outputs:
+
+- `outputs/week02_bm25/run.tsv`
+- `outputs/week04_dense/run.tsv`
+- `outputs/week05_reranker/run.tsv`
+
+The dense stage uses a qrels-anchored sample. Absolute dense metrics should
+not be compared against full-corpus BM25; only same-sample comparisons are
+valid.
+
+### Reranking
+
+Reranking is order-only over a fixed candidate set. Recall at the rerank
+depth should not change by construction. If a future reranker changes
+coverage, it should be treated as a new first-stage retrieval condition, not
+as the same rerank experiment.
+
+### Generation
+
+Generation consumes a `run.tsv`, retrieves the top-k passages, writes
+`predictions.jsonl`, and records both output text and the passages shown to
+the model. That persisted prompt context is what makes later grounding audits
+possible without re-running generation.
+
+The current generator is frozen T5-small. Current evidence suggests it mostly
+extracts from the prompt. Future generator work should therefore treat prompt
+format, passage structure, citation behaviour, and model capacity as
+experimental variables.
+
+### Evaluation
+
+Evaluation is paired wherever the claim is comparative. For BM25 vs reranked
+generation, both arms must cover the same query ids in the same order before
+bootstrap confidence intervals are meaningful.
+
+Evaluation scripts read committed code and gitignored outputs. They should
+write machine-readable summaries first, then console tables as a convenience.
+
+## Orchestration
+
+There are two orchestration surfaces:
+
+- `mgq-pipeline` reads `configs/pipeline.yaml`, a command-oriented plan.
+- `rag-eval run --config configs/baseline.yaml` builds the research
+  evaluation plan from the baseline config and the `rag_eval` section.
+
+Use `rag-eval` when the goal is to reproduce or extend the current research
+claim. Use individual `mgq-*` commands when iterating on one stage.
+
+Recommended first check:
+
+```bash
+rag-eval run --config configs/baseline.yaml --dry-run
+```
+
+That command prints the exact stage sequence and expected artifacts without
+loading the corpus or model weights.
+
+## Artifact Contract
+
+Every headline-producing stage should leave enough state to answer four
+questions later:
+
+1. Which code produced this run?
+2. Which config and CLI overrides were used?
+3. Which data inputs and upstream run files were consumed?
+4. Which metrics and output files were produced?
+
+The manifest contract in `docs/reproducibility_protocol.md` covers this for
+stage runners. Analysis scripts should follow the same spirit even when they
+do not need the full manifest machinery.
+
+## Extension Rules
+
+Add a new module under `src/` when logic is reused, unit-testable, or part of
+the research contract.
+
+Add a new script under `scripts/` when it reads existing artifacts and answers
+a bounded analysis question.
+
+Add a new experiment runner under `experiments/` when it produces primary
+artifacts that later analyses depend on.
+
+Add a new config key only when it changes a real experimental degree of
+freedom. If the key affects a headline number, record it in the resolved
+config and mention it in the evaluation protocol.

--- a/docs/evaluation_protocol.md
+++ b/docs/evaluation_protocol.md
@@ -1,0 +1,166 @@
+# Evaluation Protocol
+
+This protocol defines how to produce, compare, and report the repository's
+main RAG evaluation results. It is written for repeatable research work, not
+for a one-off demo.
+
+## Claim Under Test
+
+Primary claim:
+
+> Replacing BM25 top-3 passages with cross-encoder-reranked dense top-3
+> passages improves generation quality on the same MS MARCO dev/small query
+> set under the same frozen generator.
+
+The claim is comparative. It is valid only when the two generation arms share
+the same query ids, prompt template, generator checkpoint, decoding settings,
+and evaluation code.
+
+## Dataset
+
+- Dataset: MS MARCO Passage Ranking.
+- Evaluation split: `dev/small`.
+- Query count: 6,980.
+- Corpus: roughly 8.8M passages.
+- Large data is downloaded through `ir_datasets` and is not committed.
+
+The dense retrieval stage currently uses a qrels-anchored 50k-passage sample.
+That sampling makes dense-vs-BM25-on-sample comparisons valid, but it does not
+make the dense absolute metric directly comparable to full-corpus BM25.
+
+## Canonical Command Surface
+
+Inspect the evaluation plan:
+
+```bash
+rag-eval run --config configs/baseline.yaml --dry-run
+```
+
+Run the configured workflow:
+
+```bash
+rag-eval run --config configs/baseline.yaml
+```
+
+For focused work, run a subset:
+
+```bash
+rag-eval run --config configs/baseline.yaml --only generation_bm25 generation_reranked paired_bootstrap_ci
+```
+
+The command expands to the stage-specific `mgq-*` and analysis script calls
+recorded in `configs/baseline.yaml` under `rag_eval`.
+
+## Stage Order
+
+1. `bm25_retrieval`
+2. `dense_retrieval`
+3. `cross_encoder_rerank`
+4. `retrieval_lift_analysis`
+5. `generation_bm25`
+6. `generation_reranked`
+7. `paired_bootstrap_ci`
+8. `grounding_audit`
+
+Each stage writes under `outputs/`. Output directories are gitignored; metrics,
+manifests, and summaries should be copied into reports only after they are
+checked against this protocol.
+
+## Pairing Rules
+
+For generation comparison:
+
+- BM25 generation input: `outputs/week02_bm25/run.tsv`.
+- Reranked generation input: `outputs/week05_reranker_full/run.tsv`.
+- Both generation arms must use `--restrict-to-run` against the other arm's
+  upstream run.
+- The final `predictions.jsonl` files must contain the same query ids in the
+  same order.
+
+The bootstrap script enforces matching length, qid set, and qid order. If it
+fails, do not manually align the results in a spreadsheet. Fix the upstream
+generation command or write a checked sorter.
+
+## Metrics
+
+Surface metrics:
+
+- Token-F1
+- ROUGE-L
+- sentence BLEU
+- Exact match
+
+Retrieval metrics:
+
+- MRR@10
+- nDCG@10
+- Recall@100 / Recall@1000, depending on stage
+
+Grounding metrics:
+
+- lexical content-token grounding
+- n-gram grounding
+- optional NLI entailment
+
+Semantic proxy:
+
+- BERTScore on a fixed paired subsample when the scorer is available.
+
+No single metric is treated as the whole story. The current result is strong
+because the retrieval, surface-generation, bootstrap, and error-analysis
+signals are read together.
+
+## Statistical Test
+
+Use paired bootstrap over query-level scores:
+
+- Default resamples: 10,000.
+- Default confidence level: 95 percent.
+- Default seed: 42.
+- Delta direction: reranked minus BM25.
+
+Report the mean delta and confidence interval. If the interval crosses zero,
+the claim is not statistically supported for that metric and setting.
+
+## Reproducibility Requirements
+
+For a result to be reportable, record:
+
+- git commit and dirty-tree status
+- config file and resolved config hash
+- seed
+- upstream run files
+- output directory
+- dependency file hashes
+- environment fingerprint
+
+The manifest schema in `docs/reproducibility_protocol.md` is the detailed
+contract. Runs that bypass the manifest contract are allowed during
+development, but should not be used for headline claims.
+
+## Reporting Rules
+
+When updating `RESULTS.md` or a report:
+
+- State whether retrieval metrics are full-corpus or sampled.
+- State whether generation is full dev/small or a smaller smoke subset.
+- State the exact paired query count.
+- State the generator checkpoint and decoding budget.
+- State bootstrap seed, resample count, and confidence level.
+- Separate confirmed results from hypotheses and queued follow-ups.
+
+Avoid language that implies general QA capability. The current system is an
+MS MARCO Passage RAG evaluation pipeline with a frozen generator; the evidence
+does not support broader claims without additional datasets and models.
+
+## Failure Review Gate
+
+Before treating a new run as a real improvement, inspect regressions:
+
+1. Generate the paired bootstrap summary.
+2. Run the regression/failure taxonomy scripts.
+3. Sample at least 30-50 regressions with a fixed seed.
+4. Record whether the failure mode is retrieval-side, generation-side,
+   metric-side, or annotation-side.
+
+`docs/failure_taxonomy.md` defines the labels and adjudication notes.

--- a/docs/failure_taxonomy.md
+++ b/docs/failure_taxonomy.md
@@ -1,0 +1,152 @@
+# Failure Taxonomy
+
+This taxonomy is for paired BM25-vs-reranked generation analysis. It keeps
+error review grounded in query-level evidence instead of broad impressions.
+
+Use it when a reranked output is worse than the BM25 output, when grounding
+metrics disagree, or when a new ablation changes a headline metric enough to
+deserve inspection.
+
+## Unit Of Review
+
+One review item is a paired query record:
+
+- query id
+- query text
+- reference answer(s)
+- BM25 passages and generated answer
+- reranked passages and generated answer
+- per-query metric scores
+- optional grounding scores
+
+The label should describe the most likely primary cause of the metric
+difference. If two causes are equally plausible, use a primary label plus a
+note rather than inventing a combined category.
+
+## Current Regression Labels
+
+### `truncation_midword`
+
+The generated answer ends inside a word or phrase, or produces a fragment that
+looks like a clipped extract. The upstream passage may be relevant, but the
+generator output is malformed enough to hurt the metric or NLI entailment.
+
+Likely layer: generation.
+
+### `truncation_short`
+
+The answer is grammatical enough, but too short to express the reference
+answer. It often copies a title, entity name, or local phrase when the passage
+contains a fuller answer nearby.
+
+Likely layer: generation.
+
+### `topic_drift`
+
+The retrieved/reranked passage is about a neighbouring concept but not the
+asked entity or relation. The generated answer follows the shown passage, so
+the downstream failure is caused by ranking the wrong evidence.
+
+Likely layer: retrieval or reranking.
+
+### `extractive_passage_bias`
+
+The generator copies a salient span from the prompt even when the reference
+answer requires synthesis or a less prominent span. This is not pure retrieval
+failure: the answer may be present, but the generator picks the wrong surface
+form.
+
+Likely layer: generation conditioned on passage layout.
+
+### `semantic_mismatch`
+
+The produced answer has lexical overlap with the reference but changes the
+meaning. Examples include wrong numeric value, wrong date, wrong person, or
+negated relation.
+
+Likely layer: retrieval, generation, or annotation depending on context.
+
+### `annotation_or_reference_gap`
+
+The output appears correct or defensible from the passages, but the reference
+answer is narrow, missing a paraphrase, or mismatched to the query wording.
+
+Likely layer: dataset/evaluation.
+
+### `metric_artifact`
+
+The output is semantically acceptable but penalised by the chosen surface
+metric, or an NLI/semantic scorer fails because the answer is a fragment,
+list, unit expression, or formatting variant.
+
+Likely layer: evaluation.
+
+### `passage_context_conflict`
+
+Top passages contain conflicting answers or incompatible contexts. The
+generator selects one plausible answer, but the reference or another passage
+supports a different one.
+
+Likely layer: retrieval set composition.
+
+## Grounding-Specific Labels
+
+### `paraphrase_reorder`
+
+Content words are present in the passages, but word order or phrasing differs
+enough to reduce n-gram or NLI scores.
+
+### `partial_external`
+
+Most of the answer is grounded, but a small token, unit, morphology, or
+normalisation choice is not present exactly in the prompt.
+
+### `parametric_or_external`
+
+The answer introduces content that is not supported by the shown passages.
+This is the label to watch if a future generator becomes less extractive.
+
+## Labeling Procedure
+
+1. Fix a random seed before sampling cases.
+2. Sample from the target bucket, not from all predictions.
+3. Read the query, references, both outputs, and both top-k passage sets.
+4. Assign one primary label.
+5. Add a short evidence note when the case is non-obvious.
+6. Report counts and shares, but do not over-interpret tiny samples.
+
+Recommended sample sizes:
+
+- 30 cases for a quick sanity check.
+- 40-50 cases for a reportable regression taxonomy.
+- 100+ cases if a paper section depends on the taxonomy.
+
+## Current Snapshot
+
+The existing 40-query seeded regression triage found that most regressions are
+generation-side:
+
+| Label | Count | Share |
+|---|---:|---:|
+| `truncation_midword` | 22 | 55% |
+| `truncation_short` | 14 | 35% |
+| `topic_drift` | 2 | 5% |
+| `extractive_passage_bias` | 2 | 5% |
+| `semantic_mismatch` | 0 | 0% |
+
+Interpretation: reranking usually improves evidence placement, but T5-small
+often turns richer evidence into short or fragmentary extracts. That supports
+the next research step: change generator capacity and prompt format before
+claiming the reranker itself is the residual bottleneck.
+
+## When To Add A New Label
+
+Add a label only if at least three reviewed cases do not fit the existing
+taxonomy and the new distinction would change an experiment decision.
+
+When a label is added, update:
+
+- this file
+- the relevant taxonomy script
+- any report table that consumes the label set
+- tests that pin expected labels or summary columns

--- a/notebooks/rag_eval_demo.ipynb
+++ b/notebooks/rag_eval_demo.ipynb
@@ -1,0 +1,107 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# RAG Evaluation Demo\n",
+        "\n",
+        "This notebook is a lightweight walk-through of the evaluation workflow. It does not download MS MARCO or load model weights. The goal is to inspect the plan before running long experiments."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "setup-note",
+      "metadata": {},
+      "source": [
+        "Run from the repository root after installing the package in editable mode:\n",
+        "\n",
+        "```bash\n",
+        "pip install -r requirements.txt\n",
+        "pip install -e .\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "load-plan",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "from msmarco_genqa.rag_eval import (\n",
+        "    build_rag_eval_plan,\n",
+        "    filter_rag_eval_plan,\n",
+        "    format_rag_eval_plan,\n",
+        "    load_rag_eval_config,\n",
+        ")\n",
+        "\n",
+        "project_root = Path.cwd()\n",
+        "if not (project_root / \"configs\" / \"baseline.yaml\").exists():\n",
+        "    project_root = project_root.parent\n",
+        "\n",
+        "config_path = project_root / \"configs\" / \"baseline.yaml\"\n",
+        "cfg = load_rag_eval_config(config_path)\n",
+        "plan = build_rag_eval_plan(cfg, config_path=\"configs/baseline.yaml\")\n",
+        "print(format_rag_eval_plan(plan))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "focused-plan",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "focused = filter_rag_eval_plan(\n",
+        "    plan,\n",
+        "    only={\"generation_bm25\", \"generation_reranked\", \"paired_bootstrap_ci\"},\n",
+        ")\n",
+        "print(format_rag_eval_plan(focused))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cli-note",
+      "metadata": {},
+      "source": [
+        "The same inspection path is available from the command line:\n",
+        "\n",
+        "```bash\n",
+        "rag-eval run --config configs/baseline.yaml --dry-run\n",
+        "```\n",
+        "\n",
+        "Omit `--dry-run` only when the corpus, model cache, and expected output directories are ready."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "expected-outputs",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for stage in plan:\n",
+        "    print(stage.name)\n",
+        "    for output in stage.expected_outputs:\n",
+        "        print(\"  \", output)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ mgq-rerank   = "msmarco_genqa.cli.rerank:main"
 mgq-generate = "msmarco_genqa.cli.generate:main"
 mgq-pipeline = "msmarco_genqa.cli.pipeline:main"
 mgq-serve    = "msmarco_genqa.service.app:main"
+rag-eval     = "msmarco_genqa.cli.rag_eval:main"
 
 
 # --------------------------------------------------------------------------- #

--- a/src/msmarco_genqa/cli/rag_eval.py
+++ b/src/msmarco_genqa/cli/rag_eval.py
@@ -1,0 +1,66 @@
+"""Console entry point for the RAG evaluation workflow."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from msmarco_genqa.rag_eval import (
+    PROJECT_ROOT,
+    build_rag_eval_plan,
+    filter_rag_eval_plan,
+    format_rag_eval_plan,
+    load_rag_eval_config,
+    run_rag_eval_plan,
+)
+from msmarco_genqa.util.tracking import ExperimentTracker
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="rag-eval", description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    run = subcommands.add_parser("run", help="Run or inspect the configured evaluation workflow.")
+    run.add_argument("--config", type=Path, default=PROJECT_ROOT / "configs/baseline.yaml")
+    run.add_argument("--dry-run", action="store_true", help="Print and track the plan only.")
+    run.add_argument("--only", nargs="*", default=[], help="Run only the named stage(s).")
+    run.add_argument("--skip", nargs="*", default=[], help="Skip the named stage(s).")
+    run.add_argument("--tracking-backend", default=None, help="jsonl, mlflow, wandb, or none.")
+    run.add_argument("--tracking-dir", type=Path, default=None)
+    run.add_argument(
+        "--python",
+        default="python",
+        help="Python executable used for script-based analysis stages.",
+    )
+    return parser.parse_args(argv)
+
+
+def _tracking_settings(cfg: dict) -> dict:
+    rag_eval = cfg.get("rag_eval") or {}
+    tracking = rag_eval.get("tracking") or cfg.get("tracking") or {}
+    return tracking if isinstance(tracking, dict) else {}
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.command != "run":
+        raise SystemExit(f"unsupported command: {args.command}")
+
+    cfg = load_rag_eval_config(args.config)
+    plan = build_rag_eval_plan(cfg, config_path=args.config, python=args.python)
+    plan = filter_rag_eval_plan(plan, only=set(args.only), skip=set(args.skip))
+    print(format_rag_eval_plan(plan))
+
+    tracking = _tracking_settings(cfg)
+    tracker = ExperimentTracker(
+        backend=args.tracking_backend or tracking.get("backend", "jsonl"),
+        output_dir=args.tracking_dir or PROJECT_ROOT / tracking.get("output_dir", "outputs/rag_eval_tracking"),
+        run_name=f"rag-eval-{args.config.stem}",
+        tags={"config": str(args.config), "command": "run"},
+    )
+    with tracker:
+        run_rag_eval_plan(plan, cwd=PROJECT_ROOT, tracker=tracker, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/msmarco_genqa/rag_eval.py
+++ b/src/msmarco_genqa/rag_eval.py
@@ -1,0 +1,307 @@
+"""Research-oriented RAG evaluation plan builder."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from msmarco_genqa.util.tracking import ExperimentTracker
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+DEFAULT_STAGE_ORDER: tuple[str, ...] = (
+    "bm25_retrieval",
+    "dense_retrieval",
+    "cross_encoder_rerank",
+    "retrieval_lift_analysis",
+    "generation_bm25",
+    "generation_reranked",
+    "paired_bootstrap_ci",
+    "grounding_audit",
+)
+
+
+@dataclass(frozen=True)
+class RAGEvalStage:
+    name: str
+    command: list[str]
+    description: str
+    expected_outputs: list[str]
+
+
+def load_rag_eval_config(path: str | Path) -> dict[str, Any]:
+    with Path(path).open(encoding="utf-8") as f:
+        cfg = yaml.safe_load(f) or {}
+    if not isinstance(cfg, dict):
+        raise ValueError("RAG evaluation config must be a YAML mapping")
+    required_sections = ["eval_retrieval", "dense", "reranker", "generation"]
+    missing = [section for section in required_sections if section not in cfg]
+    if missing:
+        raise ValueError(f"RAG evaluation config is missing section(s): {missing}")
+    return cfg
+
+
+def _as_posix(value: str | Path) -> str:
+    return Path(value).as_posix()
+
+
+def _cfg_path(cfg: dict[str, Any], section: str, key: str) -> str:
+    try:
+        value = cfg[section][key]
+    except KeyError as exc:
+        raise ValueError(f"RAG evaluation config is missing {section}.{key}") from exc
+    return _as_posix(value)
+
+
+def _default_named_dir(base_dir: str, suffix: str) -> str:
+    base = Path(base_dir)
+    return _as_posix(base.with_name(f"{base.name}_{suffix}"))
+
+
+def _rag_eval_settings(cfg: dict[str, Any]) -> dict[str, Any]:
+    raw = cfg.get("rag_eval", {})
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError("rag_eval must be a YAML mapping when present")
+    return raw
+
+
+def _build_all_stages(
+    *,
+    config_path: str | Path,
+    cfg: dict[str, Any],
+    python: str,
+) -> dict[str, RAGEvalStage]:
+    settings = _rag_eval_settings(cfg)
+    config_arg = _as_posix(config_path)
+
+    bm25_dir = _cfg_path(cfg, "eval_retrieval", "output_dir")
+    dense_dir = _cfg_path(cfg, "dense", "output_dir")
+    reranker_dir = _as_posix(settings.get("reranker_output_dir", _cfg_path(cfg, "reranker", "output_dir")))
+    generation_dir = _cfg_path(cfg, "generation", "output_dir")
+
+    bm25_run = _as_posix(Path(bm25_dir) / "run.tsv")
+    dense_run = _as_posix(Path(dense_dir) / "run.tsv")
+    reranker_run = _as_posix(Path(reranker_dir) / "run.tsv")
+
+    bm25_generation_dir = _as_posix(
+        settings.get("bm25_generation_dir", _default_named_dir(generation_dir, "bm25_full"))
+    )
+    reranked_generation_dir = _as_posix(
+        settings.get("reranked_generation_dir", _default_named_dir(generation_dir, "reranked_full"))
+    )
+    bootstrap_dir = _as_posix(
+        settings.get("bootstrap_output_dir", _default_named_dir(generation_dir, "bootstrap_full"))
+    )
+    retrieval_lift_dir = _as_posix(
+        settings.get("retrieval_lift_output_dir", "outputs/week05_retrieval_lift_analysis")
+    )
+    grounding_dir = _as_posix(settings.get("grounding_output_dir", "outputs/week07_grounding"))
+    num_eval_queries = str(settings.get("num_eval_queries", cfg["generation"].get("num_eval_queries", 200)))
+    n_resamples = str(settings.get("bootstrap_resamples", 10000))
+    grounding_nli_pairs = str(settings.get("grounding_nli_pairs", 0))
+
+    rerank_command = [
+        "mgq-rerank",
+        "--config",
+        config_arg,
+        "--output-dir",
+        reranker_dir,
+    ]
+    if settings.get("reranker_resume", True):
+        rerank_command.append("--resume")
+
+    return {
+        "bm25_retrieval": RAGEvalStage(
+            name="bm25_retrieval",
+            description="Full-corpus BM25 retrieval on MS MARCO dev/small.",
+            command=["mgq-retrieve", "--config", config_arg],
+            expected_outputs=[_as_posix(Path(bm25_dir) / "run.tsv"), _as_posix(Path(bm25_dir) / "metrics.json")],
+        ),
+        "dense_retrieval": RAGEvalStage(
+            name="dense_retrieval",
+            description="Dense retrieval on the qrels-anchored sample, with BM25-on-sample comparison.",
+            command=["mgq-dense", "--config", config_arg],
+            expected_outputs=[_as_posix(Path(dense_dir) / "run.tsv"), _as_posix(Path(dense_dir) / "metrics.json")],
+        ),
+        "cross_encoder_rerank": RAGEvalStage(
+            name="cross_encoder_rerank",
+            description="Cross-encoder reranking over dense top-k candidates.",
+            command=rerank_command,
+            expected_outputs=[
+                _as_posix(Path(reranker_dir) / "run.tsv"),
+                _as_posix(Path(reranker_dir) / "metrics.json"),
+            ],
+        ),
+        "retrieval_lift_analysis": RAGEvalStage(
+            name="retrieval_lift_analysis",
+            description="Query-level retrieval gain/loss buckets after reranking.",
+            command=[
+                python,
+                "scripts/analyze_retrieval_lift.py",
+                "--before-run",
+                dense_run,
+                "--after-run",
+                reranker_run,
+                "--output-dir",
+                retrieval_lift_dir,
+            ],
+            expected_outputs=[_as_posix(Path(retrieval_lift_dir) / "summary.json")],
+        ),
+        "generation_bm25": RAGEvalStage(
+            name="generation_bm25",
+            description="Generation from BM25 top passages on the paired evaluation qid set.",
+            command=[
+                "mgq-generate",
+                "--config",
+                config_arg,
+                "--input-run",
+                bm25_run,
+                "--output-dir",
+                bm25_generation_dir,
+                "--retrieval-source",
+                "bm25",
+                "--restrict-to-run",
+                reranker_run,
+                "--num-eval-queries",
+                num_eval_queries,
+            ],
+            expected_outputs=[
+                _as_posix(Path(bm25_generation_dir) / "predictions.jsonl"),
+                _as_posix(Path(bm25_generation_dir) / "metrics.json"),
+            ],
+        ),
+        "generation_reranked": RAGEvalStage(
+            name="generation_reranked",
+            description="Generation from reranked top passages on the same paired qid set.",
+            command=[
+                "mgq-generate",
+                "--config",
+                config_arg,
+                "--input-run",
+                reranker_run,
+                "--output-dir",
+                reranked_generation_dir,
+                "--retrieval-source",
+                "reranked",
+                "--restrict-to-run",
+                bm25_run,
+                "--num-eval-queries",
+                num_eval_queries,
+            ],
+            expected_outputs=[
+                _as_posix(Path(reranked_generation_dir) / "predictions.jsonl"),
+                _as_posix(Path(reranked_generation_dir) / "metrics.json"),
+            ],
+        ),
+        "paired_bootstrap_ci": RAGEvalStage(
+            name="paired_bootstrap_ci",
+            description="Paired-bootstrap confidence intervals for reranked minus BM25 generation.",
+            command=[
+                python,
+                "scripts/bootstrap_generation_comparison.py",
+                "--bm25-dir",
+                bm25_generation_dir,
+                "--reranked-dir",
+                reranked_generation_dir,
+                "--output-dir",
+                bootstrap_dir,
+                "--n-resamples",
+                n_resamples,
+                "--seed",
+                str(cfg.get("seed", 42)),
+            ],
+            expected_outputs=[_as_posix(Path(bootstrap_dir) / "bootstrap_ci.json")],
+        ),
+        "grounding_audit": RAGEvalStage(
+            name="grounding_audit",
+            description="Grounding metrics over the paired BM25 and reranked generation outputs.",
+            command=[
+                python,
+                "scripts/grounding_audit.py",
+                "--bm25-dir",
+                bm25_generation_dir,
+                "--reranked-dir",
+                reranked_generation_dir,
+                "--output-dir",
+                grounding_dir,
+                "--nli-n-pairs",
+                grounding_nli_pairs,
+            ],
+            expected_outputs=[
+                _as_posix(Path(grounding_dir) / "summary.json"),
+                _as_posix(Path(grounding_dir) / "per_query_grounding.jsonl"),
+            ],
+        ),
+    }
+
+
+def build_rag_eval_plan(
+    cfg: dict[str, Any],
+    *,
+    config_path: str | Path = "configs/baseline.yaml",
+    python: str = "python",
+) -> list[RAGEvalStage]:
+    settings = _rag_eval_settings(cfg)
+    requested = settings.get("stages", list(DEFAULT_STAGE_ORDER))
+    if not isinstance(requested, list) or not all(isinstance(name, str) for name in requested):
+        raise ValueError("rag_eval.stages must be a list of stage names")
+
+    all_stages = _build_all_stages(config_path=config_path, cfg=cfg, python=python)
+    unknown = [name for name in requested if name not in all_stages]
+    if unknown:
+        raise ValueError(f"unknown RAG evaluation stage(s): {unknown}")
+    return [all_stages[name] for name in requested]
+
+
+def filter_rag_eval_plan(
+    plan: list[RAGEvalStage],
+    *,
+    only: set[str] | None = None,
+    skip: set[str] | None = None,
+) -> list[RAGEvalStage]:
+    only = only or set()
+    skip = skip or set()
+    return [stage for stage in plan if (not only or stage.name in only) and stage.name not in skip]
+
+
+def format_rag_eval_plan(plan: list[RAGEvalStage]) -> str:
+    lines: list[str] = []
+    for index, stage in enumerate(plan, start=1):
+        lines.append(f"{index:02d}. {stage.name}: {' '.join(stage.command)}")
+        if stage.description:
+            lines.append(f"    {stage.description}")
+        if stage.expected_outputs:
+            lines.append(f"    outputs: {', '.join(stage.expected_outputs)}")
+    return "\n".join(lines)
+
+
+def run_rag_eval_plan(
+    plan: list[RAGEvalStage],
+    *,
+    cwd: str | Path = PROJECT_ROOT,
+    tracker: ExperimentTracker,
+    dry_run: bool = False,
+) -> None:
+    tracker.log_params({"stages": [stage.name for stage in plan], "dry_run": dry_run})
+    for index, stage in enumerate(plan, start=1):
+        tracker.log_params(
+            {
+                f"stage.{index}.name": stage.name,
+                f"stage.{index}.cmd": stage.command,
+                f"stage.{index}.expected_outputs": stage.expected_outputs,
+            }
+        )
+        if dry_run:
+            continue
+        started_at = time.time()
+        subprocess.run(stage.command, cwd=cwd, check=True)
+        tracker.log_metrics({f"{stage.name}.wall_seconds": time.time() - started_at}, step=index)

--- a/tests/test_rag_eval.py
+++ b/tests/test_rag_eval.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from msmarco_genqa.cli.rag_eval import main as rag_eval_main
+from msmarco_genqa.rag_eval import (
+    build_rag_eval_plan,
+    filter_rag_eval_plan,
+    format_rag_eval_plan,
+    load_rag_eval_config,
+)
+
+
+def _write_config(path: Path) -> Path:
+    path.write_text(
+        """
+seed: 42
+eval_retrieval:
+  output_dir: outputs/bm25
+dense:
+  output_dir: outputs/dense
+reranker:
+  output_dir: outputs/reranked
+generation:
+  output_dir: outputs/generation
+  num_eval_queries: 12
+rag_eval:
+  stages:
+    - generation_bm25
+    - generation_reranked
+    - paired_bootstrap_ci
+  num_eval_queries: 99
+  bm25_generation_dir: outputs/gen_bm25
+  reranked_generation_dir: outputs/gen_reranked
+  bootstrap_output_dir: outputs/bootstrap
+  tracking:
+    backend: none
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_build_rag_eval_plan_pairs_generation_runs(tmp_path):
+    config_path = _write_config(tmp_path / "baseline.yaml")
+    cfg = load_rag_eval_config(config_path)
+
+    plan = build_rag_eval_plan(cfg, config_path=config_path, python="python")
+
+    assert [stage.name for stage in plan] == [
+        "generation_bm25",
+        "generation_reranked",
+        "paired_bootstrap_ci",
+    ]
+    bm25_cmd = plan[0].command
+    reranked_cmd = plan[1].command
+    assert bm25_cmd[bm25_cmd.index("--input-run") + 1] == "outputs/bm25/run.tsv"
+    assert bm25_cmd[bm25_cmd.index("--restrict-to-run") + 1] == "outputs/reranked/run.tsv"
+    assert reranked_cmd[reranked_cmd.index("--input-run") + 1] == "outputs/reranked/run.tsv"
+    assert reranked_cmd[reranked_cmd.index("--restrict-to-run") + 1] == "outputs/bm25/run.tsv"
+    assert "--n-resamples" in plan[2].command
+
+
+def test_filter_and_format_rag_eval_plan(tmp_path):
+    config_path = _write_config(tmp_path / "baseline.yaml")
+    cfg = load_rag_eval_config(config_path)
+    plan = build_rag_eval_plan(cfg, config_path=config_path)
+
+    filtered = filter_rag_eval_plan(plan, only={"paired_bootstrap_ci"})
+
+    assert [stage.name for stage in filtered] == ["paired_bootstrap_ci"]
+    rendered = format_rag_eval_plan(filtered)
+    assert "paired_bootstrap_ci" in rendered
+    assert "outputs/bootstrap/bootstrap_ci.json" in rendered
+
+
+def test_build_rag_eval_plan_rejects_unknown_stage(tmp_path):
+    config_path = _write_config(tmp_path / "baseline.yaml")
+    cfg = load_rag_eval_config(config_path)
+    cfg["rag_eval"]["stages"] = ["missing_stage"]
+
+    with pytest.raises(ValueError, match="unknown RAG evaluation stage"):
+        build_rag_eval_plan(cfg, config_path=config_path)
+
+
+def test_rag_eval_cli_dry_run_prints_plan_without_executing(tmp_path, capsys):
+    config_path = _write_config(tmp_path / "baseline.yaml")
+
+    rag_eval_main(
+        [
+            "run",
+            "--config",
+            str(config_path),
+            "--dry-run",
+            "--tracking-backend",
+            "none",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert "generation_bm25" in out
+    assert "paired_bootstrap_ci" in out


### PR DESCRIPTION
## Summary

- add architecture, evaluation protocol, and failure taxonomy docs
- add a lightweight RAG evaluation demo notebook
- add the `rag-eval run` CLI backed by `configs/baseline.yaml`
- add unit tests for the workflow planner and CLI dry-run path

## Validation

- `pytest tests/test_pipeline.py tests/test_rag_eval.py -q`
- `ruff check src tests experiments scripts`
- `python scripts/check_headline_metrics.py`
- `python scripts/check_secrets.py`
- notebook JSON parse