### PR TITLE
Refresh lockfile patch dependencies

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,10 +1,10 @@
 # pip-freeze-style lockfile for reproducibility.
 #
 # `requirements.txt` is the loose, easy-to-install dep list (use for fast
-# development setup). This file pins exact versions known to produce the
-# numbers in `reports/internship_report/report.pdf` (the frozen
-# v1.0-internship-final snapshot) and `outputs/*/metrics.json` on the
-# author's macOS development machine (Python 3.9, CPU-only).
+# development setup). This file pins a security-refreshed reproduction
+# environment for the repository's current code. The historical numbers in
+# `reports/internship_report/report.pdf` remain anchored by the frozen
+# v1.0-internship-final snapshot; use that tag for archival reproduction.
 #
 # Install with:
 #
@@ -16,9 +16,10 @@
 #   `requirements.txt` plus a handful of test/lint tools are pinned.
 #   Sub-dependencies are still resolved at install time. For a fully
 #   reproducible lock with hashes, regenerate via pip-tools / uv.
-# - Pinned versions reflect the macOS CPU dev environment. Linux/CUDA
-#   builds may need a different torch wheel; install `torch` separately
-#   from the appropriate index before running pip install.
+# - Pinned versions reflect the macOS CPU dev environment, with patch-level
+#   security refreshes where they do not change the core model stack.
+#   Linux/CUDA builds may need a different torch wheel; install `torch`
+#   separately from the appropriate index before running pip install.
 
 # --- Core scientific stack ---
 numpy==1.26.4
@@ -51,8 +52,8 @@ safetensors==0.7.0
 evaluate==0.4.6
 rouge_score==0.1.2
 sacrebleu==2.6.0
-nltk==3.9.2
+nltk==3.9.4
 
 # --- Testing / lint ---
-pytest==8.4.2
+pytest==9.0.3
 ruff==0.15.12


### PR DESCRIPTION
## Summary

- bump `nltk` from 3.9.2 to 3.9.4
- bump `pytest` from 8.4.2 to 9.0.3
- clarify that the lockfile is security-refreshed for the current codebase, while the historical internship snapshot remains anchored by the frozen tag

## Audit notes

- `requirements.txt`: no known vulnerabilities found
- `requirements-lock.txt` with `--no-deps --disable-pip`: `nltk` and `pytest` findings cleared
- remaining lockfile findings are limited to `torch==2.2.2` and `transformers==4.57.6`; those need a separate model-stack upgrade and metric validation pass

## Validation

- `git diff --check`
- `python scripts/check_secrets.py`
- `python scripts/check_headline_metrics.py`
- `pytest tests/test_rag_eval.py tests/test_check_headline_metrics.py -q`