### PR TITLE
Fix manifest path assertion on Windows

### DIFF
--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -170,7 +170,7 @@ def test_write_run_manifest_basic(tmp_path: Path):
     assert "sha256_16" in metrics_rec
 
     # 3. Config + auto-discovered deps are captured.
-    assert data["config"][0]["path"].endswith("configs/baseline.yaml")
+    assert Path(data["config"][0]["path"]).as_posix().endswith("configs/baseline.yaml")
     dep_paths = [rec["path"] for rec in data["dependencies"]]
     # We auto-discover all three: lockfile first (priority), then requirements,
     # then pyproject. Each gets a hash.


### PR DESCRIPTION
## Summary

Makes the manifest path assertion portable by normalizing the recorded config path before checking the expected suffix.

## Context

- Linux CI emits POSIX-style paths.
- Local Windows runs can emit backslash-separated relative paths.
- The manifest behavior remains unchanged; only the test assertion is made platform-neutral.

## Validation

- `pytest tests/test_manifest.py -q`
- `ruff check src tests experiments scripts`
- `python scripts/check_headline_metrics.py`
- `python scripts/check_secrets.py`
- `git diff --check`