### PR TITLE
Refresh model stack with smoke check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           python -m pip install --upgrade pip
           # CPU-only torch index — the default index pulls in CUDA wheels
           # that bloat the install by ~2 GB on Linux.
-          pip install --index-url https://download.pytorch.org/whl/cpu torch
+          pip install --index-url https://download.pytorch.org/whl/cpu "torch>=2.12.0"
           pip install -r requirements.txt
           pip install -e .
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results pipeline-dry-run rag-eval-dry-run serve-dev clean-pycache reproduce-baseline
+.PHONY: help install test test-slow lint check-results pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-baseline
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -19,6 +19,7 @@ help:
 	@echo "  make check-results        -- verify metadata.json headline metrics against RESULTS.md"
 	@echo "  make pipeline-dry-run     -- print the config-driven experiment plan"
 	@echo "  make rag-eval-dry-run     -- print the research evaluation workflow plan"
+	@echo "  make model-stack-smoke    -- load baseline HF models and run a short smoke"
 	@echo "  make serve-dev            -- start the optional FastAPI generation service"
 	@echo "  make reproduce-baseline   -- re-run + verify the W2 BM25 baseline (~30 min CPU laptop)"
 
@@ -66,6 +67,9 @@ pipeline-dry-run:
 
 rag-eval-dry-run:
 	rag-eval run --config configs/baseline.yaml --dry-run
+
+model-stack-smoke:
+	$(PYTHON) scripts/smoke_model_stack.py --config configs/baseline.yaml --device cpu --max-new-tokens 16
 
 serve-dev:
 	mgq-serve --host 127.0.0.1 --port 8000

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ auditing the experiments:
   builds the end-to-end BM25, dense, rerank, paired generation, bootstrap, and
   grounding plan from the baseline config. Use `--dry-run` to inspect the
   command sequence before touching data or models.
+- **Model-stack smoke.** `python scripts/smoke_model_stack.py --config
+  configs/baseline.yaml` loads the pinned generator and dense encoder, runs one
+  short CPU generation, and checks a normalized embedding shape. Use it before
+  accepting torch / transformers / sentence-transformers upgrades.
 - **CI and automation.** The GitHub Actions workflow runs unit tests, linting,
   and manifest/reproduction checks; the local mirror is `make test` and
   `make lint`.
@@ -385,14 +389,15 @@ Everything runs from the project root. Scripts add `PROJECT_ROOT` to
 
 ## 3. Setup
 
-Python 3.10+ recommended (3.9 also works).
+Python 3.10+ is required. CI currently runs on Python 3.10.
 
 ```bash
 pip install -r requirements.txt
 pip install -e .                       # register `src` as a real package
 ```
 
-To reproduce the numbers in the reports, pin to the lockfile instead:
+For a pinned version of the current security-refreshed environment, install
+the lockfile instead:
 
 ```bash
 pip install -r requirements-lock.txt
@@ -403,6 +408,14 @@ Or, equivalently:
 
 ```bash
 make install
+```
+
+Model-stack dependency updates should also run the opt-in smoke after install.
+It downloads the pinned HuggingFace checkpoints from `configs/baseline.yaml` and
+does not touch MS MARCO data:
+
+```bash
+python scripts/smoke_model_stack.py --config configs/baseline.yaml --device cpu
 ```
 
 Optional, only for PDF report generation:
@@ -610,12 +623,12 @@ All knobs live in [`configs/baseline.yaml`](configs/baseline.yaml). Key ones:
 |---|---|---|
 | Unit tests | works | `make test` / `pytest -q` — no network, no heavy deps. Slow tests excluded by `pytest.ini_options`. |
 | Slow tests | works (skips gracefully) | `make test-slow` includes `@pytest.mark.slow`. HF metric scripts skip if unavailable. |
-| Lockfile | basic | `requirements-lock.txt` is pip-freeze-style; sub-dep transitive closure + hash pinning are TODO. |
+| Lockfile | basic | `requirements-lock.txt` is pip-freeze-style; sub-dep transitive closure + hash pinning are TODO. Model-stack pins are checked with `scripts/smoke_model_stack.py`. |
 | Installable package | basic | `pip install -e .` registers `src` via `pyproject.toml`. Existing `sys.path.insert` shims in `experiments/` and `scripts/` are kept for now. |
 | CI | basic | `.github/workflows/ci.yml`: pytest + ruff on push/PR to main. No slow tests, no data download. |
 | Lint | minimal | `ruff` with `F` + `W` (pyflakes + whitespace). `E` / `I` / `UP` are off on the first pass. |
 | Artifact manifest | wired | `src/msmarco_genqa/util/manifest.py` writes `outputs/<stage>/manifest.json` alongside `metrics.json`. Captures git commit + dirty flag, command, config hash, dependency-file hashes, per-output sha256 (truncated). |
-| Numbers in `reports/internship_report/report.pdf` | historical | Reflect the dev environment at tag `v1.0-internship-final`. Re-running with `requirements-lock.txt` is the closest we get today. |
+| Numbers in `reports/internship_report/report.pdf` | historical | Reflect the dev environment at tag `v1.0-internship-final`. Current dependencies are security-refreshed; use the frozen tag for archival reproduction. |
 
 **Historical output-path naming.** `outputs/week02_bm25/`,
 `outputs/week04_dense/`, `outputs/week05_reranker/` retain

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -46,6 +46,16 @@ python scripts/run_pipeline.py --dry-run
 The dry run prints the pipeline plan without loading MS MARCO data or model
 weights.
 
+When torch, transformers, or sentence-transformers changes, also run:
+
+```bash
+python scripts/smoke_model_stack.py --config configs/baseline.yaml --device cpu
+```
+
+That opt-in check downloads the pinned generator and dense encoder revisions,
+runs one short generation, and verifies a normalized embedding shape. It is kept
+outside default CI because it requires HuggingFace Hub access and model weights.
+
 ## Reproducing the BM25 Baseline
 
 The canonical BM25 reproduction target is:

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -353,9 +353,11 @@ seed-42 promise. See
 
 Deterministic seed (`seed: 42`) is set in `configs/baseline.yaml` and
 threaded through the samplers, the dense encoder batching, and the
-evaluation bootstrap. For an environment that reproduces the numbers
-below, install [`requirements-lock.txt`](../requirements-lock.txt)
-rather than the loose [`requirements.txt`](../requirements.txt).
+evaluation bootstrap. For the current pinned environment, install
+[`requirements-lock.txt`](../requirements-lock.txt) rather than the
+loose [`requirements.txt`](../requirements.txt). Historical report
+numbers are tied to the frozen tag below; dependency refreshes should be
+accepted only after rerunning the relevant checks or smoke tests.
 
 The frozen reference snapshot is
 [`reports/internship_report/report.pdf`](../reports/internship_report/report.pdf)

--- a/docs/reproducibility_protocol.md
+++ b/docs/reproducibility_protocol.md
@@ -216,7 +216,11 @@ These remain out of scope (handled separately or accepted as gaps):
   pinned in `configs/baseline.yaml` and recorded in `extra`. The
   weights themselves are downloaded by `transformers` /
   `sentence-transformers` from HF Hub at first use; the pinned
-  revision is what guarantees the same weights.
+  revision is what guarantees the same weights. Dependency upgrades that
+  touch torch / transformers / sentence-transformers should run
+  `python scripts/smoke_model_stack.py --config configs/baseline.yaml --device cpu`
+  so both the pinned generator and dense encoder are loaded under the new
+  stack before the lockfile is accepted.
 - **Hardware non-determinism** — captured at the descriptive level
   in `env.cpu.brand`, `env.mem_gb`. CUDA non-determinism would
   surface when the repo moves off CPU-laptop (24-month-roadmap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@
 #   - ``requirements.txt`` is a dev-convenience mirror (loose lower
 #     bounds matching this file) plus dev tooling (``pytest``).
 #   - ``requirements-lock.txt`` is a pip-freeze-style pinned lockfile
-#     that reproduces the numbers in
-#     ``reports/internship_report/report.pdf`` on the author's macOS
-#     CPU dev environment.
+#     for the current security-refreshed CPU dev environment. Historical
+#     report numbers remain anchored to the frozen release tag documented
+#     in ``requirements-lock.txt``.
 #
 # To get a working dev environment use ``make install`` — that runs both
 # ``pip install -r requirements.txt`` (for ``pytest`` etc.) and
@@ -24,7 +24,7 @@ name = "msmarco-genqa"
 version = "0.1.0"
 description = "Retrieval-augmented question answering on MS MARCO."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "msmarco-genqa contributors" }]
 
@@ -44,11 +44,11 @@ dependencies = [
     # Lexical retrieval
     "bm25s>=0.2",
     # Dense retrieval
-    "sentence-transformers>=2.2",
+    "sentence-transformers>=5.5.1",
     "faiss-cpu>=1.7",
     # Generation
-    "torch>=2.0",
-    "transformers>=4.35",
+    "torch>=2.12.0",
+    "transformers>=5.10.2",
     "sentencepiece>=0.1.99",
     # Evaluation
     "evaluate>=0.4",

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -16,8 +16,9 @@
 #   `requirements.txt` plus a handful of test/lint tools are pinned.
 #   Sub-dependencies are still resolved at install time. For a fully
 #   reproducible lock with hashes, regenerate via pip-tools / uv.
-# - Pinned versions reflect the macOS CPU dev environment, with patch-level
-#   security refreshes where they do not change the core model stack.
+# - Pinned versions reflect a CPU dev environment, with security refreshes
+#   that are validated by the opt-in model-stack smoke test when they touch
+#   torch / transformers / sentence-transformers.
 #   Linux/CUDA builds may need a different torch wheel; install `torch`
 #   separately from the appropriate index before running pip install.
 
@@ -38,12 +39,12 @@ lxml==6.1.0
 bm25s==0.3.8
 
 # --- Dense retrieval ---
-sentence-transformers==5.1.2
+sentence-transformers==5.5.1
 faiss-cpu==1.13.0
 
 # --- Generation / reranking (transformers stack) ---
-torch==2.2.2
-transformers==4.57.6
+torch==2.12.0
+transformers==5.10.2
 tokenizers==0.22.2
 sentencepiece==0.2.1
 safetensors==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,12 +15,12 @@ lxml>=6.1.0                   # constrain XML/HTML parsing dependency to patched
 bm25s>=0.2                    # primary backend for the official Week 2 baseline
 
 # Dense retrieval (Week 4)
-sentence-transformers>=2.2
+sentence-transformers>=5.5.1
 faiss-cpu>=1.7
 
 # Generation
-torch>=2.0
-transformers>=4.35
+torch>=2.12.0
+transformers>=5.10.2
 sentencepiece>=0.1.99
 
 # Evaluation

--- a/scripts/smoke_model_stack.py
+++ b/scripts/smoke_model_stack.py
@@ -1,0 +1,187 @@
+"""Opt-in smoke test for the HuggingFace model stack.
+
+This script intentionally loads real model weights. It is not part of the
+default unit-test or CI path; run it before accepting torch / transformers /
+sentence-transformers upgrades that could change generation, embedding, or
+reranking behaviour.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+@dataclass(frozen=True)
+class ModelStackSmokeConfig:
+    generation_model_name: str
+    generation_revision: str | None
+    dense_model_name: str
+    dense_revision: str | None
+    max_input_length: int
+    max_new_tokens: int
+    top_k_passages: int
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    if not isinstance(cfg, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return cfg
+
+
+def build_smoke_config(
+    cfg: dict[str, Any],
+    *,
+    max_new_tokens: int | None = 16,
+) -> ModelStackSmokeConfig:
+    generation = cfg.get("generation") or {}
+    dense = cfg.get("dense") or {}
+    if not isinstance(generation, dict):
+        raise ValueError("generation must be a mapping")
+    if not isinstance(dense, dict):
+        raise ValueError("dense must be a mapping")
+
+    generation_model = str(generation.get("model_name") or "").strip()
+    dense_model = str(dense.get("model_name") or "").strip()
+    if not generation_model:
+        raise ValueError("generation.model_name is required")
+    if not dense_model:
+        raise ValueError("dense.model_name is required")
+
+    return ModelStackSmokeConfig(
+        generation_model_name=generation_model,
+        generation_revision=generation.get("revision") or None,
+        dense_model_name=dense_model,
+        dense_revision=dense.get("revision") or None,
+        max_input_length=int(generation.get("max_input_length", 512)),
+        max_new_tokens=int(max_new_tokens or generation.get("max_new_tokens", 64)),
+        top_k_passages=int(generation.get("top_k_passages", 3)),
+    )
+
+
+def package_versions() -> dict[str, str]:
+    import sentence_transformers
+    import torch
+    import transformers
+
+    return {
+        "torch": torch.__version__,
+        "transformers": transformers.__version__,
+        "sentence_transformers": sentence_transformers.__version__,
+    }
+
+
+def run_generation_smoke(config: ModelStackSmokeConfig, *, device: str) -> dict[str, Any]:
+    from msmarco_genqa.generation.rag_generator import RAGGenerationConfig, RAGGenerator
+
+    query = "Where is Rome located?"
+    passages = [
+        "Rome is the capital city of Italy and is located in the Lazio region.",
+        "The Tiber River runs through Rome.",
+        "Italy is a country in Southern Europe.",
+    ]
+    generator = RAGGenerator(
+        RAGGenerationConfig(
+            model_name=config.generation_model_name,
+            revision=config.generation_revision,
+            max_input_length=config.max_input_length,
+            max_new_tokens=config.max_new_tokens,
+            top_k_passages=config.top_k_passages,
+            device=device,
+            batch_size=1,
+        )
+    )
+    answer = generator.generate(query, passages).strip()
+    if not answer:
+        raise RuntimeError("generation smoke produced an empty answer")
+    return {
+        "model": config.generation_model_name,
+        "revision": config.generation_revision,
+        "answer": answer,
+    }
+
+
+def run_dense_smoke(config: ModelStackSmokeConfig, *, device: str) -> dict[str, Any]:
+    from sentence_transformers import SentenceTransformer
+
+    encoder = SentenceTransformer(
+        config.dense_model_name,
+        revision=config.dense_revision,
+        device=device,
+    )
+    embeddings = encoder.encode(
+        [
+            "Where is Rome located?",
+            "Rome is the capital city of Italy and is located in the Lazio region.",
+        ],
+        normalize_embeddings=True,
+    )
+    shape = list(embeddings.shape)
+    if len(shape) != 2 or shape[0] != 2 or shape[1] <= 0:
+        raise RuntimeError(f"dense smoke produced invalid embedding shape: {shape}")
+    norm = float((embeddings[0] ** 2).sum() ** 0.5)
+    if not 0.99 <= norm <= 1.01:
+        raise RuntimeError(f"dense smoke expected normalized embeddings, got norm={norm:.4f}")
+    return {
+        "model": config.dense_model_name,
+        "revision": config.dense_revision,
+        "embedding_shape": shape,
+        "embedding_norm": norm,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=PROJECT_ROOT / "configs" / "baseline.yaml",
+        help="Config file whose model names and revisions should be smoke-tested.",
+    )
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        help="Torch device for the smoke run. Keep CPU for reproducible local checks.",
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=16,
+        help="Short generation budget for the smoke prompt.",
+    )
+    parser.add_argument("--skip-generation", action="store_true")
+    parser.add_argument("--skip-dense", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    cfg = build_smoke_config(
+        load_config(args.config),
+        max_new_tokens=args.max_new_tokens,
+    )
+    print(json.dumps({"config": asdict(cfg)}, sort_keys=True))
+    print(json.dumps({"packages": package_versions()}, sort_keys=True))
+    if not args.skip_generation:
+        print(json.dumps({"generation": run_generation_smoke(cfg, device=args.device)}))
+    if not args.skip_dense:
+        print(json.dumps({"dense": run_dense_smoke(cfg, device=args.device)}, sort_keys=True))
+    print("model_stack_smoke=ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_model_stack_smoke.py
+++ b/tests/test_model_stack_smoke.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_smoke_module():
+    module_path = PROJECT_ROOT / "scripts" / "smoke_model_stack.py"
+    spec = importlib.util.spec_from_file_location("smoke_model_stack", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_smoke_config_reads_generation_and_dense_sections():
+    mod = _load_smoke_module()
+    cfg = {
+        "generation": {
+            "model_name": "t5-small",
+            "revision": "abc123",
+            "max_input_length": 256,
+            "max_new_tokens": 64,
+            "top_k_passages": 2,
+        },
+        "dense": {
+            "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+            "revision": "def456",
+        },
+    }
+
+    out = mod.build_smoke_config(cfg, max_new_tokens=12)
+
+    assert out.generation_model_name == "t5-small"
+    assert out.generation_revision == "abc123"
+    assert out.dense_model_name == "sentence-transformers/all-MiniLM-L6-v2"
+    assert out.dense_revision == "def456"
+    assert out.max_input_length == 256
+    assert out.max_new_tokens == 12
+    assert out.top_k_passages == 2
+
+
+def test_build_smoke_config_uses_config_generation_budget_when_not_overridden():
+    mod = _load_smoke_module()
+    cfg = {
+        "generation": {"model_name": "t5-small", "max_new_tokens": 32},
+        "dense": {"model_name": "sentence-transformers/all-MiniLM-L6-v2"},
+    }
+
+    out = mod.build_smoke_config(cfg, max_new_tokens=None)
+
+    assert out.max_new_tokens == 32
+    assert out.generation_revision is None
+    assert out.dense_revision is None
+
+
+def test_build_smoke_config_rejects_missing_model_names():
+    mod = _load_smoke_module()
+
+    with pytest.raises(ValueError, match="generation.model_name"):
+        mod.build_smoke_config({"generation": {}, "dense": {"model_name": "encoder"}})
+
+    with pytest.raises(ValueError, match="dense.model_name"):
+        mod.build_smoke_config({"generation": {"model_name": "generator"}, "dense": {}})


### PR DESCRIPTION
## Summary

- refresh the direct torch / transformers / sentence-transformers model-stack pins
- add an opt-in smoke check that loads the pinned T5 generator and dense encoder before accepting future model-stack changes
- update setup, reproducibility notes, and CI's CPU torch lower bound to match the refreshed stack

## Validation

- `python -m pip install -r requirements.txt && python -m pip install -e .` in an isolated temporary venv
- `python scripts/smoke_model_stack.py --config configs/baseline.yaml --device cpu --max-new-tokens 16`
- `python -m pytest -q` in the isolated venv
- `python -m ruff check src tests experiments scripts`
- `python scripts/check_headline_metrics.py`
- `python scripts/run_pipeline.py --dry-run`
- `rag-eval run --config configs/baseline.yaml --dry-run --tracking-backend none`
- `python scripts/check_secrets.py`
- `pip-audit --no-deps --disable-pip -r requirements-lock.txt`
- `pip-audit -r requirements.txt`

Closes #21