### PR TITLE
Refresh low-risk dependency pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run secret scan
         run: python3 scripts/check_secrets.py

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -33,10 +33,10 @@ PyYAML==6.0.3
 # --- Datasets and IO ---
 datasets==4.5.0
 ir_datasets==0.5.11
-lxml==6.1.0
+lxml==6.1.1
 
 # --- Lexical retrieval ---
-bm25s==0.3.8
+bm25s==0.3.9
 
 # --- Dense retrieval ---
 sentence-transformers==5.5.1
@@ -57,4 +57,4 @@ nltk==3.9.4
 
 # --- Testing / lint ---
 pytest==9.0.3
-ruff==0.15.12
+ruff==0.15.16


### PR DESCRIPTION
## Summary

- update `actions/checkout` to v6 in CI and secret scanning workflows
- refresh low-risk lockfile pins for `bm25s`, `lxml`, and `ruff`
- keep the NumPy major-version update separate for a dedicated compatibility pass

## Validation

- `python -m pytest -q` in an isolated temporary venv
- `python -m ruff check src tests experiments scripts`
- `python scripts/check_headline_metrics.py`
- `python scripts/check_secrets.py`
- `pip-audit --no-deps --disable-pip -r requirements-lock.txt`
- `git diff --check`

Supersedes #8, #9, #10, and #11.