### PR TITLE
Update matplotlib lockfile pin

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -25,7 +25,7 @@
 # --- Core scientific stack ---
 numpy==1.26.4
 pandas==2.3.3
-matplotlib==3.9.4
+matplotlib==3.10.9
 
 # --- Configuration ---
 PyYAML==6.0.3


### PR DESCRIPTION
## Summary
- Update the locked matplotlib version from 3.9.4 to 3.10.9.
- Keep the change limited to the direct lockfile pin.

## Validation
- Ruff check over src, tests, experiments, and scripts.
- Lightweight pytest subset covering retrieval metrics, query forms, generation metrics, bootstrap utilities, and headline metadata checks.
- Headline metric consistency check.
- Matplotlib Agg rendering smoke with version 3.10.9.

Closes #41.
Replaces #33.