### PR TITLE
infra(github): add issue and pull-request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: A defect in the pipeline, runners, or evaluation
+title: "[Bug] "
+labels: "bug"
+---
+
+## What happened
+
+<!-- The observed behaviour, including the exact command run and any error
+output. -->
+
+## Expected behaviour
+
+<!-- What you expected instead. -->
+
+## Reproduction
+
+<!-- Minimal steps. Include the config or run directory if relevant. -->
+
+-
+
+## Environment
+
+- OS:
+- Python version:
+- Install path (`requirements.txt` or `requirements-lock.txt`):
+- Commit (`git rev-parse --short HEAD`):

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,29 @@
+---
+name: Task
+about: A scoped piece of work — infra, research, evaluation, or cleanup
+title: "[Scope] "
+labels: ""
+---
+
+## Goal
+
+<!-- One or two sentences: what outcome this change produces and why. -->
+
+## Scope
+
+<!-- The concrete steps. Keep it self-contained; list what is and is not
+included. -->
+
+-
+-
+
+## Acceptance criteria
+
+<!-- Observable conditions that mean this is done. -->
+
+-
+- CI stays green.
+
+## Dependency
+
+<!-- Other issues this depends on, or "Independent." -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Subject prefix matches the area touched, e.g. infra(manifest):, research(nli):, docs(readme): -->
+
+## Summary
+
+<!-- What this change does and why. One logical change per pull request. -->
+
+## Checks
+
+- [ ] `make test` passes
+- [ ] `make lint` passes
+
+<!-- Paste the status line, e.g. "Suite: 398 passed. Ruff: clean." -->
+
+## Notes
+
+<!-- Anything reviewers should know: trade-offs, follow-ups, or out-of-scope items. -->
+
+Closes #


### PR DESCRIPTION
Adds issue templates (a task template matching the existing scope-prefixed Goal / Scope / Acceptance / Dependency shape, plus a bug-report template) and a pull-request template that prompts for the `make test` / `make lint` status and a closing-issue reference.

Configuration only; no code or workflow behaviour change.

Closes #53.