### PR TITLE
Preserve main CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,10 @@ on:
   pull_request:
     branches: [main]
 
-# Avoid running duplicate workflows on the same ref (push + PR from same
-# branch).
+# Avoid duplicate PR workflows while preserving every main-branch run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Keep pull request workflow runs cancellable on repeated pushes.
- Preserve in-progress main branch CI runs so merge validation is not cancelled by later main pushes.

## Validation
- Ran git diff --check.
- Checked workflow text for the pull-request-only cancellation expression.
- Scanned the changed workflow for unrelated metadata traces.

Closes #55.