### PR TITLE
Remove legacy path shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,8 @@ data/                raw/, processed/, cache/ — all gitignored, .gitkeep track
   Scripts may change shape as analyses evolve; only the `experiments/`
   output schema is held fixed.
 
-Everything runs from the project root. Scripts add `PROJECT_ROOT` to
-`sys.path` themselves; no `PYTHONPATH` needed.
+Everything runs from the project root after the editable install registers
+the package; no `PYTHONPATH` needed.
 
 ## 3. Setup
 
@@ -624,7 +624,7 @@ All knobs live in [`configs/baseline.yaml`](configs/baseline.yaml). Key ones:
 | Unit tests | works | `make test` / `pytest -q` — no network, no heavy deps. Slow tests excluded by `pytest.ini_options`. |
 | Slow tests | works (skips gracefully) | `make test-slow` includes `@pytest.mark.slow`. HF metric scripts skip if unavailable. |
 | Lockfile | basic | `requirements-lock.txt` is pip-freeze-style; sub-dep transitive closure + hash pinning are TODO. Model-stack pins are checked with `scripts/smoke_model_stack.py`. |
-| Installable package | basic | `pip install -e .` registers `src` via `pyproject.toml`. Existing `sys.path.insert` shims in `experiments/` and `scripts/` are kept for now. |
+| Installable package | works | `pip install -e .` registers `src` via `pyproject.toml`; scripts import the installed package without local `sys.path` shims. |
 | CI | basic | `.github/workflows/ci.yml`: pytest + ruff on push/PR to main. No slow tests, no data download. |
 | Lint | minimal | `ruff` with `F` + `W` (pyflakes + whitespace). `E` / `I` / `UP` are off on the first pass. |
 | Artifact manifest | wired | `src/msmarco_genqa/util/manifest.py` writes `outputs/<stage>/manifest.json` alongside `metrics.json`. Captures git commit + dirty flag, command, config hash, dependency-file hashes, per-output sha256 (truncated). |
@@ -642,7 +642,6 @@ Limitations to be aware of:
 
 - The lockfile reflects a macOS CPU-only dev environment. Linux / CUDA may resolve different versions; install `torch` from the appropriate PyTorch index first.
 - Corpus, encoder, and reranker checkpoints are downloaded by `ir_datasets` / HuggingFace at first run and are not checksummed by the project.
-- `experiments/run_*.py` still rely on `sys.path.insert(0, PROJECT_ROOT)` at the top of the file. `pip install -e .` makes this unnecessary; the shim is kept until a later pass removes it.
 
 ## 7. Known limitations
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,11 +1,5 @@
 """Run the config-driven MS MARCO GenQA experiment pipeline."""
 
-from pathlib import Path
-import sys
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
-
 from msmarco_genqa.cli.pipeline import main
 
 

--- a/scripts/smoke_model_stack.py
+++ b/scripts/smoke_model_stack.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -18,9 +17,6 @@ from typing import Any
 import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-SRC_DIR = PROJECT_ROOT / "src"
-if str(SRC_DIR) not in sys.path:
-    sys.path.insert(0, str(SRC_DIR))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Remove legacy sys.path mutation from script entry points that now rely on the editable package install.
- Keep repository-root path handling where it is still used for config defaults.
- Update README reproducibility notes to reflect the package import path cleanup.

## Validation
- Ran git diff --check.
- Ran python -m ruff check src tests experiments scripts.
- Installed the package in a temporary editable no-dependency environment and confirmed package imports resolve without local path shims.
- Ran scripts/run_pipeline.py --dry-run --tracking-backend none.
- Ran scripts/smoke_model_stack.py --help.
- Ran scripts/check_headline_metrics.py.
- Ran pytest -q tests/test_pipeline.py tests/test_model_stack_smoke.py tests/test_run_full_generation_and_analysis.py.

Note: a local full pytest -q run in the temporary no-dependency environment reached 382 passed and 4 skipped, then failed on missing bm25s/faiss imports. The pull request CI installs the project dependencies and is the full-suite gate for this change.

Closes #6.