### PR TITLE
Rename ablation drivers by topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ not against the W2 full-corpus number.
 
 **W4 follow-ups:**
 
-- *Same-tier encoder horizontal* on the identical 50 k sample
-  ([`scripts/run_encoder_horizontal.py`](scripts/run_encoder_horizontal.py)):
+- *Same-tier encoder comparison* on the identical 50 k sample
+  ([`scripts/run_encoder_comparison.py`](scripts/run_encoder_comparison.py)):
 
   | Encoder | MRR@10 | nDCG@10 | Recall@100 | ms/passage |
   |---|---:|---:|---:|---:|
@@ -377,7 +377,7 @@ data/                raw/, processed/, cache/ — all gitignored, .gitkeep track
   | Evaluation drivers | `bootstrap_generation_comparison.py`, `bertscore_paired_eval.py`, `grounding_audit.py`, `grounding_correlation.py` |
   | Failure / case analysis | `regression_failure_taxonomy.py`, `regression_query_profile.py`, `low_grounding_case_study.py` |
   | Slicing / tagging | `tag_query_forms.py`, `analyze_rerank_by_query_form.py`, `analyze_generation_rerank.py` |
-  | Ablation drivers | `run_density_sweep.py`, `run_encoder_horizontal.py`, `run_k_sweep.py`, `run_generator_capacity_sweep.py` |
+  | Ablation drivers | `run_density_sweep.py`, `run_encoder_comparison.py`, `run_topk_sweep.py`, `run_generator_capacity_sweep.py` |
   | End-to-end driver | `run_full_generation_and_analysis.py` |
   | Validation / smoke | `validate_full_rerank.py`, `smoke_test_resume.py` |
 
@@ -652,7 +652,7 @@ Limitations to be aware of:
 
 ## 8. Next
 
-- **W5-B — K-sweep Pareto.** K ∈ {50, 100, 200} perf-latency Pareto on
+- **W5-B — top-k Pareto.** K ∈ {50, 100, 200} perf-latency Pareto on
   both first stages (1 000-q subsample for K=50/200; K=100 reuses W5
   full-dev). Queued.
 - **W7-B — generator capacity, not decode budget.** The W6 closure

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -120,9 +120,9 @@ full-corpus MRR@10.
 Both numbers are **upper-bounded** by qrels-anchoring. The takeaway is
 the gap, not the absolute level.
 
-### Encoder horizontal ablation
+### Encoder comparison ablation
 
-[`scripts/run_encoder_horizontal.py`](../scripts/run_encoder_horizontal.py)
+[`scripts/run_encoder_comparison.py`](../scripts/run_encoder_comparison.py)
 swaps the encoder on the identical 50k sample.
 
 | Encoder | MRR@10 | nDCG@10 | Recall@100 | ms/passage |
@@ -176,11 +176,10 @@ unchanged by construction.
 Runtime on a 6-core MacBook CPU: ~4 h 37 min for the full dev/small
 (538k (query, passage) pairs at ~32 pairs/s; peak RSS ~3.3 GiB).
 
-### k-sweep ablation
+### Top-k sweep ablation
 
-[`scripts/run_k_sweep.py`](../scripts/run_k_sweep.py) varies
-`rerank_top_k` to characterise the depth/quality trade-off. (Slated
-for rename to `scripts/run_topk_sweep.py`.)
+[`scripts/run_topk_sweep.py`](../scripts/run_topk_sweep.py) varies
+`rerank_top_k` to characterise the depth/quality trade-off.
 
 ---
 
@@ -309,8 +308,8 @@ full-sample outcome determines the direction.
 | Ablation | Script | Status |
 |---|---|---|
 | Density sweep on dense retrieval (15k/30k/50k) | [`scripts/run_density_sweep.py`](../scripts/run_density_sweep.py) | Done; see Stage 2 |
-| Dense encoder horizontal | [`scripts/run_encoder_horizontal.py`](../scripts/run_encoder_horizontal.py) | Done; see Stage 2 |
-| Rerank depth (k-sweep) | [`scripts/run_k_sweep.py`](../scripts/run_k_sweep.py) | Done |
+| Dense encoder comparison | [`scripts/run_encoder_comparison.py`](../scripts/run_encoder_comparison.py) | Done; see Stage 2 |
+| Rerank depth (top-k sweep) | [`scripts/run_topk_sweep.py`](../scripts/run_topk_sweep.py) | Done |
 | Regression vs non-regression query profile | [`scripts/regression_query_profile.py`](../scripts/regression_query_profile.py) | Done |
 | Generation × retrieval source first-stage comparison | [`scripts/compare_rerank_first_stages.py`](../scripts/compare_rerank_first_stages.py) | Done |
 | Validation of full reranker run | [`scripts/validate_full_rerank.py`](../scripts/validate_full_rerank.py) | Done |

--- a/scripts/run_density_sweep.py
+++ b/scripts/run_density_sweep.py
@@ -119,9 +119,9 @@ def resolve_encoder_and_baseline(args: argparse.Namespace) -> tuple[str, str]:
     """Return (encoder model_name, baseline output_dir)."""
     if args.encoder and args.baseline_dir:
         return args.encoder, args.baseline_dir
-    w4b_summary = PROJECT_ROOT / "outputs/week04_encoder_horizontal/summary.json"
-    if w4b_summary.exists():
-        with open(w4b_summary) as f:
+    encoder_summary = PROJECT_ROOT / "outputs/week04_encoder_horizontal/summary.json"
+    if encoder_summary.exists():
+        with open(encoder_summary) as f:
             summary = json.load(f)
         winner = summary["best_encoder_by_mrr_at_10"]
         # Find the corresponding output_dir from the encoder list.

--- a/scripts/run_encoder_comparison.py
+++ b/scripts/run_encoder_comparison.py
@@ -1,4 +1,4 @@
-"""Same-tier dense encoder horizontal on the W4 sampled corpus.
+"""Same-tier dense encoder comparison on the W4 sampled corpus.
 
 Drives ``experiments/run_dense_retrieval.py`` for two new encoders
 (`BAAI/bge-small-en-v1.5` and `sentence-transformers/all-MiniLM-L12-v2`)
@@ -33,7 +33,7 @@ from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-logger = logging.getLogger("run_encoder_horizontal")
+logger = logging.getLogger("run_encoder_comparison")
 
 
 # (label, model_name, output_subdir, reuse_existing)
@@ -126,7 +126,7 @@ def extract(enc: dict[str, Any]) -> dict[str, Any]:
 
 def render_markdown(rows: list[dict[str, Any]]) -> str:
     lines: list[str] = []
-    lines.append("# W4-B — same-tier encoder horizontal on the W4 sampled corpus")
+    lines.append("# W4-B — same-tier encoder comparison on the W4 sampled corpus")
     lines.append("")
     lines.append(
         "Three encoders evaluated head-to-head on the same 50 k qrels-anchored "
@@ -190,7 +190,7 @@ def main() -> None:
     winner = max(rows, key=lambda r: r["dense_mrr_at_10"])
 
     summary = {
-        "task": "encoder_horizontal",
+        "task": "encoder_comparison",
         "scope": "3 encoders × same W4 50k qrels-anchored sample",
         "rows": rows,
         "best_encoder_by_mrr_at_10": winner["model_name"],
@@ -207,7 +207,7 @@ def main() -> None:
 
     # ---- console summary ----
     print()
-    print("=== W4-B — encoder horizontal ===")
+    print("=== W4-B — encoder comparison ===")
     print(f"  {'encoder':40s}  {'MRR@10':>8s}  {'nDCG@10':>8s}  {'R@100':>7s}  {'ms/p':>6s}")
     for r in rows:
         print(

--- a/scripts/run_topk_sweep.py
+++ b/scripts/run_topk_sweep.py
@@ -1,4 +1,4 @@
-"""Rerank-depth K-sweep on BM25 and dense first stages.
+"""Rerank-depth top-k sweep on BM25 and dense first stages.
 
 Drives four ``experiments/run_reranker.py`` invocations and aggregates
 the results into a single perf–latency Pareto table + figure.
@@ -43,7 +43,7 @@ from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-logger = logging.getLogger("run_k_sweep")
+logger = logging.getLogger("run_topk_sweep")
 
 
 # (label, first_stage_key_in_metrics, input_run_relpath, input_week, K, output_subdir, num_eval_queries)
@@ -248,7 +248,7 @@ def aggregate(cells: list[dict[str, Any]]) -> dict[str, Any]:
 
 def render_markdown(agg: dict[str, Any]) -> str:
     lines: list[str] = []
-    lines.append("# W5-B — rerank depth K-sweep on BM25 vs dense first stages")
+    lines.append("# W5-B — rerank depth top-k sweep on BM25 vs dense first stages")
     lines.append("")
     lines.append(
         "Cross-encoder MS-MARCO-MiniLM-L-6-v2 reranking applied at "
@@ -353,7 +353,7 @@ def main() -> None:
     fig_rel = plot_pareto(agg, args.figures_dir)
 
     summary = {
-        "task": "k_sweep",
+        "task": "topk_sweep",
         "scope": "K in {50, 100, 200}; K=50,200 on 1000-q subsample (seed 42); K=100 reuses W5 / W5-A full-dev runs",
         "cells": agg["cells"],
         "figure": fig_rel,
@@ -371,7 +371,7 @@ def main() -> None:
 
     # ---- console summary ----
     print()
-    print("=== W5-B — rerank K-sweep Pareto ===")
+    print("=== W5-B — rerank top-k Pareto ===")
     print(f"  {'cell':16s}  {'n_q':>5s}  {'rerank MRR@10':>14s}  {'Δ MRR@10':>9s}  {'sec':>6s}")
     for r in agg["cells"]:
         print(


### PR DESCRIPTION
## Summary
- Rename the remaining week-anchored ablation driver entry points to topical names.
- Update README and experiment documentation links to the new script names.
- Keep historical output directories unchanged so existing artifacts and provenance references remain stable.

## Validation
- Ran git diff --check.
- Ran python -m ruff check src tests experiments scripts.
- Ran python -m py_compile scripts/run_density_sweep.py scripts/run_encoder_comparison.py scripts/run_topk_sweep.py.
- Ran python scripts/run_encoder_comparison.py --help.
- Ran PYTHONUTF8=1 python scripts/run_topk_sweep.py --help.
- Scanned changed docs and scripts for unrelated metadata traces.

Closes #5.