### PR TITLE
Harden rerank run parsing

### DIFF
--- a/src/msmarco_genqa/reranking/io.py
+++ b/src/msmarco_genqa/reranking/io.py
@@ -10,8 +10,20 @@ ordering, so we ignore the other columns on read.
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Iterable
+
+
+class RunTsvFormatError(ValueError):
+    """Raised when a TREC-format run file is malformed."""
+
+    def __init__(self, path: Path | str, line_number: int | None, message: str) -> None:
+        self.path = Path(path)
+        self.line_number = line_number
+        self.reason = message
+        location = str(self.path) if line_number is None else f"{self.path}:{line_number}"
+        super().__init__(f"{location}: {message}")
 
 
 def read_run_tsv(path: Path | str) -> dict[str, list[tuple[str, float]]]:
@@ -20,14 +32,81 @@ def read_run_tsv(path: Path | str) -> dict[str, list[tuple[str, float]]]:
     Lines are returned in the order they appear in the file (which is
     already the rank order produced by the upstream retriever).
     """
+    p = Path(path)
     runs: dict[str, list[tuple[str, float]]] = {}
-    with open(path) as f:
-        for line in f:
-            parts = line.rstrip("\n").split("\t")
-            if len(parts) < 6:
-                continue
-            qid, _q0, doc_id, _rank, score, _sys = parts[:6]
-            runs.setdefault(qid, []).append((doc_id, float(score)))
+    seen_qid_rank: set[tuple[str, int]] = set()
+    seen_qid_doc: set[tuple[str, str]] = set()
+    try:
+        with p.open(encoding="utf-8") as f:
+            for line_number, raw_line in enumerate(f, start=1):
+                line = raw_line.rstrip("\n").rstrip("\r")
+                if not line:
+                    raise RunTsvFormatError(p, line_number, "empty line")
+                parts = line.split("\t")
+                if len(parts) != 6:
+                    raise RunTsvFormatError(
+                        p,
+                        line_number,
+                        f"expected 6 tab-separated fields, got {len(parts)}",
+                    )
+                qid, _q0, doc_id, rank_text, score_text, system = parts
+                if not qid:
+                    raise RunTsvFormatError(p, line_number, "empty query id")
+                if not doc_id:
+                    raise RunTsvFormatError(p, line_number, "empty document id")
+                if "\ufffd" in qid or "\ufffd" in doc_id or "\ufffd" in system:
+                    raise RunTsvFormatError(
+                        p,
+                        line_number,
+                        "replacement character found in identifier field",
+                    )
+                try:
+                    rank = int(rank_text)
+                except ValueError as exc:
+                    raise RunTsvFormatError(
+                        p,
+                        line_number,
+                        f"rank is not an integer: {rank_text!r}",
+                    ) from exc
+                if rank < 1:
+                    raise RunTsvFormatError(
+                        p,
+                        line_number,
+                        f"rank must be positive, got {rank}",
+                    )
+                qid_rank = (qid, rank)
+                if qid_rank in seen_qid_rank:
+                    raise RunTsvFormatError(
+                        p,
+                        line_number,
+                        f"duplicate rank {rank} for query id {qid!r}",
+                    )
+                seen_qid_rank.add(qid_rank)
+                qid_doc = (qid, doc_id)
+                if qid_doc in seen_qid_doc:
+                    raise RunTsvFormatError(
+                        p,
+                        line_number,
+                        f"duplicate document id {doc_id!r} for query id {qid!r}",
+                    )
+                seen_qid_doc.add(qid_doc)
+                try:
+                    score = float(score_text)
+                except ValueError as exc:
+                    raise RunTsvFormatError(
+                        p,
+                        line_number,
+                        f"score is not numeric: {score_text!r}",
+                    ) from exc
+                if not math.isfinite(score):
+                    raise RunTsvFormatError(
+                        p,
+                        line_number,
+                        f"score must be finite, got {score_text!r}",
+                    )
+                runs.setdefault(qid, []).append((doc_id, score))
+    except UnicodeDecodeError as exc:
+        raise RunTsvFormatError(p, None, f"file is not valid UTF-8: {exc}") from exc
     return runs
 
 

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -14,6 +14,7 @@ import pytest
 
 from msmarco_genqa.reranking.cross_encoder import CrossEncoderReranker
 from msmarco_genqa.reranking.io import (
+    RunTsvFormatError,
     append_run_tsv,
     collect_unique_doc_ids,
     prune_partial_qids,
@@ -160,6 +161,57 @@ def test_read_run_tsv_roundtrip(tmp_path):
     assert list(runs.keys()) == ["q1", "q2"]
     assert runs["q1"] == [("d_a", 3.0), ("d_b", 2.5), ("d_c", 1.0)]
     assert runs["q2"] == [("d_x", 9.9)]
+
+
+@pytest.mark.parametrize(
+    ("line", "message"),
+    [
+        ("q1\tQ0\td1\t1\t1.0\n", "expected 6 tab-separated fields"),
+        ("\tQ0\td1\t1\t1.0\tdense\n", "empty query id"),
+        ("q1\tQ0\t\t1\t1.0\tdense\n", "empty document id"),
+        ("q1\tQ0\td1\t0\t1.0\tdense\n", "rank must be positive"),
+        ("q1\tQ0\td1\tNOT_A_RANK\t1.0\tdense\n", "rank is not an integer"),
+        ("q1\tQ0\td1\t1\tNOT_A_SCORE\tdense\n", "score is not numeric"),
+        ("q1\tQ0\td1\t1\tnan\tdense\n", "score must be finite"),
+        ("q1\tQ0\td\ufffd\t1\t1.0\tdense\n", "replacement character"),
+    ],
+)
+def test_read_run_tsv_rejects_malformed_lines(tmp_path, line, message):
+    path = tmp_path / "run.tsv"
+    path.write_text(line, encoding="utf-8")
+    with pytest.raises(RunTsvFormatError, match=message) as excinfo:
+        read_run_tsv(path)
+    assert excinfo.value.line_number == 1
+
+
+def test_read_run_tsv_rejects_duplicate_rank_per_query(tmp_path):
+    path = tmp_path / "run.tsv"
+    path.write_text(
+        "q1\tQ0\td1\t1\t2.0\tdense\n"
+        "q1\tQ0\td2\t1\t1.0\tdense\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RunTsvFormatError, match="duplicate rank 1"):
+        read_run_tsv(path)
+
+
+def test_read_run_tsv_rejects_duplicate_doc_per_query(tmp_path):
+    path = tmp_path / "run.tsv"
+    path.write_text(
+        "q1\tQ0\td1\t1\t2.0\tdense\n"
+        "q1\tQ0\td1\t2\t1.0\tdense\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RunTsvFormatError, match="duplicate document id"):
+        read_run_tsv(path)
+
+
+def test_read_run_tsv_rejects_non_utf8_bytes(tmp_path):
+    path = tmp_path / "run.tsv"
+    path.write_bytes(b"q1\tQ0\td1\t1\t1.0\tdense\n\xff")
+    with pytest.raises(RunTsvFormatError, match="not valid UTF-8") as excinfo:
+        read_run_tsv(path)
+    assert excinfo.value.line_number is None
 
 
 def test_truncate_top_k():


### PR DESCRIPTION
## Summary
- Add a typed RunTsvFormatError for malformed TREC run files used by reranking and analysis helpers.
- Fail fast on malformed lines, empty identifiers, invalid or duplicate ranks, duplicate document ids per query, non-finite scores, non-UTF-8 bytes, and replacement characters in identifier fields.
- Add boundary tests for malformed run.tsv inputs.

## Validation
- Ran PYTHONPATH=src python -m pytest -q tests/test_reranker.py tests/test_retrieval_lift.py.
- Ran python -m ruff check src tests experiments scripts.
- Ran git diff --check.
- Scanned changed files for unrelated metadata traces.

Refs #30.