### PR TITLE
Add RRF hybrid fusion runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ python experiments/run_retrieval.py    # script form
 mgq-retrieve                            # console form
 ```
 
-Console names: `mgq-retrieve`, `mgq-dense`, `mgq-rerank`, `mgq-generate`.
+Console names: `mgq-retrieve`, `mgq-dense`, `mgq-fuse`, `mgq-rerank`, `mgq-generate`.
 The examples below use the script form.
 
 ### Stage 2 — BM25
@@ -500,6 +500,25 @@ runs reuse the cached index. Tunable knobs:
 - `dense.model_name` (e.g. `sentence-transformers/msmarco-MiniLM-L6-cos-v5`)
 - `dense.sample_size` (default 50 000)
 - `dense.compare_bm25_on_sample`
+
+### Stage 4B - Hybrid RRF fusion
+
+Fuse two or more TREC-format first-stage runs with weighted Reciprocal
+Rank Fusion (RRF). The sample-matched BM25 and dense outputs from Stage 4
+are the recommended first comparison because both runs share the same
+candidate pool and qrels caveat.
+
+```bash
+python experiments/run_hybrid_fusion.py \
+    --input-run bm25_sample=outputs/week04_dense/run_bm25_sample.tsv \
+    --input-run dense=outputs/week04_dense/run.tsv \
+    --output-dir outputs/week04_hybrid_rrf \
+    --top-k 1000
+```
+
+Pass `--qrels <path>` to compute MRR, nDCG, and recall in `metrics.json`.
+The runner always writes `run.tsv`, `provenance.jsonl`, `metrics.json`,
+`resolved_config.yaml`, and `manifest.json`.
 
 ### Stage 5 — Cross-encoder reranking
 

--- a/docs/reproducibility_protocol.md
+++ b/docs/reproducibility_protocol.md
@@ -6,7 +6,7 @@ verify a recorded run is reproducible.
 
 ## TL;DR
 
-Every run of `mgq-{retrieve, rerank, generate, evaluate}` writes:
+Every run of `mgq-{retrieve, dense, fuse, rerank, generate, evaluate}` writes:
 
 - `outputs/<run>/manifest.json` — schema-v2 provenance contract
 - `outputs/<run>/resolved_config.yaml` — config dict actually used (with CLI overrides applied)

--- a/experiments/run_hybrid_fusion.py
+++ b/experiments/run_hybrid_fusion.py
@@ -1,0 +1,358 @@
+"""Fuse retrieval runs with weighted Reciprocal Rank Fusion.
+
+The runner consumes two or more standard TREC-format ``run.tsv`` files,
+preserves per-source provenance in ``provenance.jsonl``, writes a fused
+``run.tsv``, and records metrics/provenance in ``metrics.json`` and
+``manifest.json``.
+
+Example:
+
+    python experiments/run_hybrid_fusion.py \
+        --input-run bm25_sample=outputs/week04_dense/run_bm25_sample.tsv \
+        --input-run dense=outputs/week04_dense/run.tsv \
+        --output-dir outputs/week04_hybrid_rrf \
+        --top-k 1000 \
+        --qrels data/qrels.dev.small.tsv
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
+from msmarco_genqa.reranking.io import read_run_tsv, write_run_tsv
+from msmarco_genqa.retrieval.fusion import fused_doc_ids_and_scores, reciprocal_rank_fusion
+from msmarco_genqa.util.environment import capture_environment
+from msmarco_genqa.util.manifest import (
+    compute_data_fingerprint,
+    compute_env_fingerprint,
+    compute_resolved_config_hash,
+    write_resolved_config,
+    write_run_manifest,
+)
+from msmarco_genqa.util.seeding import set_global_seed
+
+logger = logging.getLogger("run_hybrid_fusion")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input-run",
+        action="append",
+        required=True,
+        metavar="NAME=PATH",
+        help=(
+            "Named input run. Pass once per source, for example "
+            "bm25=outputs/week04_dense/run_bm25_sample.tsv."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=PROJECT_ROOT / "outputs/week04_hybrid_rrf",
+        help="Directory for run.tsv, provenance.jsonl, metrics.json, and manifest.json.",
+    )
+    parser.add_argument(
+        "--rank-constant",
+        type=float,
+        default=60.0,
+        help="RRF rank constant k. Larger values reduce early-rank dominance.",
+    )
+    parser.add_argument(
+        "--weight",
+        action="append",
+        default=[],
+        metavar="NAME=FLOAT",
+        help="Optional source weight. Omitted sources default to 1.0.",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=1000,
+        help="Maximum fused candidates to keep per query.",
+    )
+    parser.add_argument(
+        "--qrels",
+        type=Path,
+        default=None,
+        help=(
+            "Optional qrels TSV for retrieval metrics. Accepts either "
+            "'qid docid rel' or 'qid iter docid rel' whitespace-separated rows."
+        ),
+    )
+    parser.add_argument(
+        "--system-name",
+        default="rrf",
+        help="System name written in the sixth TREC run column.",
+    )
+    parser.add_argument(
+        "--require-clean-tree",
+        action="store_true",
+        help="Refuse to write the manifest if the git tree is dirty.",
+    )
+    parser.add_argument(
+        "--allow-incomplete-manifest",
+        action="store_true",
+        help="Bypass strict manifest required-field validation during development.",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_path(path: Path) -> Path:
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _parse_named_path(value: str, option_name: str) -> tuple[str, Path]:
+    name, sep, raw_path = value.partition("=")
+    if not sep or not name or not raw_path:
+        raise SystemExit(f"{option_name} must use NAME=PATH, got {value!r}")
+    return name, _resolve_path(Path(raw_path))
+
+
+def _parse_weights(values: list[str], source_names: set[str]) -> dict[str, float]:
+    weights: dict[str, float] = {}
+    for raw in values:
+        name, sep, raw_value = raw.partition("=")
+        if not sep or not name or not raw_value:
+            raise SystemExit(f"--weight must use NAME=FLOAT, got {raw!r}")
+        if name not in source_names:
+            raise SystemExit(f"--weight names unknown source {name!r}")
+        try:
+            weight = float(raw_value)
+        except ValueError as exc:
+            raise SystemExit(f"--weight for {name!r} is not numeric: {raw_value!r}") from exc
+        if weight < 0:
+            raise SystemExit(f"--weight for {name!r} must be non-negative")
+        weights[name] = weight
+    return weights
+
+
+def _path_for_payload(path: Path) -> str:
+    return (
+        str(path.relative_to(PROJECT_ROOT).as_posix())
+        if path.is_relative_to(PROJECT_ROOT)
+        else str(path)
+    )
+
+
+def _load_qrels(path: Path) -> dict[str, set[str]]:
+    qrels: dict[str, set[str]] = {}
+    with path.open(encoding="utf-8") as f:
+        for line_number, raw_line in enumerate(f, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            if len(parts) == 3:
+                qid, doc_id, rel_text = parts
+            elif len(parts) >= 4:
+                qid, _iter, doc_id, rel_text = parts[:4]
+            else:
+                raise SystemExit(
+                    f"{path}:{line_number}: expected 3 or 4+ qrels columns, got {len(parts)}"
+                )
+            try:
+                rel = float(rel_text)
+            except ValueError as exc:
+                raise SystemExit(
+                    f"{path}:{line_number}: relevance is not numeric: {rel_text!r}"
+                ) from exc
+            if rel > 0:
+                qrels.setdefault(qid, set()).add(doc_id)
+    return qrels
+
+
+def _write_provenance(path: Path, fused) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for qid in sorted(fused):
+            for rank, hit in enumerate(fused[qid], start=1):
+                row = {
+                    "qid": qid,
+                    "doc_id": hit.doc_id,
+                    "rank": rank,
+                    "rrf_score": hit.score,
+                    "sources": {
+                        name: {
+                            "rank": source.rank,
+                            "score": source.score,
+                            "weight": source.weight,
+                            "contribution": source.contribution,
+                        }
+                        for name, source in sorted(hit.sources.items())
+                    },
+                }
+                f.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _source_coverage(runs_by_source) -> dict[str, dict[str, int]]:
+    return {
+        name: {
+            "n_queries": len(runs),
+            "n_rows": sum(len(rows) for rows in runs.values()),
+            "n_unique_docs": len({doc_id for rows in runs.values() for doc_id, _ in rows}),
+        }
+        for name, runs in sorted(runs_by_source.items())
+    }
+
+
+def _overlap_stats(runs_by_source) -> dict[str, int]:
+    qid_sets = [set(runs) for runs in runs_by_source.values()]
+    if not qid_sets:
+        return {"qids_union": 0, "qids_shared_all": 0}
+    return {
+        "qids_union": len(set().union(*qid_sets)),
+        "qids_shared_all": len(set.intersection(*qid_sets)),
+    }
+
+
+def _build_resolved_config(args: argparse.Namespace, input_runs: dict[str, Path], weights) -> dict[str, Any]:
+    return {
+        "task": "hybrid_fusion",
+        "input_runs": {name: _path_for_payload(path) for name, path in sorted(input_runs.items())},
+        "rank_constant": args.rank_constant,
+        "weights": {name: float(weights.get(name, 1.0)) for name in sorted(input_runs)},
+        "top_k": args.top_k,
+        "qrels": _path_for_payload(_resolve_path(args.qrels)) if args.qrels else None,
+        "system_name": args.system_name,
+    }
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = parse_args(argv)
+
+    input_runs: dict[str, Path] = {}
+    for raw in args.input_run:
+        name, path = _parse_named_path(raw, "--input-run")
+        if name in input_runs:
+            raise SystemExit(f"duplicate --input-run source name {name!r}")
+        if not path.exists():
+            raise SystemExit(f"input run not found: {path}")
+        input_runs[name] = path
+    if len(input_runs) < 2:
+        raise SystemExit("RRF fusion requires at least two --input-run sources")
+
+    weights = _parse_weights(args.weight, set(input_runs))
+    qrels_path = _resolve_path(args.qrels) if args.qrels else None
+    if qrels_path is not None and not qrels_path.exists():
+        raise SystemExit(f"qrels file not found: {qrels_path}")
+
+    output_dir = _resolve_path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    seed = 0
+    seed_coverage = set_global_seed(seed)
+    runs_by_source = {
+        name: read_run_tsv(path)
+        for name, path in sorted(input_runs.items())
+    }
+    logger.info(
+        "Fusing %d source runs over %d qids.",
+        len(runs_by_source),
+        _overlap_stats(runs_by_source)["qids_union"],
+    )
+    fused = reciprocal_rank_fusion(
+        runs_by_source,
+        rank_constant=args.rank_constant,
+        weights=weights,
+        top_k=args.top_k,
+    )
+
+    qids, doc_ids, scores = fused_doc_ids_and_scores(fused)
+    run_path = output_dir / "run.tsv"
+    write_run_tsv(run_path, qids, doc_ids, scores, args.system_name)
+
+    provenance_path = output_dir / "provenance.jsonl"
+    _write_provenance(provenance_path, fused)
+
+    metrics = {}
+    n_examples = None
+    if qrels_path is not None:
+        qrels = _load_qrels(qrels_path)
+        runs_for_eval = {qid: [hit.doc_id for hit in hits] for qid, hits in fused.items()}
+        metrics = evaluate_retrieval(runs_for_eval, qrels)
+        n_examples = metrics.pop("n_queries", None)
+
+    env_dict = capture_environment()
+    resolved_config = _build_resolved_config(args, input_runs, weights)
+    payload = {
+        "task": "hybrid_fusion",
+        "dataset": "msmarco-passage/dev/small" if qrels_path else "run-fusion",
+        "n_examples": n_examples,
+        "fusion": {
+            "method": "weighted_rrf",
+            "rank_constant": args.rank_constant,
+            "top_k": args.top_k,
+            "weights": resolved_config["weights"],
+            "input_runs": resolved_config["input_runs"],
+        },
+        "source_coverage": _source_coverage(runs_by_source),
+        "overlap": _overlap_stats(runs_by_source),
+        "metrics": {"rrf": metrics} if metrics else {},
+        "environment": env_dict,
+    }
+    metrics_path = output_dir / "metrics.json"
+    with metrics_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True, default=str)
+        f.write("\n")
+    logger.info("Wrote fused run and metrics to %s", output_dir)
+
+    resolved_config_path = write_resolved_config(resolved_config, output_dir)
+    resolved_config_hash = compute_resolved_config_hash(resolved_config)
+    extra_files = {f"input_run.{name}": path for name, path in input_runs.items()}
+    if qrels_path is not None:
+        extra_files["qrels"] = qrels_path
+    data_fingerprint = compute_data_fingerprint(
+        cache_dir=PROJECT_ROOT / "data/raw",
+        extra_files=extra_files,
+    )
+    env_fingerprint = compute_env_fingerprint(env_dict)
+
+    write_run_manifest(
+        project_root=PROJECT_ROOT,
+        output_dir=output_dir,
+        command=sys.argv if argv is None else ["mgq-fuse", *argv],
+        config_path=None,
+        extra_outputs=[run_path, provenance_path, resolved_config_path],
+        extra={
+            "task": "hybrid_fusion",
+            "method": "weighted_rrf",
+            "rank_constant": args.rank_constant,
+            "top_k": args.top_k,
+            "input_runs": resolved_config["input_runs"],
+            "weights": resolved_config["weights"],
+            "n_eval_queries": n_examples,
+            "seed": seed,
+            "seed_coverage": seed_coverage,
+            "resolved_config_hash": resolved_config_hash,
+            "data_fingerprint": data_fingerprint,
+            "env_fingerprint": env_fingerprint,
+        },
+        require_clean_tree=args.require_clean_tree,
+        allow_incomplete=args.allow_incomplete_manifest,
+    )
+
+    print("\n=== Hybrid retrieval fusion (RRF) ===")
+    print(f"sources: {', '.join(sorted(input_runs))}")
+    print(f"qids:    {len(fused)} union")
+    print(f"top-K:   {args.top_k}")
+    if metrics:
+        for key in ("mrr@10", "ndcg@10", "recall@100", "recall@1000"):
+            if key in metrics:
+                print(f"  {key:14s} = {metrics[key]:.4f}")
+    print(f"outputs: {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ exclude = ["tests*", "scripts*"]
 # re-exports main() from the matching experiments/run_<name>.py.
 mgq-retrieve = "msmarco_genqa.cli.retrieve:main"
 mgq-dense    = "msmarco_genqa.cli.dense:main"
+mgq-fuse     = "msmarco_genqa.cli.fuse:main"
 mgq-rerank   = "msmarco_genqa.cli.rerank:main"
 mgq-generate = "msmarco_genqa.cli.generate:main"
 mgq-pipeline = "msmarco_genqa.cli.pipeline:main"

--- a/src/msmarco_genqa/cli/fuse.py
+++ b/src/msmarco_genqa/cli/fuse.py
@@ -1,0 +1,5 @@
+"""``mgq-fuse`` console entry point: hybrid RRF retrieval fusion."""
+
+from experiments.run_hybrid_fusion import main
+
+__all__ = ["main"]

--- a/src/msmarco_genqa/retrieval/fusion.py
+++ b/src/msmarco_genqa/retrieval/fusion.py
@@ -1,0 +1,134 @@
+"""Hybrid retrieval fusion utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+
+RunItems = Mapping[str, Sequence[tuple[str, float]]]
+RunsBySource = Mapping[str, RunItems]
+
+
+@dataclass(frozen=True)
+class SourceContribution:
+    """Contribution of one source run to one fused document."""
+
+    rank: int
+    score: float
+    weight: float
+    contribution: float
+
+
+@dataclass(frozen=True)
+class FusedHit:
+    """One fused retrieval candidate for a query."""
+
+    doc_id: str
+    score: float
+    sources: dict[str, SourceContribution]
+
+    @property
+    def best_rank(self) -> int:
+        return min(source.rank for source in self.sources.values())
+
+
+def _validate_fusion_inputs(
+    runs_by_source: RunsBySource,
+    rank_constant: float,
+    top_k: int | None,
+    weights: Mapping[str, float] | None,
+) -> dict[str, float]:
+    if not runs_by_source:
+        raise ValueError("at least one source run is required")
+    if rank_constant < 0:
+        raise ValueError("rank_constant must be non-negative")
+    if top_k is not None and top_k < 1:
+        raise ValueError("top_k must be positive when provided")
+
+    source_names = list(runs_by_source)
+    if len(set(source_names)) != len(source_names):
+        raise ValueError("source names must be unique")
+
+    resolved = {name: 1.0 for name in source_names}
+    if weights:
+        unknown = sorted(set(weights) - set(source_names))
+        if unknown:
+            raise ValueError(f"weights provided for unknown source(s): {unknown}")
+        for name, weight in weights.items():
+            value = float(weight)
+            if value < 0:
+                raise ValueError(f"weight for source {name!r} must be non-negative")
+            resolved[name] = value
+    return resolved
+
+
+def reciprocal_rank_fusion(
+    runs_by_source: RunsBySource,
+    *,
+    rank_constant: float = 60.0,
+    weights: Mapping[str, float] | None = None,
+    top_k: int | None = None,
+) -> dict[str, list[FusedHit]]:
+    """Fuse ranked retrieval runs with weighted Reciprocal Rank Fusion.
+
+    Scores follow:
+
+        sum_s weight_s / (rank_constant + rank_s(doc))
+
+    where ranks are one-based within each source run. Ties are resolved
+    deterministically by fused score, best observed rank, and document id.
+    """
+    resolved_weights = _validate_fusion_inputs(
+        runs_by_source=runs_by_source,
+        rank_constant=rank_constant,
+        top_k=top_k,
+        weights=weights,
+    )
+    all_qids = sorted({qid for runs in runs_by_source.values() for qid in runs})
+    fused_by_qid: dict[str, list[FusedHit]] = {}
+
+    for qid in all_qids:
+        contributions: dict[str, dict[str, SourceContribution]] = {}
+        for source_name, runs in runs_by_source.items():
+            weight = resolved_weights[source_name]
+            seen_in_source: set[str] = set()
+            for rank, (doc_id, source_score) in enumerate(runs.get(qid, ()), start=1):
+                if doc_id in seen_in_source:
+                    raise ValueError(
+                        f"duplicate document id {doc_id!r} in source "
+                        f"{source_name!r} for query id {qid!r}"
+                    )
+                seen_in_source.add(doc_id)
+                contribution = weight / (rank_constant + rank)
+                contributions.setdefault(doc_id, {})[source_name] = SourceContribution(
+                    rank=rank,
+                    score=float(source_score),
+                    weight=weight,
+                    contribution=contribution,
+                )
+
+        rows = [
+            FusedHit(
+                doc_id=doc_id,
+                score=sum(source.contribution for source in sources.values()),
+                sources=sources,
+            )
+            for doc_id, sources in contributions.items()
+        ]
+        rows.sort(key=lambda row: (-row.score, row.best_rank, row.doc_id))
+        if top_k is not None:
+            rows = rows[:top_k]
+        fused_by_qid[qid] = rows
+
+    return fused_by_qid
+
+
+def fused_doc_ids_and_scores(
+    fused: Mapping[str, Sequence[FusedHit]],
+) -> tuple[list[str], list[list[str]], list[list[float]]]:
+    """Return qids, doc ids, and scores in ``write_run_tsv`` shape."""
+    qids = sorted(fused)
+    doc_ids = [[hit.doc_id for hit in fused[qid]] for qid in qids]
+    scores = [[hit.score for hit in fused[qid]] for qid in qids]
+    return qids, doc_ids, scores

--- a/tests/test_hybrid_fusion.py
+++ b/tests/test_hybrid_fusion.py
@@ -1,0 +1,148 @@
+"""Tests for weighted RRF hybrid retrieval fusion."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from experiments import run_hybrid_fusion
+from msmarco_genqa.retrieval.fusion import fused_doc_ids_and_scores, reciprocal_rank_fusion
+
+
+def test_rrf_accumulates_duplicate_docs_across_sources():
+    fused = reciprocal_rank_fusion(
+        {
+            "bm25": {"q1": [("d_sparse", 9.0), ("d_shared", 8.0)]},
+            "dense": {"q1": [("d_shared", 0.9), ("d_dense", 0.8)]},
+        },
+        rank_constant=60,
+    )
+
+    q1 = fused["q1"]
+    assert q1[0].doc_id == "d_shared"
+    assert q1[0].score == pytest.approx((1 / 62) + (1 / 61))
+    assert set(q1[0].sources) == {"bm25", "dense"}
+    assert q1[0].sources["bm25"].rank == 2
+    assert q1[0].sources["dense"].rank == 1
+
+
+def test_rrf_weights_change_ranking():
+    runs = {
+        "bm25": {"q1": [("d_sparse", 10.0)]},
+        "dense": {"q1": [("d_dense", 1.0)]},
+    }
+
+    equal = reciprocal_rank_fusion(runs, rank_constant=60)
+    weighted = reciprocal_rank_fusion(runs, rank_constant=60, weights={"bm25": 2.0})
+
+    assert [hit.doc_id for hit in equal["q1"]] == ["d_dense", "d_sparse"]
+    assert [hit.doc_id for hit in weighted["q1"]] == ["d_sparse", "d_dense"]
+    assert weighted["q1"][0].sources["bm25"].weight == 2.0
+
+
+def test_rrf_handles_missing_query_in_one_source():
+    fused = reciprocal_rank_fusion(
+        {
+            "bm25": {"q1": [("d1", 1.0)]},
+            "dense": {"q2": [("d2", 1.0)]},
+        }
+    )
+
+    assert sorted(fused) == ["q1", "q2"]
+    assert fused["q1"][0].doc_id == "d1"
+    assert fused["q2"][0].doc_id == "d2"
+
+
+def test_rrf_ties_are_deterministic_by_score_best_rank_doc_id():
+    fused = reciprocal_rank_fusion(
+        {
+            "a": {"q1": [("d_b", 1.0)]},
+            "b": {"q1": [("d_a", 1.0)]},
+        },
+        rank_constant=60,
+    )
+
+    assert [hit.doc_id for hit in fused["q1"]] == ["d_a", "d_b"]
+
+
+def test_rrf_rejects_duplicate_doc_within_source_query():
+    with pytest.raises(ValueError, match="duplicate document id"):
+        reciprocal_rank_fusion(
+            {"bm25": {"q1": [("d1", 2.0), ("d1", 1.0)]}},
+        )
+
+
+def test_rrf_validates_weight_names():
+    with pytest.raises(ValueError, match="unknown source"):
+        reciprocal_rank_fusion(
+            {"bm25": {"q1": [("d1", 1.0)]}},
+            weights={"dense": 1.5},
+        )
+
+
+def test_fused_doc_ids_and_scores_shape():
+    fused = reciprocal_rank_fusion(
+        {"a": {"q2": [("d2", 1.0)], "q1": [("d1", 1.0)]}},
+        top_k=1,
+    )
+
+    qids, doc_ids, scores = fused_doc_ids_and_scores(fused)
+    assert qids == ["q1", "q2"]
+    assert doc_ids == [["d1"], ["d2"]]
+    assert len(scores) == 2
+
+
+def test_hybrid_fusion_runner_writes_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_hybrid_fusion, "PROJECT_ROOT", tmp_path)
+    bm25 = tmp_path / "bm25.tsv"
+    bm25.write_text(
+        "q1\tQ0\td_sparse\t1\t10.0\tbm25\n"
+        "q1\tQ0\td_shared\t2\t9.0\tbm25\n"
+        "q2\tQ0\td_other\t1\t8.0\tbm25\n",
+        encoding="utf-8",
+    )
+    dense = tmp_path / "dense.tsv"
+    dense.write_text(
+        "q1\tQ0\td_shared\t1\t1.0\tdense\n"
+        "q1\tQ0\td_dense\t2\t0.5\tdense\n"
+        "q2\tQ0\td_other\t1\t0.9\tdense\n",
+        encoding="utf-8",
+    )
+    qrels = tmp_path / "qrels.tsv"
+    qrels.write_text("q1 0 d_shared 1\nq2 0 d_other 1\n", encoding="utf-8")
+
+    output_dir = tmp_path / "outputs" / "rrf"
+    run_hybrid_fusion.main(
+        [
+            "--input-run",
+            f"bm25={bm25}",
+            "--input-run",
+            f"dense={dense}",
+            "--output-dir",
+            str(output_dir),
+            "--top-k",
+            "2",
+            "--qrels",
+            str(qrels),
+            "--allow-incomplete-manifest",
+        ]
+    )
+
+    run_lines = (output_dir / "run.tsv").read_text(encoding="utf-8").splitlines()
+    assert run_lines[0].startswith("q1\tQ0\td_shared\t1\t")
+    assert (output_dir / "provenance.jsonl").exists()
+    assert (output_dir / "metrics.json").exists()
+    assert (output_dir / "manifest.json").exists()
+
+    metrics = json.loads((output_dir / "metrics.json").read_text(encoding="utf-8"))
+    assert metrics["fusion"]["method"] == "weighted_rrf"
+    assert metrics["fusion"]["input_runs"]["bm25"] == "bm25.tsv"
+    assert metrics["metrics"]["rrf"]["mrr@10"] == pytest.approx(1.0)
+    assert metrics["overlap"] == {"qids_shared_all": 2, "qids_union": 2}
+
+    first_provenance = json.loads(
+        (output_dir / "provenance.jsonl").read_text(encoding="utf-8").splitlines()[0]
+    )
+    assert first_provenance["doc_id"] == "d_shared"
+    assert set(first_provenance["sources"]) == {"bm25", "dense"}


### PR DESCRIPTION
## Summary
- Add reusable weighted Reciprocal Rank Fusion utilities with deterministic tie handling and source provenance.
- Add mgq-fuse / experiments/run_hybrid_fusion.py to write un.tsv, provenance.jsonl, metrics.json, resolved config, and manifest artifacts.
- Document Stage 4B usage and cover fusion behavior with unit and runner tests.

Refs #35.

## Validation
- PYTHONPATH=src python -m pytest -q tests/test_hybrid_fusion.py tests/test_reranker.py tests/test_retrieval_metrics.py
- python -m ruff check src tests experiments scripts
- git diff --cached --check
- PYTHONPATH=src python -m pytest -q fails in the local Windows environment because m25s and aiss are not installed; the target RRF tests above pass.