### PR TITLE
Add retrieval quality reporting CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The repository includes runnable code plus written analysis artifacts:
 - [`docs/architecture.md`](docs/architecture.md) — module boundaries and artifact flow.
 - [`docs/evaluation_protocol.md`](docs/evaluation_protocol.md) — reproducible evaluation contract.
 - [`docs/failure_taxonomy.md`](docs/failure_taxonomy.md) — regression and grounding error taxonomy.
+- [`docs/retrieval_quality_reporting.md`](docs/retrieval_quality_reporting.md) — run-level retrieval metrics and matched-qid comparison reports.
 - [`docs/retrieval_lift_analysis.md`](docs/retrieval_lift_analysis.md) — query-level reranker lift analysis protocol.
 - [`notebooks/rag_eval_demo.ipynb`](notebooks/rag_eval_demo.ipynb) — lightweight evaluation workflow demo.
 - [`reports/repo_report/report.pdf`](reports/repo_report/report.pdf) / [`report.html`](reports/repo_report/report.html) — repository report with the current engineering surface and historical experiment results.
@@ -79,6 +80,10 @@ auditing the experiments:
 - **Run metadata.** Major runners write `manifest.json`, `resolved_config.yaml`,
   metrics, output hashes, config hashes, git commit, dependency fingerprints,
   and sampling metadata.
+- **Retrieval quality reports.** `mgq-retrieval-report` evaluates any
+  TREC-format `run.tsv` and compares two runs on matched qids, writing JSON
+  and Markdown artifacts for BM25, dense, RRF, and reranked outputs. See
+  [`docs/retrieval_quality_reporting.md`](docs/retrieval_quality_reporting.md).
 - **Retrieval lift diagnostics.** `scripts/analyze_retrieval_lift.py` compares
   two `run.tsv` files per query, bucketizing reranker gains/losses into
   promoted, demoted, new-hit, and lost-hit cases. See
@@ -436,7 +441,7 @@ python experiments/run_retrieval.py    # script form
 mgq-retrieve                            # console form
 ```
 
-Console names: `mgq-retrieve`, `mgq-dense`, `mgq-fuse`, `mgq-rerank`, `mgq-generate`.
+Console names: `mgq-retrieve`, `mgq-dense`, `mgq-fuse`, `mgq-retrieval-report`, `mgq-rerank`, `mgq-generate`.
 The examples below use the script form.
 
 ### Stage 2 — BM25

--- a/docs/reproducibility_protocol.md
+++ b/docs/reproducibility_protocol.md
@@ -6,7 +6,8 @@ verify a recorded run is reproducible.
 
 ## TL;DR
 
-Every run of `mgq-{retrieve, dense, fuse, rerank, generate, evaluate}` writes:
+Every manifest-writing experiment runner (`mgq-{retrieve, dense, fuse, rerank,
+generate}` and the matching `experiments/run_*.py` entry points) writes:
 
 - `outputs/<run>/manifest.json` — schema-v2 provenance contract
 - `outputs/<run>/resolved_config.yaml` — config dict actually used (with CLI overrides applied)
@@ -119,7 +120,7 @@ silent wording drift.
 
 ## Dev-time bypasses
 
-Two CLI flags recognised by every `mgq-*` and `experiments/run_*.py`:
+Two CLI flags recognised by the manifest-writing experiment runners:
 
 - `--require-clean-tree` — refuse to write the manifest if the git
   tree is dirty. Default off. Use for canonical / headline runs.

--- a/docs/retrieval_quality_reporting.md
+++ b/docs/retrieval_quality_reporting.md
@@ -1,0 +1,79 @@
+# Retrieval Quality Reporting
+
+`mgq-retrieval-report` evaluates any TREC-format `run.tsv` against a qrels
+file and writes reproducible JSON and Markdown artifacts. It is intended for
+BM25, dense, hybrid RRF, and reranked runs, as long as each input follows the
+standard six-column run format:
+
+```text
+qid Q0 doc_id rank score system
+```
+
+## Single-Run Metrics
+
+Use `evaluate` when a run should be scored independently:
+
+```bash
+mgq-retrieval-report evaluate \
+  --run outputs/week04_dense/run.tsv \
+  --qrels data/qrels.dev.small.tsv \
+  --run-name dense \
+  --output-dir outputs/retrieval_reports/dense
+```
+
+Artifacts:
+
+- `metrics.json`: input run/qrels paths, metric values, metric settings,
+  evaluated qid count, and skipped-qid coverage diagnostics.
+- `report.md`: a compact Markdown summary for experiment notes.
+
+By default the report computes `MRR@10`, `nDCG@10`, `Recall@100`, and
+`Recall@1000`. Override cutoffs with `--ks-mrr`, `--ks-ndcg`, and
+`--ks-recall`.
+
+## Matched-Qid Comparison
+
+Use `compare` when the claim is comparative. The command restricts both runs
+to the same qid set with positive qrels before computing deltas, which avoids
+misleading comparisons when two retrieval stages cover different queries.
+
+```bash
+mgq-retrieval-report compare \
+  --baseline-run outputs/week04_dense/run.tsv \
+  --candidate-run outputs/week04_hybrid_rrf/run.tsv \
+  --qrels data/qrels.dev.small.tsv \
+  --baseline-name dense \
+  --candidate-name rrf \
+  --output-dir outputs/retrieval_reports/dense_vs_rrf
+```
+
+Artifacts:
+
+- `comparison.json`: input run/qrels paths, matched metrics,
+  candidate-minus-baseline deltas, coverage counts, and movement-bucket
+  summary.
+- `per_query.jsonl`: query-level promoted, demoted, new-hit, lost-hit,
+  unchanged-hit, and unchanged-miss diagnostics.
+- `report.md`: a compact Markdown summary.
+
+The coverage block is part of the result, not a footnote. Check
+`n_baseline_only_qids`, `n_candidate_only_qids`, and
+`n_shared_without_positive_qrels` before interpreting metric deltas.
+
+## Qrels Format
+
+The command accepts standard four-column TREC qrels:
+
+```text
+qid iter doc_id relevance
+```
+
+It also accepts compact three-column qrels:
+
+```text
+qid doc_id relevance
+```
+
+Only positive relevance labels count as relevant. Non-positive labels are
+kept as empty-qrel coverage evidence so the report can distinguish missing
+qrels from explicitly non-relevant qrels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ exclude = ["tests*", "scripts*"]
 mgq-retrieve = "msmarco_genqa.cli.retrieve:main"
 mgq-dense    = "msmarco_genqa.cli.dense:main"
 mgq-fuse     = "msmarco_genqa.cli.fuse:main"
+mgq-retrieval-report = "msmarco_genqa.cli.retrieval_report:main"
 mgq-rerank   = "msmarco_genqa.cli.rerank:main"
 mgq-generate = "msmarco_genqa.cli.generate:main"
 mgq-pipeline = "msmarco_genqa.cli.pipeline:main"

--- a/src/msmarco_genqa/cli/retrieval_report.py
+++ b/src/msmarco_genqa/cli/retrieval_report.py
@@ -1,0 +1,144 @@
+"""``mgq-retrieval-report`` console entry point."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from msmarco_genqa.evaluation.retrieval_report import (
+    compare_runs_report,
+    evaluate_run_report,
+    load_qrels_tsv,
+    read_run_doc_ids,
+    render_comparison_markdown,
+    render_single_run_markdown,
+    write_json,
+    write_jsonl,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="mgq-retrieval-report", description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    evaluate = subcommands.add_parser("evaluate", help="Evaluate one retrieval run.")
+    evaluate.add_argument("--run", type=Path, required=True, help="TREC-format run.tsv file.")
+    evaluate.add_argument("--qrels", type=Path, required=True, help="Qrels TSV file.")
+    evaluate.add_argument("--run-name", default="run")
+    evaluate.add_argument("--output-dir", type=Path, required=True)
+    _add_metric_args(evaluate)
+
+    compare = subcommands.add_parser("compare", help="Compare two runs on matched qids.")
+    compare.add_argument("--baseline-run", type=Path, required=True)
+    compare.add_argument("--candidate-run", type=Path, required=True)
+    compare.add_argument("--qrels", type=Path, required=True)
+    compare.add_argument("--baseline-name", default="baseline")
+    compare.add_argument("--candidate-name", default="candidate")
+    compare.add_argument("--output-dir", type=Path, required=True)
+    compare.add_argument("--k-rank", type=int, default=10)
+    compare.add_argument("--k-recall", type=int, default=100)
+    _add_metric_args(compare)
+
+    return parser.parse_args(argv)
+
+
+def _add_metric_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--ks-mrr", type=int, nargs="+", default=[10])
+    parser.add_argument("--ks-ndcg", type=int, nargs="+", default=[10])
+    parser.add_argument("--ks-recall", type=int, nargs="+", default=[100, 1000])
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _display_path(path: Path) -> str:
+    return (
+        path.relative_to(PROJECT_ROOT).as_posix()
+        if path.is_relative_to(PROJECT_ROOT)
+        else str(path)
+    )
+
+
+def _load_qrels(path: Path):
+    qrels_path = _resolve(path)
+    if not qrels_path.exists():
+        raise SystemExit(f"qrels file not found: {qrels_path}")
+    return qrels_path, load_qrels_tsv(qrels_path)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    qrels_path, qrels = _load_qrels(args.qrels)
+    output_dir = _resolve(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.command == "evaluate":
+        run_path = _resolve(args.run)
+        if not run_path.exists():
+            raise SystemExit(f"run file not found: {run_path}")
+        report = evaluate_run_report(
+            read_run_doc_ids(run_path),
+            qrels,
+            run_name=args.run_name,
+            ks_mrr=tuple(args.ks_mrr),
+            ks_ndcg=tuple(args.ks_ndcg),
+            ks_recall=tuple(args.ks_recall),
+        )
+        report["inputs"] = {
+            "run": _display_path(run_path),
+            "qrels": _display_path(qrels_path),
+        }
+        write_json(output_dir / "metrics.json", report)
+        (output_dir / "report.md").write_text(
+            render_single_run_markdown(
+                report,
+                run_path=_display_path(run_path),
+                qrels_path=_display_path(qrels_path),
+            ),
+            encoding="utf-8",
+        )
+        print(f"Wrote retrieval report to {output_dir}")
+        return
+
+    if args.command == "compare":
+        baseline_path = _resolve(args.baseline_run)
+        candidate_path = _resolve(args.candidate_run)
+        for label, path in (("baseline", baseline_path), ("candidate", candidate_path)):
+            if not path.exists():
+                raise SystemExit(f"{label} run file not found: {path}")
+        report = compare_runs_report(
+            read_run_doc_ids(baseline_path),
+            read_run_doc_ids(candidate_path),
+            qrels,
+            baseline_name=args.baseline_name,
+            candidate_name=args.candidate_name,
+            k_rank=args.k_rank,
+            k_recall=args.k_recall,
+            ks_mrr=tuple(args.ks_mrr),
+            ks_ndcg=tuple(args.ks_ndcg),
+            ks_recall=tuple(args.ks_recall),
+        )
+        per_query = report.pop("per_query")
+        report["inputs"] = {
+            "baseline_run": _display_path(baseline_path),
+            "candidate_run": _display_path(candidate_path),
+            "qrels": _display_path(qrels_path),
+        }
+        write_json(output_dir / "comparison.json", report)
+        write_jsonl(output_dir / "per_query.jsonl", per_query)
+        (output_dir / "report.md").write_text(
+            render_comparison_markdown(report, qrels_path=_display_path(qrels_path)),
+            encoding="utf-8",
+        )
+        print(f"Wrote retrieval comparison report to {output_dir}")
+        return
+
+    raise SystemExit(f"unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/msmarco_genqa/evaluation/retrieval_report.py
+++ b/src/msmarco_genqa/evaluation/retrieval_report.py
@@ -1,0 +1,278 @@
+"""Retrieval quality reporting helpers."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from statistics import mean
+from typing import Any, Mapping, Sequence
+
+from msmarco_genqa.evaluation.retrieval import (
+    compare_retrieval_runs_per_query,
+    evaluate_retrieval,
+)
+from msmarco_genqa.reranking.io import read_run_tsv
+
+
+RunDocs = Mapping[str, Sequence[str]]
+Qrels = Mapping[str, set[str]]
+
+
+def load_qrels_tsv(path: Path | str) -> dict[str, set[str]]:
+    """Load positive qrels from a compact or TREC-format TSV/space file."""
+    qrels: dict[str, set[str]] = {}
+    p = Path(path)
+    with p.open(encoding="utf-8") as f:
+        for line_number, raw_line in enumerate(f, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) == 3:
+                qid, doc_id, rel_text = parts
+            elif len(parts) >= 4:
+                qid, _iter, doc_id, rel_text = parts[:4]
+            else:
+                raise ValueError(
+                    f"{p}:{line_number}: expected 3 or 4+ qrels columns, got {len(parts)}"
+                )
+            try:
+                rel = float(rel_text)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{p}:{line_number}: relevance is not numeric: {rel_text!r}"
+                ) from exc
+            if rel > 0:
+                qrels.setdefault(qid, set()).add(doc_id)
+            else:
+                qrels.setdefault(qid, set())
+    return qrels
+
+
+def read_run_doc_ids(path: Path | str) -> dict[str, list[str]]:
+    """Read a standard run.tsv file as ``{qid: [doc_id, ...]}``."""
+    return {
+        qid: [doc_id for doc_id, _score in docs]
+        for qid, docs in read_run_tsv(path).items()
+    }
+
+
+def qrels_with_positive_labels(qrels: Qrels) -> set[str]:
+    return {qid for qid, doc_ids in qrels.items() if doc_ids}
+
+
+def evaluate_run_report(
+    runs: RunDocs,
+    qrels: Qrels,
+    *,
+    run_name: str,
+    ks_mrr: Sequence[int] = (10,),
+    ks_ndcg: Sequence[int] = (10,),
+    ks_recall: Sequence[int] = (100, 1000),
+) -> dict[str, Any]:
+    """Evaluate one run and attach coverage/skipped-qid diagnostics."""
+    run_qids = set(runs)
+    positive_qrels = qrels_with_positive_labels(qrels)
+    metrics = evaluate_retrieval(
+        {qid: list(doc_ids) for qid, doc_ids in runs.items()},
+        dict(qrels),
+        ks_mrr=ks_mrr,
+        ks_ndcg=ks_ndcg,
+        ks_recall=ks_recall,
+    )
+    n_evaluable = int(metrics.pop("n_queries", 0))
+    missing_qrels = sorted(run_qids - set(qrels))
+    empty_qrels = sorted(qid for qid in run_qids & set(qrels) if not qrels.get(qid))
+    qrels_only = sorted(positive_qrels - run_qids)
+    return {
+        "run_name": run_name,
+        "settings": {
+            "ks_mrr": list(ks_mrr),
+            "ks_ndcg": list(ks_ndcg),
+            "ks_recall": list(ks_recall),
+        },
+        "coverage": {
+            "n_run_qids": len(run_qids),
+            "n_positive_qrels_qids": len(positive_qrels),
+            "n_evaluable_qids": n_evaluable,
+            "n_skipped_missing_qrels": len(missing_qrels),
+            "n_skipped_empty_qrels": len(empty_qrels),
+            "n_qrels_only": len(qrels_only),
+        },
+        "metrics": metrics,
+    }
+
+
+def compare_runs_report(
+    baseline_runs: RunDocs,
+    candidate_runs: RunDocs,
+    qrels: Qrels,
+    *,
+    baseline_name: str,
+    candidate_name: str,
+    k_rank: int = 10,
+    k_recall: int = 100,
+    ks_mrr: Sequence[int] = (10,),
+    ks_ndcg: Sequence[int] = (10,),
+    ks_recall: Sequence[int] = (100, 1000),
+) -> dict[str, Any]:
+    """Evaluate two runs on matched qids and summarize deltas."""
+    baseline_qids = set(baseline_runs)
+    candidate_qids = set(candidate_runs)
+    shared_qids = baseline_qids & candidate_qids
+    positive_qrels = qrels_with_positive_labels(qrels)
+    matched_qids = sorted(shared_qids & positive_qrels)
+
+    baseline_matched = {qid: list(baseline_runs[qid]) for qid in matched_qids}
+    candidate_matched = {qid: list(candidate_runs[qid]) for qid in matched_qids}
+    matched_qrels = {qid: set(qrels[qid]) for qid in matched_qids}
+
+    baseline_summary = evaluate_run_report(
+        baseline_matched,
+        matched_qrels,
+        run_name=baseline_name,
+        ks_mrr=ks_mrr,
+        ks_ndcg=ks_ndcg,
+        ks_recall=ks_recall,
+    )
+    candidate_summary = evaluate_run_report(
+        candidate_matched,
+        matched_qrels,
+        run_name=candidate_name,
+        ks_mrr=ks_mrr,
+        ks_ndcg=ks_ndcg,
+        ks_recall=ks_recall,
+    )
+    baseline_metrics = baseline_summary["metrics"]
+    candidate_metrics = candidate_summary["metrics"]
+    deltas = {
+        key: candidate_metrics[key] - baseline_metrics[key]
+        for key in sorted(baseline_metrics.keys() & candidate_metrics.keys())
+    }
+
+    per_query = compare_retrieval_runs_per_query(
+        baseline_matched,
+        candidate_matched,
+        matched_qrels,
+        k_rank=k_rank,
+        k_recall=k_recall,
+    )
+    bucket_counts = Counter(str(row["bucket"]) for row in per_query)
+    rr_key = f"rr_delta@{k_rank}"
+    recall_key = f"recall_delta@{k_recall}"
+
+    return {
+        "baseline": baseline_summary,
+        "candidate": candidate_summary,
+        "deltas": deltas,
+        "coverage": {
+            "n_baseline_qids": len(baseline_qids),
+            "n_candidate_qids": len(candidate_qids),
+            "n_shared_qids": len(shared_qids),
+            "n_matched_evaluable_qids": len(matched_qids),
+            "n_baseline_only_qids": len(baseline_qids - candidate_qids),
+            "n_candidate_only_qids": len(candidate_qids - baseline_qids),
+            "n_shared_without_positive_qrels": len(shared_qids - positive_qrels),
+        },
+        "diagnostics": {
+            "k_rank": k_rank,
+            "k_recall": k_recall,
+            "buckets": dict(sorted(bucket_counts.items())),
+            f"mean_{rr_key}": _mean([row[rr_key] for row in per_query]),
+            f"mean_{recall_key}": _mean([row[recall_key] for row in per_query]),
+        },
+        "per_query": per_query,
+    }
+
+
+def _mean(values: Sequence[float | int]) -> float:
+    return mean([float(value) for value in values]) if values else 0.0
+
+
+def render_single_run_markdown(report: Mapping[str, Any], *, run_path: str, qrels_path: str) -> str:
+    lines = [
+        "# Retrieval quality report",
+        "",
+        f"- Run: `{run_path}`",
+        f"- Qrels: `{qrels_path}`",
+        f"- Run name: `{report['run_name']}`",
+        f"- Evaluable qids: **{report['coverage']['n_evaluable_qids']}**",
+        "",
+        "| metric | value |",
+        "|---|---:|",
+    ]
+    for key, value in sorted(report["metrics"].items()):
+        lines.append(f"| {key} | {float(value):.4f} |")
+    lines.extend(
+        [
+            "",
+            "## Coverage",
+            "",
+            "| field | value |",
+            "|---|---:|",
+        ]
+    )
+    for key, value in sorted(report["coverage"].items()):
+        lines.append(f"| {key} | {value} |")
+    return "\n".join(lines) + "\n"
+
+
+def render_comparison_markdown(report: Mapping[str, Any], *, qrels_path: str) -> str:
+    baseline = report["baseline"]
+    candidate = report["candidate"]
+    lines = [
+        "# Retrieval comparison report",
+        "",
+        f"- Baseline: `{baseline['run_name']}`",
+        f"- Candidate: `{candidate['run_name']}`",
+        f"- Qrels: `{qrels_path}`",
+        f"- Matched evaluable qids: **{report['coverage']['n_matched_evaluable_qids']}**",
+        "",
+        "| metric | baseline | candidate | delta |",
+        "|---|---:|---:|---:|",
+    ]
+    for key in sorted(report["deltas"]):
+        b = float(baseline["metrics"][key])
+        c = float(candidate["metrics"][key])
+        d = float(report["deltas"][key])
+        lines.append(f"| {key} | {b:.4f} | {c:.4f} | {d:+.4f} |")
+    lines.extend(
+        [
+            "",
+            "## Coverage",
+            "",
+            "| field | value |",
+            "|---|---:|",
+        ]
+    )
+    for key, value in sorted(report["coverage"].items()):
+        lines.append(f"| {key} | {value} |")
+    lines.extend(
+        [
+            "",
+            "## Movement buckets",
+            "",
+            "| bucket | qids |",
+            "|---|---:|",
+        ]
+    )
+    for bucket, count in sorted(report["diagnostics"]["buckets"].items()):
+        lines.append(f"| {bucket} | {count} |")
+    lines.append("")
+    lines.append("Metric deltas are candidate minus baseline on the matched qid set.")
+    return "\n".join(lines) + "\n"
+
+
+def write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True, default=str)
+        f.write("\n")
+
+
+def write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, sort_keys=True, default=str) + "\n")

--- a/tests/test_retrieval_report.py
+++ b/tests/test_retrieval_report.py
@@ -1,0 +1,195 @@
+"""Tests for retrieval quality reporting."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from msmarco_genqa.cli import retrieval_report as cli
+from msmarco_genqa.evaluation.retrieval_report import (
+    compare_runs_report,
+    evaluate_run_report,
+    load_qrels_tsv,
+    read_run_doc_ids,
+)
+from msmarco_genqa.reranking.io import RunTsvFormatError
+
+
+def test_load_qrels_tsv_keeps_empty_qrel_queries(tmp_path):
+    qrels = tmp_path / "qrels.tsv"
+    qrels.write_text(
+        "# qid iter doc rel\n"
+        "q1 0 d1 1\n"
+        "q2 0 d2 0\n"
+        "q3 d3 1\n",
+        encoding="utf-8",
+    )
+
+    loaded = load_qrels_tsv(qrels)
+
+    assert loaded == {"q1": {"d1"}, "q2": set(), "q3": {"d3"}}
+
+
+def test_evaluate_run_report_records_missing_and_empty_qrels():
+    report = evaluate_run_report(
+        {
+            "q1": ["d1", "d2"],
+            "q2": ["d2"],
+            "q_missing": ["d9"],
+        },
+        {
+            "q1": {"d1"},
+            "q2": set(),
+            "q_qrels_only": {"d7"},
+        },
+        run_name="bm25",
+        ks_recall=(2,),
+    )
+
+    assert report["coverage"]["n_run_qids"] == 3
+    assert report["coverage"]["n_evaluable_qids"] == 1
+    assert report["coverage"]["n_skipped_missing_qrels"] == 1
+    assert report["coverage"]["n_skipped_empty_qrels"] == 1
+    assert report["coverage"]["n_qrels_only"] == 1
+    assert report["metrics"]["mrr@10"] == pytest.approx(1.0)
+    assert report["metrics"]["recall@2"] == pytest.approx(1.0)
+
+
+def test_compare_runs_report_uses_matched_qids_and_records_coverage():
+    report = compare_runs_report(
+        baseline_runs={
+            "q1": ["d0", "d1"],
+            "q2": ["d2"],
+            "q_baseline_only": ["d3"],
+            "q_empty": ["d4"],
+        },
+        candidate_runs={
+            "q1": ["d1", "d0"],
+            "q2": ["d9"],
+            "q_candidate_only": ["d5"],
+            "q_empty": ["d4"],
+        },
+        qrels={
+            "q1": {"d1"},
+            "q2": {"d2"},
+            "q_empty": set(),
+            "q_baseline_only": {"d3"},
+            "q_candidate_only": {"d5"},
+        },
+        baseline_name="dense",
+        candidate_name="rrf",
+        k_recall=2,
+        ks_recall=(2,),
+    )
+
+    assert report["coverage"]["n_baseline_qids"] == 4
+    assert report["coverage"]["n_candidate_qids"] == 4
+    assert report["coverage"]["n_shared_qids"] == 3
+    assert report["coverage"]["n_matched_evaluable_qids"] == 2
+    assert report["coverage"]["n_baseline_only_qids"] == 1
+    assert report["coverage"]["n_candidate_only_qids"] == 1
+    assert report["coverage"]["n_shared_without_positive_qrels"] == 1
+    assert report["deltas"]["mrr@10"] == pytest.approx((1.0 + 0.0) / 2 - (0.5 + 1.0) / 2)
+    assert report["diagnostics"]["buckets"] == {"lost_hit": 1, "promoted": 1}
+    assert len(report["per_query"]) == 2
+
+
+def test_read_run_doc_ids_rejects_duplicate_doc_ids(tmp_path):
+    run = tmp_path / "run.tsv"
+    run.write_text(
+        "q1\tQ0\td1\t1\t1.0\tbm25\n"
+        "q1\tQ0\td1\t2\t0.5\tbm25\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RunTsvFormatError, match="duplicate document id"):
+        read_run_doc_ids(run)
+
+
+def test_cli_evaluate_writes_metrics_and_markdown(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    run = tmp_path / "run.tsv"
+    run.write_text(
+        "q1\tQ0\td1\t1\t2.0\tbm25\n"
+        "q2\tQ0\td9\t1\t1.0\tbm25\n",
+        encoding="utf-8",
+    )
+    qrels = tmp_path / "qrels.tsv"
+    qrels.write_text("q1 0 d1 1\nq2 0 d2 1\n", encoding="utf-8")
+    output_dir = tmp_path / "outputs" / "eval"
+
+    cli.main(
+        [
+            "evaluate",
+            "--run",
+            str(run),
+            "--qrels",
+            str(qrels),
+            "--run-name",
+            "bm25",
+            "--output-dir",
+            str(output_dir),
+            "--ks-recall",
+            "1",
+        ]
+    )
+
+    metrics = json.loads((output_dir / "metrics.json").read_text(encoding="utf-8"))
+    assert metrics["run_name"] == "bm25"
+    assert metrics["inputs"] == {"qrels": "qrels.tsv", "run": "run.tsv"}
+    assert metrics["coverage"]["n_evaluable_qids"] == 2
+    assert metrics["metrics"]["mrr@10"] == pytest.approx(0.5)
+    assert "Retrieval quality report" in (output_dir / "report.md").read_text(encoding="utf-8")
+
+
+def test_cli_compare_writes_comparison_and_per_query(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    baseline = tmp_path / "baseline.tsv"
+    baseline.write_text(
+        "q1\tQ0\td0\t1\t2.0\tdense\n"
+        "q1\tQ0\td1\t2\t1.0\tdense\n",
+        encoding="utf-8",
+    )
+    candidate = tmp_path / "candidate.tsv"
+    candidate.write_text(
+        "q1\tQ0\td1\t1\t2.0\trrf\n"
+        "q1\tQ0\td0\t2\t1.0\trrf\n",
+        encoding="utf-8",
+    )
+    qrels = tmp_path / "qrels.tsv"
+    qrels.write_text("q1 0 d1 1\n", encoding="utf-8")
+    output_dir = tmp_path / "outputs" / "compare"
+
+    cli.main(
+        [
+            "compare",
+            "--baseline-run",
+            str(baseline),
+            "--candidate-run",
+            str(candidate),
+            "--qrels",
+            str(qrels),
+            "--baseline-name",
+            "dense",
+            "--candidate-name",
+            "rrf",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    comparison = json.loads((output_dir / "comparison.json").read_text(encoding="utf-8"))
+    assert comparison["inputs"] == {
+        "baseline_run": "baseline.tsv",
+        "candidate_run": "candidate.tsv",
+        "qrels": "qrels.tsv",
+    }
+    assert comparison["deltas"]["mrr@10"] == pytest.approx(0.5)
+    assert comparison["diagnostics"]["buckets"] == {"promoted": 1}
+    assert "per_query" not in comparison
+    per_query_lines = (output_dir / "per_query.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(per_query_lines) == 1
+    assert "Retrieval comparison report" in (output_dir / "report.md").read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
## Summary
- Add mgq-retrieval-report for single-run retrieval metrics and matched-qid run comparisons.
- Record metric settings, qid coverage, input run/qrels paths, candidate-minus-baseline deltas, and movement-bucket diagnostics.
- Document retrieval reporting usage for BM25, dense, RRF, and reranked runs.

Refs #36.

## Validation
- PYTHONPATH=src python -m pytest -q tests/test_retrieval_report.py tests/test_retrieval_metrics.py tests/test_retrieval_lift.py tests/test_hybrid_fusion.py
- python -m ruff check src tests experiments scripts
- git diff --check
- PYTHONPATH=src python -m pytest -q fails in the local Windows environment because m25s and aiss are not installed; the target reporting tests above pass.