### PR TITLE
Wire retrieval reports into evaluation workflow

### DIFF
--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -108,6 +108,7 @@ rag_eval:
     - bm25_retrieval
     - dense_retrieval
     - cross_encoder_rerank
+    - retrieval_quality_report
     - retrieval_lift_analysis
     - generation_bm25
     - generation_reranked
@@ -119,6 +120,7 @@ rag_eval:
   reranker_resume: true
   reranked_generation_dir: outputs/week03_generation_reranked_full
   bootstrap_output_dir: outputs/week03_generation_bootstrap_full
+  retrieval_report_output_dir: outputs/retrieval_reports/dense_vs_reranked
   retrieval_lift_output_dir: outputs/week05_retrieval_lift_analysis
   grounding_output_dir: outputs/week07_grounding
   bootstrap_resamples: 10000

--- a/configs/pipeline.yaml
+++ b/configs/pipeline.yaml
@@ -30,6 +30,22 @@ stages:
       - --config
       - configs/baseline.yaml
 
+  - name: retrieval_quality_report
+    description: Matched-qid retrieval metrics and movement diagnostics for dense vs reranked runs.
+    command:
+      - mgq-retrieval-report
+      - compare
+      - --baseline-run
+      - outputs/week04_dense/run.tsv
+      - --candidate-run
+      - outputs/week05_reranker_full/run.tsv
+      - --baseline-name
+      - dense
+      - --candidate-name
+      - reranked
+      - --output-dir
+      - outputs/retrieval_reports/dense_vs_reranked
+
   - name: retrieval_lift_analysis
     description: Query-level diagnostics for promoted, demoted, new-hit, and lost-hit rerank cases.
     command:

--- a/docs/evaluation_protocol.md
+++ b/docs/evaluation_protocol.md
@@ -56,11 +56,12 @@ recorded in `configs/baseline.yaml` under `rag_eval`.
 1. `bm25_retrieval`
 2. `dense_retrieval`
 3. `cross_encoder_rerank`
-4. `retrieval_lift_analysis`
-5. `generation_bm25`
-6. `generation_reranked`
-7. `paired_bootstrap_ci`
-8. `grounding_audit`
+4. `retrieval_quality_report`
+5. `retrieval_lift_analysis`
+6. `generation_bm25`
+7. `generation_reranked`
+8. `paired_bootstrap_ci`
+9. `grounding_audit`
 
 Each stage writes under `outputs/`. Output directories are gitignored; metrics,
 manifests, and summaries should be copied into reports only after they are
@@ -95,6 +96,10 @@ Retrieval metrics:
 - MRR@10
 - nDCG@10
 - Recall@100 / Recall@1000, depending on stage
+
+Use `retrieval_quality_report` for matched-qid retrieval comparisons before
+interpreting deltas. Coverage counts are part of the report and should be
+checked before comparing dense, RRF, or reranked runs.
 
 Grounding metrics:
 

--- a/docs/retrieval_quality_reporting.md
+++ b/docs/retrieval_quality_reporting.md
@@ -16,7 +16,6 @@ Use `evaluate` when a run should be scored independently:
 ```bash
 mgq-retrieval-report evaluate \
   --run outputs/week04_dense/run.tsv \
-  --qrels data/qrels.dev.small.tsv \
   --run-name dense \
   --output-dir outputs/retrieval_reports/dense
 ```
@@ -41,7 +40,6 @@ misleading comparisons when two retrieval stages cover different queries.
 mgq-retrieval-report compare \
   --baseline-run outputs/week04_dense/run.tsv \
   --candidate-run outputs/week04_hybrid_rrf/run.tsv \
-  --qrels data/qrels.dev.small.tsv \
   --baseline-name dense \
   --candidate-name rrf \
   --output-dir outputs/retrieval_reports/dense_vs_rrf
@@ -61,6 +59,10 @@ The coverage block is part of the result, not a footnote. Check
 `n_shared_without_positive_qrels` before interpreting metric deltas.
 
 ## Qrels Format
+
+If `--qrels` is omitted, the command loads MS MARCO Passage dev/small qrels
+through `ir_datasets`. Pass `--qrels` when evaluating a custom split,
+sample-specific qrels file, or downloaded TREC qrels artifact.
 
 The command accepts standard four-column TREC qrels:
 

--- a/src/msmarco_genqa/cli/retrieval_report.py
+++ b/src/msmarco_genqa/cli/retrieval_report.py
@@ -26,7 +26,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     evaluate = subcommands.add_parser("evaluate", help="Evaluate one retrieval run.")
     evaluate.add_argument("--run", type=Path, required=True, help="TREC-format run.tsv file.")
-    evaluate.add_argument("--qrels", type=Path, required=True, help="Qrels TSV file.")
+    evaluate.add_argument(
+        "--qrels",
+        type=Path,
+        default=None,
+        help="Optional qrels TSV file. Defaults to MS MARCO passage dev/small via ir_datasets.",
+    )
     evaluate.add_argument("--run-name", default="run")
     evaluate.add_argument("--output-dir", type=Path, required=True)
     _add_metric_args(evaluate)
@@ -34,7 +39,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     compare = subcommands.add_parser("compare", help="Compare two runs on matched qids.")
     compare.add_argument("--baseline-run", type=Path, required=True)
     compare.add_argument("--candidate-run", type=Path, required=True)
-    compare.add_argument("--qrels", type=Path, required=True)
+    compare.add_argument(
+        "--qrels",
+        type=Path,
+        default=None,
+        help="Optional qrels TSV file. Defaults to MS MARCO passage dev/small via ir_datasets.",
+    )
     compare.add_argument("--baseline-name", default="baseline")
     compare.add_argument("--candidate-name", default="candidate")
     compare.add_argument("--output-dir", type=Path, required=True)
@@ -63,7 +73,12 @@ def _display_path(path: Path) -> str:
     )
 
 
-def _load_qrels(path: Path):
+def _load_qrels(path: Path | None):
+    if path is None:
+        from msmarco_genqa.data.msmarco import load_msmarco_passage
+
+        bundle = load_msmarco_passage(load_corpus=False)
+        return "msmarco-passage/dev/small via ir_datasets", bundle.qrels
     qrels_path = _resolve(path)
     if not qrels_path.exists():
         raise SystemExit(f"qrels file not found: {qrels_path}")
@@ -90,14 +105,14 @@ def main(argv: list[str] | None = None) -> None:
         )
         report["inputs"] = {
             "run": _display_path(run_path),
-            "qrels": _display_path(qrels_path),
+            "qrels": _display_path(qrels_path) if isinstance(qrels_path, Path) else qrels_path,
         }
         write_json(output_dir / "metrics.json", report)
         (output_dir / "report.md").write_text(
             render_single_run_markdown(
                 report,
                 run_path=_display_path(run_path),
-                qrels_path=_display_path(qrels_path),
+                qrels_path=_display_path(qrels_path) if isinstance(qrels_path, Path) else qrels_path,
             ),
             encoding="utf-8",
         )
@@ -126,12 +141,15 @@ def main(argv: list[str] | None = None) -> None:
         report["inputs"] = {
             "baseline_run": _display_path(baseline_path),
             "candidate_run": _display_path(candidate_path),
-            "qrels": _display_path(qrels_path),
+            "qrels": _display_path(qrels_path) if isinstance(qrels_path, Path) else qrels_path,
         }
         write_json(output_dir / "comparison.json", report)
         write_jsonl(output_dir / "per_query.jsonl", per_query)
         (output_dir / "report.md").write_text(
-            render_comparison_markdown(report, qrels_path=_display_path(qrels_path)),
+            render_comparison_markdown(
+                report,
+                qrels_path=_display_path(qrels_path) if isinstance(qrels_path, Path) else qrels_path,
+            ),
             encoding="utf-8",
         )
         print(f"Wrote retrieval comparison report to {output_dir}")

--- a/src/msmarco_genqa/rag_eval.py
+++ b/src/msmarco_genqa/rag_eval.py
@@ -20,6 +20,7 @@ DEFAULT_STAGE_ORDER: tuple[str, ...] = (
     "bm25_retrieval",
     "dense_retrieval",
     "cross_encoder_rerank",
+    "retrieval_quality_report",
     "retrieval_lift_analysis",
     "generation_bm25",
     "generation_reranked",
@@ -104,6 +105,10 @@ def _build_all_stages(
     retrieval_lift_dir = _as_posix(
         settings.get("retrieval_lift_output_dir", "outputs/week05_retrieval_lift_analysis")
     )
+    retrieval_report_dir = _as_posix(
+        settings.get("retrieval_report_output_dir", "outputs/retrieval_reports/dense_vs_reranked")
+    )
+    retrieval_qrels_path = settings.get("retrieval_qrels_path")
     grounding_dir = _as_posix(settings.get("grounding_output_dir", "outputs/week07_grounding"))
     num_eval_queries = str(settings.get("num_eval_queries", cfg["generation"].get("num_eval_queries", 200)))
     n_resamples = str(settings.get("bootstrap_resamples", 10000))
@@ -118,6 +123,23 @@ def _build_all_stages(
     ]
     if settings.get("reranker_resume", True):
         rerank_command.append("--resume")
+
+    retrieval_report_command = [
+        "mgq-retrieval-report",
+        "compare",
+        "--baseline-run",
+        dense_run,
+        "--candidate-run",
+        reranker_run,
+        "--baseline-name",
+        "dense",
+        "--candidate-name",
+        "reranked",
+        "--output-dir",
+        retrieval_report_dir,
+    ]
+    if retrieval_qrels_path:
+        retrieval_report_command.extend(["--qrels", _as_posix(retrieval_qrels_path)])
 
     return {
         "bm25_retrieval": RAGEvalStage(
@@ -141,6 +163,16 @@ def _build_all_stages(
                 _as_posix(Path(reranker_dir) / "metrics.json"),
             ],
         ),
+        "retrieval_quality_report": RAGEvalStage(
+            name="retrieval_quality_report",
+            description="Matched-qid retrieval metric report for dense vs reranked runs.",
+            command=retrieval_report_command,
+            expected_outputs=[
+                _as_posix(Path(retrieval_report_dir) / "comparison.json"),
+                _as_posix(Path(retrieval_report_dir) / "per_query.jsonl"),
+                _as_posix(Path(retrieval_report_dir) / "report.md"),
+            ],
+        ),
         "retrieval_lift_analysis": RAGEvalStage(
             name="retrieval_lift_analysis",
             description="Query-level retrieval gain/loss buckets after reranking.",
@@ -154,7 +186,7 @@ def _build_all_stages(
                 "--output-dir",
                 retrieval_lift_dir,
             ],
-            expected_outputs=[_as_posix(Path(retrieval_lift_dir) / "summary.json")],
+            expected_outputs=[_as_posix(Path(retrieval_lift_dir) / "retrieval_lift.json")],
         ),
         "generation_bm25": RAGEvalStage(
             name="generation_bm25",

--- a/tests/test_rag_eval.py
+++ b/tests/test_rag_eval.py
@@ -76,6 +76,24 @@ def test_filter_and_format_rag_eval_plan(tmp_path):
     assert "outputs/bootstrap/bootstrap_ci.json" in rendered
 
 
+def test_build_rag_eval_plan_includes_retrieval_quality_report(tmp_path):
+    config_path = _write_config(tmp_path / "baseline.yaml")
+    cfg = load_rag_eval_config(config_path)
+    cfg["rag_eval"]["stages"] = ["retrieval_quality_report"]
+    cfg["rag_eval"]["retrieval_report_output_dir"] = "outputs/report_dense_vs_reranked"
+    cfg["rag_eval"]["retrieval_qrels_path"] = "data/qrels.dev.small.tsv"
+
+    plan = build_rag_eval_plan(cfg, config_path=config_path)
+
+    assert [stage.name for stage in plan] == ["retrieval_quality_report"]
+    cmd = plan[0].command
+    assert cmd[:2] == ["mgq-retrieval-report", "compare"]
+    assert cmd[cmd.index("--baseline-run") + 1] == "outputs/dense/run.tsv"
+    assert cmd[cmd.index("--candidate-run") + 1] == "outputs/reranked/run.tsv"
+    assert cmd[cmd.index("--qrels") + 1] == "data/qrels.dev.small.tsv"
+    assert "outputs/report_dense_vs_reranked/comparison.json" in plan[0].expected_outputs
+
+
 def test_build_rag_eval_plan_rejects_unknown_stage(tmp_path):
     config_path = _write_config(tmp_path / "baseline.yaml")
     cfg = load_rag_eval_config(config_path)

--- a/tests/test_retrieval_report.py
+++ b/tests/test_retrieval_report.py
@@ -143,6 +143,34 @@ def test_cli_evaluate_writes_metrics_and_markdown(tmp_path, monkeypatch):
     assert "Retrieval quality report" in (output_dir / "report.md").read_text(encoding="utf-8")
 
 
+def test_cli_evaluate_defaults_to_msmarco_qrels(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "_load_qrels",
+        lambda path: ("msmarco-passage/dev/small via ir_datasets", {"q1": {"d1"}}),
+    )
+    run = tmp_path / "run.tsv"
+    run.write_text("q1\tQ0\td1\t1\t2.0\tbm25\n", encoding="utf-8")
+    output_dir = tmp_path / "outputs" / "eval_default_qrels"
+
+    cli.main(
+        [
+            "evaluate",
+            "--run",
+            str(run),
+            "--run-name",
+            "bm25",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    metrics = json.loads((output_dir / "metrics.json").read_text(encoding="utf-8"))
+    assert metrics["inputs"]["qrels"] == "msmarco-passage/dev/small via ir_datasets"
+    assert metrics["metrics"]["mrr@10"] == pytest.approx(1.0)
+
+
 def test_cli_compare_writes_comparison_and_per_query(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
     baseline = tmp_path / "baseline.tsv"


### PR DESCRIPTION
## Summary
- Make retrieval report commands default to MS MARCO passage dev/small qrels while keeping explicit qrels support for custom splits.
- Add retrieval_quality_report to the rag-eval and pipeline workflows for dense-vs-reranked comparisons.
- Document the workflow and cover CLI/planning behavior with focused tests.

## Validation
- PYTHONPATH=src python -m pytest -q tests/test_rag_eval.py tests/test_retrieval_report.py tests/test_retrieval_metrics.py tests/test_retrieval_lift.py
- python -m ruff check src tests experiments scripts
- git diff --check
- rag-eval retrieval_quality_report dry-run against configs/baseline.yaml
- PYTHONPATH=src python scripts\\run_pipeline.py --config configs\\pipeline.yaml --dry-run

Refs #36.