### PR TITLE
Add deterministic query transformation stage

### DIFF
--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -34,6 +34,26 @@ retrieval:
   n_threads: 0
   bm25s_chunksize: 50
 
+query_transform:
+  # Default stays off so historical retrieval baselines remain reproducible.
+  # Set to normalize or lexical_expansion for controlled ablations.
+  method: none
+  output_dir: outputs/query_transform/none
+  lowercase: true
+  strip_terminal_punctuation: true
+  max_query_terms_for_expansion: 6
+  max_expansion_terms: 4
+  expansion_terms:
+    covid: [coronavirus]
+    fda: [food and drug administration]
+    flu: [influenza]
+    heart attack: [myocardial infarction]
+    irs: [internal revenue service]
+    nyc: [new york city]
+    u.s.: [united states]
+    uk: [united kingdom]
+    usa: [united states]
+
 eval_retrieval:
   ks_mrr: [10]
   ks_ndcg: [10]
@@ -105,6 +125,7 @@ reranker:
 # -> bootstrap -> grounding plan without duplicating stage logic.
 rag_eval:
   stages:
+    - query_transformation
     - bm25_retrieval
     - dense_retrieval
     - cross_encoder_rerank

--- a/configs/pipeline.yaml
+++ b/configs/pipeline.yaml
@@ -9,6 +9,15 @@ tracking:
   output_dir: outputs/pipeline_tracking
 
 stages:
+  - name: query_transformation
+    description: Deterministic query normalization or expansion audit before retrieval.
+    command:
+      - mgq-transform-queries
+      - --config
+      - configs/baseline.yaml
+      - --output-dir
+      - outputs/query_transform/none
+
   - name: bm25_retrieval
     description: Full-corpus BM25 baseline on dev/small.
     command:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,11 @@ configuration, code, metrics, and provenance, not the corpus itself.
 
 ### Retrieval
 
+`src/msmarco_genqa/retrieval/query_transform.py` owns optional
+pre-retrieval query normalization, lexical expansion, and de-contextualization
+baselines. The default method is `none`; transformed runs must preserve the
+original query text and record the transformation config hash.
+
 Retrieval modules produce TREC-style `run.tsv` files. A retrieval run is the
 contract between the ranking layer and every downstream experiment.
 

--- a/docs/evaluation_protocol.md
+++ b/docs/evaluation_protocol.md
@@ -53,15 +53,16 @@ recorded in `configs/baseline.yaml` under `rag_eval`.
 
 ## Stage Order
 
-1. `bm25_retrieval`
-2. `dense_retrieval`
-3. `cross_encoder_rerank`
-4. `retrieval_quality_report`
-5. `retrieval_lift_analysis`
-6. `generation_bm25`
-7. `generation_reranked`
-8. `paired_bootstrap_ci`
-9. `grounding_audit`
+1. `query_transformation`
+2. `bm25_retrieval`
+3. `dense_retrieval`
+4. `cross_encoder_rerank`
+5. `retrieval_quality_report`
+6. `retrieval_lift_analysis`
+7. `generation_bm25`
+8. `generation_reranked`
+9. `paired_bootstrap_ci`
+10. `grounding_audit`
 
 Each stage writes under `outputs/`. Output directories are gitignored; metrics,
 manifests, and summaries should be copied into reports only after they are
@@ -100,6 +101,13 @@ Retrieval metrics:
 Use `retrieval_quality_report` for matched-qid retrieval comparisons before
 interpreting deltas. Coverage counts are part of the report and should be
 checked before comparing dense, RRF, or reranked runs.
+
+Query transformation:
+
+- Keep `query_transform.method: none` for no-transform baselines.
+- Record the `config_hash` and changed-query count for normalization or
+  expansion ablations.
+- Compare transformed and untransformed retrieval runs on matched query ids.
 
 Grounding metrics:
 

--- a/docs/query_transformation.md
+++ b/docs/query_transformation.md
@@ -1,0 +1,50 @@
+# Query Transformation Protocol
+
+Query transformation is an optional pre-retrieval ablation layer. It keeps the
+original MS MARCO query text alongside the transformed text so retrieval gains
+can be audited without losing the baseline input.
+
+## Methods
+
+- `none`: preserve the original query exactly. This is the default for
+  historical baseline reproducibility.
+- `normalize`: collapse whitespace, lowercase text, and strip terminal
+  punctuation.
+- `lexical_expansion`: normalize the query, then append deterministic curated
+  expansion terms for short queries such as `nyc` -> `new york city`.
+- `decontextualize`: normalize elliptical follow-up queries and prepend a
+  configured context string when one is available.
+
+The first production ablation should compare `none`, `normalize`, and
+`lexical_expansion` before changing retriever or reranker parameters.
+
+## Artifacts
+
+Run:
+
+```bash
+mgq-transform-queries \
+  --config configs/baseline.yaml \
+  --method lexical_expansion \
+  --output-dir outputs/query_transform/lexical_expansion
+```
+
+The command writes:
+
+- `queries.jsonl`: one record per query with `query_id`, `original_query`,
+  `transformed_query`, `method`, `config_hash`, `changed`, and `added_terms`.
+- `summary.json`: query count, changed count, changed fraction, method, config
+  hash, and cache status.
+
+The same transformation config is used by `mgq-retrieve` and `mgq-dense`.
+When the method is not `none`, each runner writes its own
+`query_transform/queries.jsonl` and `query_transform/summary.json` under the
+run output directory.
+
+## Reproducibility Notes
+
+- Keep `query_transform.method: none` for canonical no-transform baselines.
+- Record the `config_hash` when reporting metric deltas.
+- Compare transformed and untransformed runs on matched query ids with
+  `mgq-retrieval-report compare`.
+- Do not tune expansion terms using answer labels from the evaluation split.

--- a/experiments/run_dense_retrieval.py
+++ b/experiments/run_dense_retrieval.py
@@ -53,6 +53,7 @@ from msmarco_genqa.data.msmarco import get_docs_store, load_msmarco_passage
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
 from msmarco_genqa.retrieval.bm25 import BM25Retriever
 from msmarco_genqa.retrieval.dense import DenseRetriever
+from msmarco_genqa.retrieval.query_transform import materialize_query_transform
 from msmarco_genqa.retrieval.sampling import qrels_anchored_sample
 from msmarco_genqa.util.environment import capture_environment
 from msmarco_genqa.util.manifest import (
@@ -233,6 +234,20 @@ def main() -> None:
     # ---------------------------------------------------------------- #
     data = load_msmarco_passage(cache_dir=cache_dir, load_corpus=False)
     docs_store = data.docs_store or get_docs_store(cache_dir=cache_dir)
+    query_text_by_qid, query_transform_summary, query_transform_outputs = (
+        materialize_query_transform(
+            data.queries,
+            cfg.get("query_transform"),
+            output_dir=output_dir / "query_transform",
+        )
+    )
+    if query_transform_summary["method"] != "none":
+        logger.info(
+            "Query transformation %s changed %d / %d queries.",
+            query_transform_summary["method"],
+            query_transform_summary["n_changed"],
+            query_transform_summary["n_queries"],
+        )
 
     pool_doc_ids = _load_pool_doc_ids(PROJECT_ROOT)
     sample_doc_ids = qrels_anchored_sample(
@@ -350,7 +365,7 @@ def main() -> None:
     # 4. Retrieval
     # ---------------------------------------------------------------- #
     qids = list(data.queries.keys())
-    queries_text = [data.queries[q] for q in qids]
+    queries_text = [query_text_by_qid[q] for q in qids]
     top_k_eff = min(top_k, len(sample_doc_ids))
 
     logger.info("Dense retrieval: top-%d for %d queries...", top_k_eff, len(qids))
@@ -439,6 +454,8 @@ def main() -> None:
                 "dense_top10": dense_block,
                 "dense_first_rank_in_top10": _first_rank(dense_block),
             }
+            if query_transform_summary["method"] != "none":
+                entry["transformed_query"] = query_text_by_qid[qid]
             if bm25 is not None:
                 bm25_block = _top10_block(bm25_scores, bm25_doc_ids_lists, qid, relevant)
                 entry["bm25_sample_top10"] = bm25_block
@@ -484,6 +501,7 @@ def main() -> None:
             "doc_ids_path": str(sample_path.relative_to(PROJECT_ROOT)),
         },
         "top_k": top_k_eff,
+        "query_transform": query_transform_summary,
     }
     with open(output_dir / "metrics.json", "w") as f:
         json.dump(payload, f, indent=2, default=str)
@@ -497,7 +515,13 @@ def main() -> None:
     )
     env_fingerprint = compute_env_fingerprint(env_dict)
 
-    manifest_outputs = [dense_run_path, examples_path, sample_path, resolved_config_path]
+    manifest_outputs = [
+        dense_run_path,
+        examples_path,
+        sample_path,
+        resolved_config_path,
+        *query_transform_outputs,
+    ]
     if bm25_run_path is not None:
         manifest_outputs.append(bm25_run_path)
     write_run_manifest(
@@ -519,6 +543,7 @@ def main() -> None:
             "resolved_config_hash": resolved_config_hash,
             "data_fingerprint": data_fingerprint,
             "env_fingerprint": env_fingerprint,
+            "query_transform": query_transform_summary,
         },
         require_clean_tree=args.require_clean_tree,
         allow_incomplete=args.allow_incomplete_manifest,

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -36,6 +36,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 from msmarco_genqa.data.msmarco import load_msmarco_passage
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
 from msmarco_genqa.retrieval.bm25 import BM25Retriever
+from msmarco_genqa.retrieval.query_transform import materialize_query_transform
 from msmarco_genqa.util.environment import capture_environment
 from msmarco_genqa.util.manifest import (
     compute_data_fingerprint,
@@ -185,6 +186,20 @@ def main() -> None:
         load_corpus=not have_index,
         limit=corpus_limit,
     )
+    query_text_by_qid, query_transform_summary, query_transform_outputs = (
+        materialize_query_transform(
+            data.queries,
+            cfg.get("query_transform"),
+            output_dir=output_dir / "query_transform",
+        )
+    )
+    if query_transform_summary["method"] != "none":
+        logger.info(
+            "Query transformation %s changed %d / %d queries.",
+            query_transform_summary["method"],
+            query_transform_summary["n_changed"],
+            query_transform_summary["n_queries"],
+        )
 
     # ---- 2. Index ----
     index_time: float | None = None
@@ -287,7 +302,7 @@ def main() -> None:
         with open(run_path, run_file_mode) as run_f:
             for chunk_start in range(0, len(pending_qids), chunk_size):
                 chunk_qids = pending_qids[chunk_start : chunk_start + chunk_size]
-                chunk_texts = [data.queries[q] for q in chunk_qids]
+                chunk_texts = [query_text_by_qid[q] for q in chunk_qids]
 
                 t0 = time.time()
                 chunk_scores, chunk_doc_ids = retriever.retrieve_batch(
@@ -392,6 +407,8 @@ def main() -> None:
                 "first_relevant_rank_in_top10": first_rank,
                 "top_results": top_results,
             }
+            if query_transform_summary["method"] != "none":
+                example["transformed_query"] = query_text_by_qid[qid]
             f.write(json.dumps(example, ensure_ascii=False) + "\n")
     logger.info("Wrote %d examples to %s", len(sample_qids), examples_path)
 
@@ -420,6 +437,7 @@ def main() -> None:
         },
         "environment": env_dict,
         "top_k": top_k,
+        "query_transform": query_transform_summary,
         "resumed": args.resume and bool(set(qids) - set(pending_qids)),
     }
     with open(output_dir / "metrics.json", "w") as f:
@@ -439,7 +457,7 @@ def main() -> None:
         output_dir=output_dir,
         command=sys.argv,
         config_path=args.config,
-        extra_outputs=[run_path, examples_path, resolved_config_path],
+        extra_outputs=[run_path, examples_path, resolved_config_path, *query_transform_outputs],
         extra={
             "task": "retrieval",
             "backend": cfg["retrieval"].get("backend", "bm25s"),
@@ -454,6 +472,7 @@ def main() -> None:
             "resolved_config_hash": resolved_config_hash,
             "data_fingerprint": data_fingerprint,
             "env_fingerprint": env_fingerprint,
+            "query_transform": query_transform_summary,
         },
         require_clean_tree=args.require_clean_tree,
         allow_incomplete=args.allow_incomplete_manifest,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ exclude = ["tests*", "scripts*"]
 mgq-retrieve = "msmarco_genqa.cli.retrieve:main"
 mgq-dense    = "msmarco_genqa.cli.dense:main"
 mgq-fuse     = "msmarco_genqa.cli.fuse:main"
+mgq-transform-queries = "msmarco_genqa.cli.query_transform:main"
 mgq-retrieval-report = "msmarco_genqa.cli.retrieval_report:main"
 mgq-rerank   = "msmarco_genqa.cli.rerank:main"
 mgq-generate = "msmarco_genqa.cli.generate:main"

--- a/src/msmarco_genqa/cli/query_transform.py
+++ b/src/msmarco_genqa/cli/query_transform.py
@@ -1,0 +1,159 @@
+"""``mgq-transform-queries`` console entry point."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Mapping
+
+import yaml
+
+from msmarco_genqa.data.msmarco import load_msmarco_passage
+from msmarco_genqa.retrieval.query_transform import (
+    QueryTransformConfig,
+    query_transform_config_hash,
+    read_cached_transformations,
+    transform_queries,
+    write_transformation_artifacts,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=PROJECT_ROOT / "configs/baseline.yaml",
+        help="Pipeline YAML containing the query_transform section.",
+    )
+    parser.add_argument(
+        "--method",
+        choices=["none", "normalize", "lexical_expansion", "decontextualize"],
+        default=None,
+        help="Override query_transform.method from the config.",
+    )
+    parser.add_argument(
+        "--queries-tsv",
+        type=Path,
+        default=None,
+        help="Optional two-column TSV of qid and query. Defaults to MS MARCO dev/small.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Artifact directory. Defaults to query_transform.output_dir from the config.",
+    )
+    parser.add_argument(
+        "--cache-file",
+        type=Path,
+        default=None,
+        help="Reuse a JSONL artifact when qids and config hash match.",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_config(path: Path) -> dict[str, object]:
+    with path.open(encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    if not isinstance(raw, dict):
+        raise SystemExit("config must be a YAML mapping")
+    return raw
+
+
+def _load_queries(path: Path | None, cfg: Mapping[str, object]) -> dict[str, str]:
+    if path is None:
+        data_cfg = cfg.get("data", {})
+        cache_dir = None
+        if isinstance(data_cfg, Mapping):
+            cache_dir_value = data_cfg.get("cache_dir")
+            if cache_dir_value:
+                cache_dir = PROJECT_ROOT / str(cache_dir_value)
+        bundle = load_msmarco_passage(cache_dir=cache_dir, load_corpus=False)
+        return bundle.queries
+
+    queries: dict[str, str] = {}
+    resolved = path if path.is_absolute() else PROJECT_ROOT / path
+    with resolved.open(encoding="utf-8") as f:
+        for line_number, line in enumerate(f, start=1):
+            if not line.strip():
+                continue
+            parts = line.rstrip("\n").split("\t", 1)
+            if len(parts) != 2:
+                raise SystemExit(f"{resolved}:{line_number}: expected qid<TAB>query")
+            qid, query = parts
+            if not qid:
+                raise SystemExit(f"{resolved}:{line_number}: empty query id")
+            queries[qid] = query
+    return queries
+
+
+def _settings_from_config(
+    cfg: Mapping[str, object],
+    *,
+    method_override: str | None,
+) -> dict[str, object]:
+    raw = cfg.get("query_transform", {})
+    if raw is None:
+        settings: dict[str, object] = {}
+    elif isinstance(raw, Mapping):
+        settings = dict(raw)
+    else:
+        raise SystemExit("query_transform must be a YAML mapping")
+    if method_override is not None:
+        settings["method"] = method_override
+    return settings
+
+
+def _output_dir_from_settings(
+    settings: Mapping[str, object],
+    override: Path | None,
+) -> Path:
+    if override is not None:
+        return override if override.is_absolute() else PROJECT_ROOT / override
+    configured = settings.get("output_dir", "outputs/query_transform")
+    path = Path(str(configured))
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    cfg = _load_config(args.config)
+    settings = _settings_from_config(cfg, method_override=args.method)
+    transform_config = QueryTransformConfig.from_mapping(settings)
+    queries = _load_queries(args.queries_tsv, cfg)
+    query_ids = list(queries)
+    config_hash = query_transform_config_hash(transform_config)
+
+    cache_hit = False
+    records = None
+    if args.cache_file is not None:
+        cache_path = args.cache_file if args.cache_file.is_absolute() else PROJECT_ROOT / args.cache_file
+        records = read_cached_transformations(
+            cache_path,
+            expected_config_hash=config_hash,
+            expected_query_ids=query_ids,
+        )
+        cache_hit = records is not None
+    if records is None:
+        records = transform_queries(queries, transform_config)
+
+    output_dir = _output_dir_from_settings(settings, args.output_dir)
+    summary, _paths = write_transformation_artifacts(
+        records,
+        output_dir,
+        transform_config,
+        cache_hit=cache_hit,
+    )
+    print(
+        "query transformations: "
+        f"{summary['n_queries']} queries, {summary['n_changed']} changed, "
+        f"method={summary['method']}, output={output_dir}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/msmarco_genqa/rag_eval.py
+++ b/src/msmarco_genqa/rag_eval.py
@@ -17,6 +17,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 DEFAULT_STAGE_ORDER: tuple[str, ...] = (
+    "query_transformation",
     "bm25_retrieval",
     "dense_retrieval",
     "cross_encoder_rerank",
@@ -92,6 +93,15 @@ def _build_all_stages(
     bm25_run = _as_posix(Path(bm25_dir) / "run.tsv")
     dense_run = _as_posix(Path(dense_dir) / "run.tsv")
     reranker_run = _as_posix(Path(reranker_dir) / "run.tsv")
+    query_transform_settings = cfg.get("query_transform", {})
+    query_transform_output_dir = "outputs/query_transform/none"
+    if isinstance(query_transform_settings, dict):
+        query_transform_output_dir = str(
+            query_transform_settings.get("output_dir", query_transform_output_dir)
+        )
+    query_transform_dir = _as_posix(
+        settings.get("query_transform_output_dir", query_transform_output_dir)
+    )
 
     bm25_generation_dir = _as_posix(
         settings.get("bm25_generation_dir", _default_named_dir(generation_dir, "bm25_full"))
@@ -142,6 +152,21 @@ def _build_all_stages(
         retrieval_report_command.extend(["--qrels", _as_posix(retrieval_qrels_path)])
 
     return {
+        "query_transformation": RAGEvalStage(
+            name="query_transformation",
+            description="Deterministic query transformation audit artifacts before retrieval.",
+            command=[
+                "mgq-transform-queries",
+                "--config",
+                config_arg,
+                "--output-dir",
+                query_transform_dir,
+            ],
+            expected_outputs=[
+                _as_posix(Path(query_transform_dir) / "queries.jsonl"),
+                _as_posix(Path(query_transform_dir) / "summary.json"),
+            ],
+        ),
         "bm25_retrieval": RAGEvalStage(
             name="bm25_retrieval",
             description="Full-corpus BM25 retrieval on MS MARCO dev/small.",

--- a/src/msmarco_genqa/retrieval/query_transform.py
+++ b/src/msmarco_genqa/retrieval/query_transform.py
@@ -1,0 +1,384 @@
+"""Deterministic query transformation utilities for retrieval ablations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+SUPPORTED_METHODS = {"none", "normalize", "lexical_expansion", "decontextualize"}
+
+DEFAULT_EXPANSION_TERMS: dict[str, tuple[str, ...]] = {
+    "covid": ("coronavirus",),
+    "fda": ("food and drug administration",),
+    "flu": ("influenza",),
+    "heart attack": ("myocardial infarction",),
+    "irs": ("internal revenue service",),
+    "nyc": ("new york city",),
+    "u.s.": ("united states",),
+    "uk": ("united kingdom",),
+    "usa": ("united states",),
+}
+
+_SPACE_RE = re.compile(r"\s+")
+_TOKEN_RE = re.compile(r"[a-z0-9]+(?:[.'-][a-z0-9]+)?")
+_TERMINAL_PUNCT_RE = re.compile(r"[\s?!.]+$")
+_ELLIPTICAL_PREFIX_RE = re.compile(
+    r"^(and|also|how about|it|that|these|they|this|those|what about)\b"
+)
+
+
+@dataclass(frozen=True)
+class QueryTransformConfig:
+    """Configuration for deterministic query transformation."""
+
+    method: str = "none"
+    lowercase: bool = True
+    strip_terminal_punctuation: bool = True
+    max_query_terms_for_expansion: int = 6
+    max_expansion_terms: int = 4
+    expansion_terms: Mapping[str, tuple[str, ...]] = field(
+        default_factory=lambda: dict(DEFAULT_EXPANSION_TERMS)
+    )
+    decontextualization_context: str | None = None
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, object] | None) -> "QueryTransformConfig":
+        settings = dict(raw or {})
+        method = str(settings.get("method", "none"))
+        if method not in SUPPORTED_METHODS:
+            raise ValueError(
+                f"unsupported query transformation method {method!r}; "
+                f"expected one of {sorted(SUPPORTED_METHODS)}"
+            )
+
+        expansion_terms = _parse_expansion_terms(
+            settings.get("expansion_terms", DEFAULT_EXPANSION_TERMS)
+        )
+        return cls(
+            method=method,
+            lowercase=_as_bool(settings.get("lowercase", True)),
+            strip_terminal_punctuation=_as_bool(
+                settings.get("strip_terminal_punctuation", True)
+            ),
+            max_query_terms_for_expansion=int(
+                settings.get("max_query_terms_for_expansion", 6)
+            ),
+            max_expansion_terms=int(settings.get("max_expansion_terms", 4)),
+            expansion_terms=expansion_terms,
+            decontextualization_context=_optional_str(
+                settings.get("decontextualization_context")
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class QueryTransformationRecord:
+    """One auditable query transformation record."""
+
+    query_id: str
+    original_query: str
+    transformed_query: str
+    method: str
+    config_hash: str
+    changed: bool
+    added_terms: tuple[str, ...] = ()
+
+    def to_json(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["added_terms"] = list(self.added_terms)
+        return payload
+
+
+def _as_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_expansion_terms(raw: object) -> dict[str, tuple[str, ...]]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise ValueError("query_transform.expansion_terms must be a mapping")
+
+    parsed: dict[str, tuple[str, ...]] = {}
+    for trigger, terms in raw.items():
+        trigger_text = str(trigger).strip()
+        if not trigger_text:
+            continue
+        if isinstance(terms, str):
+            values = (terms,)
+        elif isinstance(terms, Sequence):
+            values = tuple(str(term) for term in terms)
+        else:
+            raise ValueError(
+                f"expansion terms for {trigger_text!r} must be a string or sequence"
+            )
+        cleaned = tuple(term.strip() for term in values if term.strip())
+        if cleaned:
+            parsed[trigger_text] = cleaned
+    return parsed
+
+
+def normalize_query(
+    query: str,
+    *,
+    lowercase: bool = True,
+    strip_terminal_punctuation: bool = True,
+) -> str:
+    """Collapse whitespace and optionally lowercase a query."""
+
+    text = str(query)
+    text = text.replace("\u2018", "'").replace("\u2019", "'")
+    text = text.replace("\u201c", '"').replace("\u201d", '"')
+    text = _SPACE_RE.sub(" ", text.strip())
+    if strip_terminal_punctuation:
+        text = _TERMINAL_PUNCT_RE.sub("", text).strip()
+    if lowercase:
+        text = text.lower()
+    return text
+
+
+def query_transform_config_hash(config: QueryTransformConfig) -> str:
+    """Return a stable short hash for artifact compatibility checks."""
+
+    payload = {
+        "method": config.method,
+        "lowercase": config.lowercase,
+        "strip_terminal_punctuation": config.strip_terminal_punctuation,
+        "max_query_terms_for_expansion": config.max_query_terms_for_expansion,
+        "max_expansion_terms": config.max_expansion_terms,
+        "expansion_terms": {
+            key: list(value) for key, value in sorted(config.expansion_terms.items())
+        },
+        "decontextualization_context": config.decontextualization_context,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:12]
+
+
+def transform_query(
+    query: str,
+    config: QueryTransformConfig,
+    *,
+    context: str | None = None,
+) -> tuple[str, tuple[str, ...]]:
+    """Transform one query and return ``(transformed_query, added_terms)``."""
+
+    if config.method == "none":
+        return str(query), ()
+
+    normalized = normalize_query(
+        str(query),
+        lowercase=config.lowercase,
+        strip_terminal_punctuation=config.strip_terminal_punctuation,
+    )
+    if config.method == "normalize":
+        return normalized, ()
+
+    if config.method == "lexical_expansion":
+        added_terms = _expansion_terms_for_query(normalized, config)
+        if not added_terms:
+            return normalized, ()
+        return " ".join([normalized, *added_terms]).strip(), added_terms
+
+    if config.method == "decontextualize":
+        ctx = context or config.decontextualization_context
+        if not ctx or not normalized or not _ELLIPTICAL_PREFIX_RE.search(normalized):
+            return normalized, ()
+        prefix = normalize_query(
+            ctx,
+            lowercase=config.lowercase,
+            strip_terminal_punctuation=config.strip_terminal_punctuation,
+        )
+        return f"{prefix} {normalized}".strip(), ()
+
+    raise ValueError(f"unsupported query transformation method {config.method!r}")
+
+
+def _expansion_terms_for_query(
+    normalized_query: str,
+    config: QueryTransformConfig,
+) -> tuple[str, ...]:
+    tokens = _TOKEN_RE.findall(normalized_query)
+    if not tokens or len(tokens) > config.max_query_terms_for_expansion:
+        return ()
+
+    token_set = set(tokens)
+    additions: list[str] = []
+    seen_additions: set[str] = set()
+    for trigger, raw_terms in sorted(config.expansion_terms.items()):
+        trigger_normalized = normalize_query(
+            trigger,
+            lowercase=config.lowercase,
+            strip_terminal_punctuation=config.strip_terminal_punctuation,
+        )
+        if not _trigger_matches(trigger_normalized, normalized_query, token_set):
+            continue
+        for term in raw_terms:
+            normalized_term = normalize_query(
+                term,
+                lowercase=config.lowercase,
+                strip_terminal_punctuation=config.strip_terminal_punctuation,
+            )
+            if not normalized_term:
+                continue
+            if normalized_term in normalized_query or normalized_term in seen_additions:
+                continue
+            additions.append(normalized_term)
+            seen_additions.add(normalized_term)
+            if len(additions) >= config.max_expansion_terms:
+                return tuple(additions)
+    return tuple(additions)
+
+
+def _trigger_matches(trigger: str, normalized_query: str, token_set: set[str]) -> bool:
+    if " " not in trigger and trigger in token_set:
+        return True
+    return re.search(rf"(?<!\w){re.escape(trigger)}(?!\w)", normalized_query) is not None
+
+
+def transform_queries(
+    queries: Mapping[str, str],
+    config: QueryTransformConfig,
+    *,
+    contexts: Mapping[str, str] | None = None,
+) -> list[QueryTransformationRecord]:
+    """Transform a query mapping into ordered audit records."""
+
+    config_hash = query_transform_config_hash(config)
+    records: list[QueryTransformationRecord] = []
+    for qid, query in queries.items():
+        transformed, added_terms = transform_query(
+            query,
+            config,
+            context=(contexts or {}).get(qid),
+        )
+        records.append(
+            QueryTransformationRecord(
+                query_id=str(qid),
+                original_query=str(query),
+                transformed_query=transformed,
+                method=config.method,
+                config_hash=config_hash,
+                changed=str(query) != transformed,
+                added_terms=added_terms,
+            )
+        )
+    return records
+
+
+def summarize_transformations(
+    records: Sequence[QueryTransformationRecord],
+    config: QueryTransformConfig,
+    *,
+    cache_hit: bool = False,
+) -> dict[str, object]:
+    config_hash = query_transform_config_hash(config)
+    n_queries = len(records)
+    n_changed = sum(1 for record in records if record.changed)
+    return {
+        "method": config.method,
+        "config_hash": config_hash,
+        "n_queries": n_queries,
+        "n_changed": n_changed,
+        "changed_fraction": (n_changed / n_queries) if n_queries else 0.0,
+        "cache_hit": cache_hit,
+    }
+
+
+def transformed_query_map(
+    records: Sequence[QueryTransformationRecord],
+) -> dict[str, str]:
+    return {record.query_id: record.transformed_query for record in records}
+
+
+def write_transformation_artifacts(
+    records: Sequence[QueryTransformationRecord],
+    output_dir: Path,
+    config: QueryTransformConfig,
+    *,
+    cache_hit: bool = False,
+) -> tuple[dict[str, object], list[Path]]:
+    """Write query transformation JSONL and summary artifacts."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    queries_path = output_dir / "queries.jsonl"
+    summary_path = output_dir / "summary.json"
+
+    with queries_path.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record.to_json(), ensure_ascii=False) + "\n")
+
+    summary = summarize_transformations(records, config, cache_hit=cache_hit)
+    summary["queries_path"] = str(queries_path)
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False)
+    return summary, [queries_path, summary_path]
+
+
+def read_cached_transformations(
+    path: Path,
+    *,
+    expected_config_hash: str,
+    expected_query_ids: Sequence[str],
+) -> list[QueryTransformationRecord] | None:
+    """Read cached records if the config hash and qid order match."""
+
+    if not path.exists():
+        return None
+
+    records: list[QueryTransformationRecord] = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            added_terms = tuple(payload.get("added_terms", ()))
+            records.append(
+                QueryTransformationRecord(
+                    query_id=str(payload["query_id"]),
+                    original_query=str(payload["original_query"]),
+                    transformed_query=str(payload["transformed_query"]),
+                    method=str(payload["method"]),
+                    config_hash=str(payload["config_hash"]),
+                    changed=bool(payload["changed"]),
+                    added_terms=added_terms,
+                )
+            )
+
+    if [record.query_id for record in records] != [str(qid) for qid in expected_query_ids]:
+        return None
+    if any(record.config_hash != expected_config_hash for record in records):
+        return None
+    return records
+
+
+def materialize_query_transform(
+    queries: Mapping[str, str],
+    settings: Mapping[str, object] | None,
+    *,
+    output_dir: Path,
+) -> tuple[dict[str, str], dict[str, object], list[Path]]:
+    """Return transformed query text plus optional audit artifacts for runners."""
+
+    config = QueryTransformConfig.from_mapping(settings)
+    records = transform_queries(queries, config)
+    if config.method == "none":
+        return dict(queries), summarize_transformations(records, config), []
+    summary, paths = write_transformation_artifacts(records, output_dir, config)
+    return transformed_query_map(records), summary, paths

--- a/tests/test_query_transform.py
+++ b/tests/test_query_transform.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+
+from msmarco_genqa.cli import query_transform as cli
+from msmarco_genqa.retrieval.query_transform import (
+    QueryTransformConfig,
+    normalize_query,
+    query_transform_config_hash,
+    read_cached_transformations,
+    transform_queries,
+    transform_query,
+    write_transformation_artifacts,
+)
+
+
+def test_normalize_query_handles_empty_and_whitespace():
+    assert normalize_query("   ") == ""
+    assert normalize_query("  What   IS   NLP?  ") == "what is nlp"
+
+
+def test_lexical_expansion_adds_terms_for_short_queries():
+    config = QueryTransformConfig.from_mapping({"method": "lexical_expansion"})
+
+    transformed, added = transform_query("NYC weather?", config)
+
+    assert transformed == "nyc weather new york city"
+    assert added == ("new york city",)
+
+
+def test_lexical_expansion_leaves_specific_queries_stable():
+    config = QueryTransformConfig.from_mapping({"method": "lexical_expansion"})
+
+    transformed, added = transform_query(
+        "what is the capital city of france in europe",
+        config,
+    )
+
+    assert transformed == "what is the capital city of france in europe"
+    assert added == ()
+
+
+def test_decontextualize_prepends_context_only_for_elliptical_query():
+    config = QueryTransformConfig.from_mapping(
+        {
+            "method": "decontextualize",
+            "decontextualization_context": "Symptoms of influenza",
+        }
+    )
+
+    transformed, added = transform_query("what about children?", config)
+
+    assert transformed == "symptoms of influenza what about children"
+    assert added == ()
+
+
+def test_config_hash_changes_with_method():
+    normalize = QueryTransformConfig.from_mapping({"method": "normalize"})
+    expansion = QueryTransformConfig.from_mapping({"method": "lexical_expansion"})
+
+    assert query_transform_config_hash(normalize) != query_transform_config_hash(expansion)
+
+
+def test_artifact_cache_requires_matching_hash_and_qids(tmp_path):
+    config = QueryTransformConfig.from_mapping({"method": "normalize"})
+    records = transform_queries({"q1": " What is NLP? "}, config)
+    _summary, paths = write_transformation_artifacts(records, tmp_path, config)
+    queries_path = paths[0]
+
+    cached = read_cached_transformations(
+        queries_path,
+        expected_config_hash=query_transform_config_hash(config),
+        expected_query_ids=["q1"],
+    )
+    assert cached == records
+
+    assert (
+        read_cached_transformations(
+            queries_path,
+            expected_config_hash="different",
+            expected_query_ids=["q1"],
+        )
+        is None
+    )
+    assert (
+        read_cached_transformations(
+            queries_path,
+            expected_config_hash=query_transform_config_hash(config),
+            expected_query_ids=["q2"],
+        )
+        is None
+    )
+
+
+def test_transform_queries_records_original_and_transformed_text():
+    config = QueryTransformConfig.from_mapping({"method": "normalize"})
+
+    records = transform_queries({"q1": "  What   is NLP? "}, config)
+
+    assert records[0].original_query == "  What   is NLP? "
+    assert records[0].transformed_query == "what is nlp"
+    assert records[0].changed is True
+
+
+def test_cli_writes_local_query_artifacts(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    config_path = tmp_path / "baseline.yaml"
+    config_path.write_text(
+        "query_transform:\n"
+        "  method: normalize\n"
+        "  output_dir: outputs/query_transform/normalize\n",
+        encoding="utf-8",
+    )
+    queries_path = tmp_path / "queries.tsv"
+    queries_path.write_text("q1\t What   is NLP? \n", encoding="utf-8")
+
+    cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--queries-tsv",
+            str(queries_path),
+        ]
+    )
+
+    output_dir = tmp_path / "outputs" / "query_transform" / "normalize"
+    lines = (output_dir / "queries.jsonl").read_text(encoding="utf-8").splitlines()
+    summary = json.loads((output_dir / "summary.json").read_text(encoding="utf-8"))
+    record = json.loads(lines[0])
+
+    assert record["original_query"] == " What   is NLP? "
+    assert record["transformed_query"] == "what is nlp"
+    assert summary["n_changed"] == 1
+    assert "query transformations: 1 queries, 1 changed" in capsys.readouterr().out

--- a/tests/test_rag_eval.py
+++ b/tests/test_rag_eval.py
@@ -94,6 +94,25 @@ def test_build_rag_eval_plan_includes_retrieval_quality_report(tmp_path):
     assert "outputs/report_dense_vs_reranked/comparison.json" in plan[0].expected_outputs
 
 
+def test_build_rag_eval_plan_includes_query_transformation(tmp_path):
+    config_path = _write_config(tmp_path / "baseline.yaml")
+    cfg = load_rag_eval_config(config_path)
+    cfg["query_transform"] = {"method": "normalize", "output_dir": "outputs/query_norm"}
+    cfg["rag_eval"]["stages"] = ["query_transformation"]
+
+    plan = build_rag_eval_plan(cfg, config_path=config_path)
+
+    assert [stage.name for stage in plan] == ["query_transformation"]
+    assert plan[0].command == [
+        "mgq-transform-queries",
+        "--config",
+        config_path.as_posix(),
+        "--output-dir",
+        "outputs/query_norm",
+    ]
+    assert "outputs/query_norm/queries.jsonl" in plan[0].expected_outputs
+
+
 def test_build_rag_eval_plan_rejects_unknown_stage(tmp_path):
     config_path = _write_config(tmp_path / "baseline.yaml")
     cfg = load_rag_eval_config(config_path)


### PR DESCRIPTION
## Summary
- Add a deterministic query transformation module and mgq-transform-queries artifact CLI.
- Wire optional transformed queries into BM25 and dense retrieval runners while keeping the default method as none.
- Add query_transformation to rag-eval and pipeline plans, with protocol documentation and focused tests.

## Validation
- PYTHONPATH=src python -m pytest -q tests/test_query_transform.py tests/test_rag_eval.py tests/test_pipeline.py
- python -m ruff check src tests experiments scripts
- git diff --check
- rag-eval query_transformation dry-run against configs/baseline.yaml
- PYTHONPATH=src python scripts\\run_pipeline.py --config configs\\pipeline.yaml --dry-run

## Local Environment Note
- Full default pytest was attempted locally. It reached 418 passed, 4 skipped, and 1 deselected, then failed on existing tests that require bm25s and faiss, which are not installed in this local environment.

Refs #37.