### PR TITLE
Add lightweight notebook demo checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check headline metric metadata
         run: python scripts/check_headline_metrics.py
 
+      - name: Check demo notebooks
+        run: python scripts/check_notebooks.py
+
       - name: Check generated report tables
         run: |
           python scripts/export_report_tables.py

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-baseline
+.PHONY: help install test test-slow lint check-results check-notebooks export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-baseline
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -17,6 +17,7 @@ help:
 	@echo "  make test-slow            -- include slow tests (HF metric scripts; skipped if offline)"
 	@echo "  make lint                 -- ruff check on src/, tests/, experiments/, scripts/"
 	@echo "  make check-results        -- verify metadata.json headline metrics against RESULTS.md"
+	@echo "  make check-notebooks      -- verify notebooks stay lightweight demos"
 	@echo "  make export-report-tables -- refresh checked LaTeX table fragments"
 	@echo "  make check-report-tables  -- verify checked LaTeX table fragments are current"
 	@echo "  make pipeline-dry-run     -- print the config-driven experiment plan"
@@ -63,6 +64,9 @@ lint:
 
 check-results:
 	$(PYTHON) scripts/check_headline_metrics.py
+
+check-notebooks:
+	$(PYTHON) scripts/check_notebooks.py
 
 export-report-tables:
 	$(PYTHON) scripts/export_report_tables.py

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ auditing the experiments:
 - **`scripts/`** — analyses, ablations, validation, integration smokes that read `experiments/` outputs.
 - **`src/`** — importable library code backing both.
 - **`docs/`** — experiment narratives and reproducibility notes.
-- **`notebooks/`** — lightweight demos for inspecting the workflow without running heavy jobs.
+- **`notebooks/`** — lightweight demos over package APIs and CLI dry runs; they are
+  not required for metric reproduction.
 - **`reports/acl_findings/`** — ACL-Findings-style experimental report draft.
 - **`reports/repo_report/`** — repository report PDF, HTML, sources, and figures.
 - **`reports/generated/artifacts/`** — checked machine-readable report table inputs.
@@ -149,6 +150,15 @@ python scripts/export_report_tables.py
 
 CI runs the same exporter and fails if `reports/generated/tables/` drifts
 from the checked artifacts.
+
+Notebook demos are kept output-free and lightweight:
+
+```bash
+python scripts/check_notebooks.py
+```
+
+Use package entry points, scripts, and configs for reproducible experiments;
+notebooks are only for interactive inspection.
 
 ## 1. Status
 

--- a/docs/evaluation_protocol.md
+++ b/docs/evaluation_protocol.md
@@ -189,6 +189,8 @@ When updating `RESULTS.md` or a report:
 - Refresh checked LaTeX fragments with `python scripts/export_report_tables.py`
   when a report table is backed by `reports/generated/artifacts/*.json`.
 - Commit the matching `.sources.json` sidecar for each refreshed table fragment.
+- Keep notebooks as output-free demos over package APIs or dry-run CLIs; runnable
+  experiment logic belongs in `src/`, `scripts/`, and config files.
 - Separate confirmed results from hypotheses and queued follow-ups.
 
 Avoid language that implies general QA capability. The current system is an

--- a/scripts/check_notebooks.py
+++ b/scripts/check_notebooks.py
@@ -1,0 +1,161 @@
+"""Check that notebooks stay lightweight and demo-oriented."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+FORBIDDEN_CODE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?m)^\s*[!%]"), "shell commands and notebook magics are not allowed"),
+    (re.compile(r"\bir_datasets\.load\s*\("), "full benchmark loaders belong in scripts"),
+    (re.compile(r"\bload_dataset\s*\("), "dataset downloads belong in scripts"),
+    (re.compile(r"\.download\s*\("), "downloads belong in scripts"),
+    (re.compile(r"\bfrom_pretrained\s*\("), "model loading belongs in package code"),
+    (re.compile(r"\bSentenceTransformer\s*\("), "model loading belongs in package code"),
+    (re.compile(r"\bCrossEncoder\s*\("), "model loading belongs in package code"),
+    (re.compile(r"\bAuto(Model|Tokenizer)\b"), "model loading belongs in package code"),
+    (re.compile(r"\bsubprocess\."), "CLI execution belongs in scripts or documented commands"),
+    (re.compile(r"\brequests\."), "network calls are not allowed in notebooks"),
+    (re.compile(r"\burllib\.request\b"), "network calls are not allowed in notebooks"),
+    (re.compile(r"\bfaiss\.(read|write)_index\s*\("), "index IO belongs in package code"),
+)
+
+PACKAGE_REFERENCES = (
+    "from msmarco_genqa",
+    "import msmarco_genqa",
+    "msmarco_genqa.",
+)
+
+
+def cell_source(cell: dict[str, Any]) -> str:
+    """Return a notebook cell source as one string."""
+    source = cell.get("source", "")
+    if isinstance(source, list):
+        return "".join(str(part) for part in source)
+    return str(source)
+
+
+def package_imports(source: str) -> set[str]:
+    """Collect imported msmarco_genqa modules from one code cell."""
+    imports: set[str] = set()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "msmarco_genqa" or alias.name.startswith("msmarco_genqa."):
+                    imports.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "msmarco_genqa" or node.module.startswith("msmarco_genqa."):
+                imports.add(node.module)
+    return imports
+
+
+def check_notebook(path: Path, *, project_root: Path) -> list[str]:
+    """Return validation errors for one notebook."""
+    errors: list[str] = []
+    try:
+        notebook = json.loads(path.read_text(encoding="utf-8-sig"))
+    except json.JSONDecodeError as exc:
+        return [f"{path}: invalid notebook JSON: {exc}"]
+
+    if notebook.get("nbformat") != 4:
+        errors.append(f"{path}: nbformat must be 4")
+
+    cells = notebook.get("cells")
+    if not isinstance(cells, list):
+        return [*errors, f"{path}: cells must be a list"]
+
+    combined_source: list[str] = []
+    imported_modules: set[str] = set()
+    for index, cell in enumerate(cells, start=1):
+        cell_type = cell.get("cell_type")
+        source = cell_source(cell)
+        combined_source.append(source)
+
+        if cell_type != "code":
+            continue
+
+        if cell.get("outputs"):
+            errors.append(f"{path}: code cell {index} must not store outputs")
+        if cell.get("execution_count") is not None:
+            errors.append(f"{path}: code cell {index} must have execution_count=null")
+
+        for pattern, message in FORBIDDEN_CODE_PATTERNS:
+            if pattern.search(source):
+                errors.append(f"{path}: code cell {index}: {message}")
+
+        if source.strip():
+            try:
+                imported_modules.update(package_imports(source))
+            except SyntaxError as exc:
+                errors.append(f"{path}: code cell {index} is not plain Python: {exc.msg}")
+
+    all_source = "\n".join(combined_source)
+    has_package_reference = any(token in all_source for token in PACKAGE_REFERENCES)
+    has_cli_reference = "rag-eval" in all_source
+    if not (has_package_reference or has_cli_reference):
+        errors.append(f"{path}: notebook must reference package APIs or a registered CLI")
+
+    pyproject = (project_root / "pyproject.toml").read_text(encoding="utf-8")
+    if has_cli_reference and 'rag-eval     = "msmarco_genqa.cli.rag_eval:main"' not in pyproject:
+        errors.append(f"{path}: references rag-eval, but the CLI is not registered")
+
+    for module in sorted(imported_modules):
+        if importlib.util.find_spec(module) is None:
+            errors.append(f"{path}: imported module is not available: {module}")
+
+    return errors
+
+
+def discover_notebooks(root: Path) -> list[Path]:
+    """Return notebooks to validate."""
+    return sorted(root.glob("*.ipynb"))
+
+
+def check_notebooks(notebook_root: Path, *, project_root: Path) -> list[str]:
+    """Return validation errors for all notebooks under a root."""
+    notebooks = discover_notebooks(notebook_root)
+    if not notebooks:
+        return [f"{notebook_root}: no notebooks found"]
+
+    errors: list[str] = []
+    for notebook in notebooks:
+        errors.extend(check_notebook(notebook, project_root=project_root))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--notebook-root",
+        type=Path,
+        default=Path("notebooks"),
+        help="Directory containing demo notebooks.",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root used for pyproject.toml and import checks.",
+    )
+    args = parser.parse_args(argv)
+
+    errors = check_notebooks(args.notebook_root, project_root=args.project_root)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("Notebook demo checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_notebooks.py
+++ b/tests/test_check_notebooks.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+_CHECK_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_notebooks.py"
+_spec = importlib.util.spec_from_file_location("check_notebooks", _CHECK_PATH)
+check_notebooks = importlib.util.module_from_spec(_spec)
+sys.modules["check_notebooks"] = check_notebooks
+_spec.loader.exec_module(check_notebooks)  # type: ignore[union-attr]
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_pyproject(root: Path) -> None:
+    root.joinpath("pyproject.toml").write_text(
+        '[project.scripts]\nrag-eval     = "msmarco_genqa.cli.rag_eval:main"\n',
+        encoding="utf-8",
+    )
+
+
+def _write_notebook(path: Path, cells: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _markdown(source: str) -> dict:
+    return {"cell_type": "markdown", "metadata": {}, "source": source}
+
+
+def _code(source: str, *, outputs: list | None = None, execution_count=None) -> dict:
+    return {
+        "cell_type": "code",
+        "execution_count": execution_count,
+        "metadata": {},
+        "outputs": outputs or [],
+        "source": source,
+    }
+
+
+def test_current_notebooks_pass_demo_checks():
+    assert check_notebooks.check_notebooks(
+        PROJECT_ROOT / "notebooks",
+        project_root=PROJECT_ROOT,
+    ) == []
+
+
+def test_rejects_stored_outputs(tmp_path: Path):
+    _write_pyproject(tmp_path)
+    notebook = _write_notebook(
+        tmp_path / "notebooks" / "demo.ipynb",
+        [
+            _markdown("Use `rag-eval run --dry-run`."),
+            _code(
+                "from msmarco_genqa.rag_eval import build_rag_eval_plan\n",
+                outputs=[{"output_type": "stream", "text": "hello"}],
+            ),
+        ],
+    )
+
+    errors = check_notebooks.check_notebook(notebook, project_root=tmp_path)
+
+    assert any("must not store outputs" in error for error in errors)
+
+
+def test_rejects_heavy_model_loading(tmp_path: Path):
+    _write_pyproject(tmp_path)
+    notebook = _write_notebook(
+        tmp_path / "notebooks" / "demo.ipynb",
+        [
+            _markdown("Thin demo over package APIs."),
+            _code(
+                "from msmarco_genqa.rag_eval import build_rag_eval_plan\n"
+                "model = AutoModel.from_pretrained('example')\n"
+            ),
+        ],
+    )
+
+    errors = check_notebooks.check_notebook(notebook, project_root=tmp_path)
+
+    assert any("model loading belongs in package code" in error for error in errors)
+
+
+def test_rejects_missing_package_or_cli_reference(tmp_path: Path):
+    _write_pyproject(tmp_path)
+    notebook = _write_notebook(
+        tmp_path / "notebooks" / "demo.ipynb",
+        [_markdown("A prose-only notebook."), _code("x = 1\n")],
+    )
+
+    errors = check_notebooks.check_notebook(notebook, project_root=tmp_path)
+
+    assert any("must reference package APIs" in error for error in errors)


### PR DESCRIPTION
## Summary
- add a notebook validation script that keeps notebooks parseable, output-free, and lightweight
- reject shell or magic cells, benchmark downloads, model loading, network calls, and index IO in notebooks
- wire the check into Makefile, CI, README, and the evaluation protocol

## Local checks
- python -m pip install -e .
- python scripts/check_notebooks.py
- python -m pytest -q tests/test_check_notebooks.py
- python -m ruff check scripts/check_notebooks.py tests/test_check_notebooks.py
- python -m ruff check src tests experiments scripts
- python scripts/check_headline_metrics.py
- python scripts/export_report_tables.py
- git diff --exit-code reports/generated/tables
- python -m pytest -q
- git diff --check

Closes #82