### PR TITLE
Refresh Python test and lint tooling pins

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -59,5 +59,5 @@ sacrebleu==2.6.0
 nltk==3.9.4
 
 # --- Testing / lint ---
-pytest==9.0.3
-ruff==0.15.16
+pytest==9.1.0
+ruff==0.15.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ bert_score>=0.3.13            # semantic-proxy generation eval (sanity check)
 #   pip install -e ".[tracking]"
 
 # Testing
-pytest>=7.0
+pytest>=9.1.0


### PR DESCRIPTION
﻿## Summary

- Update the pinned pytest version to 9.1.0 and align the testing lower bound.
- Update the pinned Ruff version to 0.15.17.
- Keep model, retrieval, and generation dependencies unchanged.

## Validation

- python -m pip install --dry-run -r requirements-lock.txt
- python -m pip install pytest==9.1.0 ruff==0.15.17
- python -m pip install -e .
- python -m ruff --version
- python -m pytest --version
- python scripts/check_headline_metrics.py
- python scripts/check_notebooks.py
- python -m ruff check src tests experiments scripts
- python scripts/export_report_tables.py
- git diff --exit-code reports/generated/tables
- python -m pytest -q
- git diff --check

Supersedes #93 and #94.
Closes #101
