### PR TITLE
Add fixture headline metric regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check headline metric metadata
         run: python scripts/check_headline_metrics.py
 
+      - name: Check fixture headline metric goldens
+        run: python scripts/check_fixture_headline_metrics.py
+
       - name: Check lockfile resolver consistency
         run: python -m pip install --dry-run -r requirements-lock.txt
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results check-lockfile check-notebooks export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-baseline
+.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-baseline
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -17,6 +17,7 @@ help:
 	@echo "  make test-slow            -- include slow tests (HF metric scripts; skipped if offline)"
 	@echo "  make lint                 -- ruff check on src/, tests/, experiments/, scripts/"
 	@echo "  make check-results        -- verify metadata.json headline metrics against RESULTS.md"
+	@echo "  make check-fixture-metrics -- verify deterministic fixture metric goldens"
 	@echo "  make check-lockfile       -- dry-run the pinned lockfile resolver"
 	@echo "  make check-notebooks      -- verify notebooks stay lightweight demos"
 	@echo "  make export-report-tables -- refresh checked LaTeX table fragments"
@@ -65,6 +66,9 @@ lint:
 
 check-results:
 	$(PYTHON) scripts/check_headline_metrics.py
+
+check-fixture-metrics:
+	$(PYTHON) scripts/check_fixture_headline_metrics.py
 
 check-lockfile:
 	$(PYTHON) -m pip install --dry-run -r requirements-lock.txt

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ auditing the experiments:
   short CPU generation, and checks a normalized embedding shape. Use it before
   accepting torch / transformers / sentence-transformers upgrades.
 - **CI and automation.** The GitHub Actions workflow runs unit tests, linting,
-  and manifest/reproduction checks; the local mirror is `make test` and
-  `make lint`.
+  deterministic fixture metric goldens, and manifest/reproduction checks; the
+  local mirror is `make test`, `make lint`, and `make check-fixture-metrics`.
 - **Run metadata.** Major runners write `manifest.json`, `resolved_config.yaml`,
   metrics, output hashes, config hashes, git commit, dependency fingerprints,
   and sampling metadata.

--- a/docs/evaluation_protocol.md
+++ b/docs/evaluation_protocol.md
@@ -128,6 +128,31 @@ Grounding metrics:
 - n-gram grounding
 - optional NLI entailment
 
+## CI Fixture Metric Gate
+
+The default CI suite includes a deterministic numeric regression gate:
+
+```bash
+python scripts/check_fixture_headline_metrics.py
+```
+
+The gate reads `tests/fixtures/headline_regression/config.json`, reuses the
+committed TREC-DL fixture run, and computes three CPU-only headline checks:
+`retrieval.mrr@10`, `generation.mean_token_f1`, and
+`grounding.mean_lexical_content_token_grounding`. Expected values and
+tolerances live in `tests/fixtures/headline_regression/golden.json`.
+
+If a deliberate metric-code change moves these values, inspect the proposed
+numbers with:
+
+```bash
+python scripts/check_fixture_headline_metrics.py --dump-observed
+```
+
+Then edit `golden.json` in the same pull request as the metric-code change.
+The script never overwrites goldens automatically; golden updates must be
+reviewable diffs.
+
 RAG triad:
 
 - context relevance

--- a/scripts/check_fixture_headline_metrics.py
+++ b/scripts/check_fixture_headline_metrics.py
@@ -1,0 +1,158 @@
+"""Check deterministic fixture headline metrics against committed goldens."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from msmarco_genqa.data.trec_dl import load_trec_dl_from_files
+from msmarco_genqa.evaluation.generation import token_f1
+from msmarco_genqa.evaluation.grounding import lexical_grounding
+from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
+from msmarco_genqa.evaluation.retrieval_report import read_run_doc_ids
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = PROJECT_ROOT / "tests/fixtures/headline_regression/config.json"
+DEFAULT_GOLDEN = PROJECT_ROOT / "tests/fixtures/headline_regression/golden.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_project_path(path_text: str) -> Path:
+    path = Path(path_text)
+    if path.is_absolute():
+        return path
+    return PROJECT_ROOT / path
+
+
+def _mean(values: list[float], *, name: str) -> float:
+    if not values:
+        raise ValueError(f"{name} has no examples")
+    return sum(values) / len(values)
+
+
+def compute_observed(config: dict[str, Any]) -> dict[str, float]:
+    resolved = config["resolved_config"]
+
+    retrieval_cfg = resolved["retrieval"]
+    retrieval_bundle = load_trec_dl_from_files(
+        _resolve_project_path(retrieval_cfg["queries_path"]),
+        _resolve_project_path(retrieval_cfg["qrels_path"]),
+        year=2019,
+        rel_threshold=int(retrieval_cfg["rel_threshold"]),
+    )
+    run_doc_ids = read_run_doc_ids(_resolve_project_path(retrieval_cfg["run_path"]))
+    retrieval_metrics = evaluate_retrieval(
+        run_doc_ids,
+        retrieval_bundle.qrels,
+        ks_mrr=tuple(int(k) for k in retrieval_cfg["ks_mrr"]),
+        ks_ndcg=(),
+        ks_recall=(),
+    )
+
+    examples = config["generation_examples"]
+    token_f1_scores = [
+        token_f1(example["prediction"], example["references"])
+        for example in examples
+    ]
+    lexical_grounding_scores = [
+        lexical_grounding(example["prediction"], example["passages"])
+        for example in examples
+    ]
+
+    return {
+        "retrieval.mrr@10": float(retrieval_metrics["mrr@10"]),
+        "generation.mean_token_f1": _mean(token_f1_scores, name="generation_examples"),
+        "grounding.mean_lexical_content_token_grounding": _mean(
+            lexical_grounding_scores,
+            name="generation_examples",
+        ),
+    }
+
+
+def compare_to_golden(
+    observed: dict[str, float],
+    golden: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    for name, spec in sorted(golden["metrics"].items()):
+        if name not in observed:
+            failures.append(f"{name}: missing observed value")
+            continue
+        expected = float(spec["expected"])
+        tolerance = float(spec["tolerance"])
+        actual = float(observed[name])
+        delta = actual - expected
+        if abs(delta) > tolerance:
+            failures.append(
+                f"{name}: expected {expected:.12g} +/- {tolerance:.3g}, "
+                f"observed {actual:.12g}, delta {delta:+.12g}"
+            )
+    unexpected = sorted(set(observed) - set(golden["metrics"]))
+    for name in unexpected:
+        failures.append(f"{name}: observed metric has no golden entry")
+    return failures
+
+
+def observed_payload(config: dict[str, Any], observed: dict[str, float]) -> dict[str, Any]:
+    return {
+        "schema": "msmarco-genqa.headline-regression-observed.v1",
+        "source_config_schema": config.get("schema"),
+        "seed": config.get("seed"),
+        "metrics": {
+            name: {"expected": value, "tolerance": 1e-12}
+            for name, value in sorted(observed.items())
+        },
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare deterministic fixture headline metrics against committed goldens.",
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--golden", type=Path, default=DEFAULT_GOLDEN)
+    parser.add_argument(
+        "--dump-observed",
+        action="store_true",
+        help="Print observed metrics as JSON for review; do not overwrite goldens.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = _load_json(args.config)
+    observed = compute_observed(config)
+
+    if args.dump_observed:
+        print(json.dumps(observed_payload(config, observed), indent=2, sort_keys=True))
+        return 0
+
+    golden = _load_json(args.golden)
+    failures = compare_to_golden(observed, golden)
+    if failures:
+        print("Fixture headline metric regression check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(
+            "Run `python scripts/check_fixture_headline_metrics.py --dump-observed` "
+            "to inspect proposed values before editing the golden file.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Fixture headline metric regression check passed")
+    for name, value in sorted(observed.items()):
+        print(f"  {name}: {value:.12g}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/headline_regression/config.json
+++ b/tests/fixtures/headline_regression/config.json
@@ -1,0 +1,55 @@
+{
+  "schema": "msmarco-genqa.headline-regression-fixture.v1",
+  "seed": 42,
+  "description": "Tiny deterministic fixture for CI headline-metric regression checks.",
+  "resolved_config": {
+    "retrieval": {
+      "queries_path": "tests/fixtures/trec_dl/queries_2019.tsv",
+      "qrels_path": "tests/fixtures/trec_dl/qrels_2019.txt",
+      "run_path": "tests/fixtures/trec_dl/run_2019.tsv",
+      "rel_threshold": 2,
+      "ks_mrr": [
+        10
+      ]
+    },
+    "generation": {
+      "metric": "token_f1",
+      "normalization": "squad_style"
+    },
+    "grounding": {
+      "metric": "lexical_content_token_grounding"
+    }
+  },
+  "generation_examples": [
+    {
+      "qid": "19335",
+      "prediction": "durable medical equipment includes wheelchairs",
+      "references": [
+        "durable medical equipment includes wheelchairs"
+      ],
+      "passages": [
+        "Durable medical equipment includes wheelchairs and hospital beds."
+      ]
+    },
+    {
+      "qid": "1037798",
+      "prediction": "Robert Gray is a British poet",
+      "references": [
+        "Robert Gray is an Australian poet"
+      ],
+      "passages": [
+        "Robert Gray is an Australian poet known for landscapes."
+      ]
+    },
+    {
+      "qid": "104861",
+      "prediction": "Concrete flooring costs five dollars per square foot",
+      "references": [
+        "Concrete flooring costs five dollars per square foot"
+      ],
+      "passages": [
+        "Interior concrete flooring costs five dollars per square foot for basic finishes."
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/headline_regression/golden.json
+++ b/tests/fixtures/headline_regression/golden.json
@@ -1,0 +1,19 @@
+{
+  "schema": "msmarco-genqa.headline-regression-golden.v1",
+  "source_config": "tests/fixtures/headline_regression/config.json",
+  "seed": 42,
+  "metrics": {
+    "retrieval.mrr@10": {
+      "expected": 0.5,
+      "tolerance": 1e-12
+    },
+    "generation.mean_token_f1": {
+      "expected": 0.9333333333333332,
+      "tolerance": 1e-12
+    },
+    "grounding.mean_lexical_content_token_grounding": {
+      "expected": 0.9166666666666666,
+      "tolerance": 1e-12
+    }
+  }
+}

--- a/tests/test_fixture_headline_metrics.py
+++ b/tests/test_fixture_headline_metrics.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+_CHECK_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "check_fixture_headline_metrics.py"
+)
+_spec = importlib.util.spec_from_file_location("check_fixture_headline_metrics", _CHECK_PATH)
+check_fixture_headline_metrics = importlib.util.module_from_spec(_spec)
+sys.modules["check_fixture_headline_metrics"] = check_fixture_headline_metrics
+_spec.loader.exec_module(check_fixture_headline_metrics)  # type: ignore[union-attr]
+
+
+def test_fixture_metrics_match_committed_goldens():
+    config = check_fixture_headline_metrics._load_json(
+        check_fixture_headline_metrics.DEFAULT_CONFIG
+    )
+    golden = check_fixture_headline_metrics._load_json(
+        check_fixture_headline_metrics.DEFAULT_GOLDEN
+    )
+    observed = check_fixture_headline_metrics.compute_observed(config)
+    assert check_fixture_headline_metrics.compare_to_golden(observed, golden) == []
+
+
+def test_fixture_metric_drift_is_reported():
+    config = check_fixture_headline_metrics._load_json(
+        check_fixture_headline_metrics.DEFAULT_CONFIG
+    )
+    golden = check_fixture_headline_metrics._load_json(
+        check_fixture_headline_metrics.DEFAULT_GOLDEN
+    )
+    drifted = copy.deepcopy(golden)
+    drifted["metrics"]["generation.mean_token_f1"]["expected"] = 0.0
+
+    observed = check_fixture_headline_metrics.compute_observed(config)
+    failures = check_fixture_headline_metrics.compare_to_golden(observed, drifted)
+
+    assert len(failures) == 1
+    assert "generation.mean_token_f1" in failures[0]
+    assert "observed" in failures[0]
+
+
+def test_dump_observed_does_not_modify_goldens(capsys):
+    before = check_fixture_headline_metrics.DEFAULT_GOLDEN.read_text(encoding="utf-8")
+
+    rc = check_fixture_headline_metrics.main(["--dump-observed"])
+
+    after = check_fixture_headline_metrics.DEFAULT_GOLDEN.read_text(encoding="utf-8")
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert before == after
+    assert payload["seed"] == 42
+    assert "retrieval.mrr@10" in payload["metrics"]


### PR DESCRIPTION
﻿## Summary

- Add a deterministic fixture headline-metric regression gate for retrieval, generation, and grounding scores.
- Commit versioned fixture config and golden tolerances for the gate.
- Wire the gate into CI, Makefile, README, and the evaluation protocol update procedure.

## Validation

- python scripts/check_fixture_headline_metrics.py
- python scripts/check_fixture_headline_metrics.py --dump-observed
- python -m pytest -q tests/test_fixture_headline_metrics.py
- python -m ruff check src tests experiments scripts
- python scripts/check_headline_metrics.py
- python scripts/check_notebooks.py
- python -m pip install --dry-run -r requirements-lock.txt
- python -m pytest -q
- python scripts/export_report_tables.py
- git diff --exit-code reports/generated/tables
- git diff --check

Closes #99
