### PR TITLE
Refresh Python test and lint patch pins

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -59,5 +59,5 @@ sacrebleu==2.6.0
 nltk==3.9.4
 
 # --- Testing / lint ---
-pytest==9.1.0
-ruff==0.15.17
+pytest==9.1.1
+ruff==0.15.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ bert_score>=0.3.13            # semantic-proxy generation eval (sanity check)
 #   pip install -e ".[tracking]"
 
 # Testing
-pytest>=9.1.0
+pytest>=9.1.1


### PR DESCRIPTION
Summary: refresh pytest from 9.1.0 to 9.1.1 and ruff from 0.15.17 to 0.15.18, keeping the runtime test floor and lockfile pins aligned. Validation: python -m pip install --dry-run -r requirements-lock.txt; python -m pip install pytest==9.1.1 ruff==0.15.18; python -m pip install -e .; python scripts/check_fixture_headline_metrics.py; python scripts/check_headline_metrics.py; python scripts/check_notebooks.py; python -m ruff check src tests experiments scripts; python scripts/export_report_tables.py; git diff --exit-code reports/generated/tables; python -m pytest -q; git diff --check. Closes #104.