### PR TITLE
Refresh safetensors lockfile pin

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -50,7 +50,7 @@ transformers==5.10.2
 # 0.23.0 has no stable release, so keep the latest stable compatible pin.
 tokenizers==0.22.2
 sentencepiece==0.2.1
-safetensors==0.7.0
+safetensors==0.8.0
 
 # --- Evaluation ---
 evaluate==0.4.6


### PR DESCRIPTION
Summary: update the safetensors lockfile pin from 0.7.0 to 0.8.0 for the transformers stack. Validation: python -m pip install --dry-run -r requirements-lock.txt; python -m pip install safetensors==0.8.0; python -c import/version smoke; safetensors.torch save/load roundtrip smoke; python -m pip install -e .; python scripts/check_fixture_headline_metrics.py; python scripts/check_headline_metrics.py; python scripts/check_notebooks.py; python -m ruff check src tests experiments scripts; python scripts/export_report_tables.py; git diff --exit-code reports/generated/tables; python -m pytest -q; git diff --check. Closes #106.