### PR TITLE
Refresh faiss-cpu lockfile pin

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -41,7 +41,7 @@ bm25s==0.3.9
 
 # --- Dense retrieval ---
 sentence-transformers==5.5.1
-faiss-cpu==1.13.0
+faiss-cpu==1.14.3
 
 # --- Generation / reranking (transformers stack) ---
 torch==2.12.0


### PR DESCRIPTION
Summary: update the faiss-cpu lockfile pin from 1.13.0 to 1.14.3 for dense retrieval. Validation: python -m pip install --dry-run -r requirements-lock.txt; python -m pip install faiss-cpu==1.14.3; python -c import/version smoke; FAISS IndexFlatIP add/search and write/read_index smoke; python -m pip install -e .; python scripts/check_fixture_headline_metrics.py; python scripts/check_headline_metrics.py; python scripts/check_notebooks.py; python -m ruff check src tests experiments scripts; python scripts/export_report_tables.py; git diff --exit-code reports/generated/tables; python -m pytest -q; git diff --check. Closes #108.