### PR TITLE
Refresh transformers lockfile pin

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -45,9 +45,9 @@ faiss-cpu==1.14.3
 
 # --- Generation / reranking (transformers stack) ---
 torch==2.12.0
-transformers==5.10.2
-# transformers 5.10.x requires tokenizers >=0.22.0 and <=0.23.0;
-# 0.23.0 has no stable release, so keep the latest stable compatible pin.
+transformers==5.12.1
+# Keep tokenizers on the latest stable 0.22.x pin accepted by the
+# transformers stack; 0.23.0 has no stable release.
 tokenizers==0.22.2
 sentencepiece==0.2.1
 safetensors==0.8.0


### PR DESCRIPTION
Summary: update the transformers lockfile pin from 5.10.2 to 5.12.1 and refresh the adjacent tokenizers compatibility note so it is no longer tied to the old minor version. Validation: python -m pip install --dry-run -r requirements-lock.txt; python -m pip install transformers==5.12.1 tokenizers==0.22.2; transformers/tokenizers import and version smoke; tiny local T5ForConditionalGeneration instantiation smoke; python scripts/smoke_model_stack.py --skip-generation --skip-dense; python -m pip install -e .; python scripts/check_fixture_headline_metrics.py; python scripts/check_headline_metrics.py; python scripts/check_notebooks.py; python -m ruff check src tests experiments scripts; python scripts/export_report_tables.py; git diff --exit-code reports/generated/tables; python -m pytest -q; git diff --check. Closes #110.