### PR TITLE
Update ir-datasets lockfile pin

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -32,7 +32,7 @@ PyYAML==6.0.3
 
 # --- Datasets and IO ---
 datasets==5.0.0
-ir_datasets==0.5.11
+ir_datasets==0.6.1
 lxml==6.1.1
 
 # --- Lexical retrieval ---


### PR DESCRIPTION
## Summary
- Update the direct ir_datasets lockfile pin from 0.5.11 to 0.6.1.
- Keep the loose dependency list unchanged.

## Validation
- git diff --check
- python -m pip install --dry-run -r requirements-lock.txt
- python -m pip install ir_datasets==0.6.1
- MS MARCO dataset-handle smoke: loaded msmarco-passage/dev/small and checked docs/queries/qrels counts plus iterator availability
- python scripts/check_fixture_headline_metrics.py
- python scripts/check_headline_metrics.py
- python scripts/check_notebooks.py
- python -m ruff check src tests experiments scripts
- python -m pytest -q --basetemp=... -p no:cacheprovider

Closes #121.
Supersedes #117.