### PR TITLE
Clarify report and artifact naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ manifests, config-driven runners, query-level diagnostics, CI checks, report
 artifacts, and reproducibility notes alongside the code. Detailed experiment
 notes live in [`docs/experiments.md`](docs/experiments.md); the result summary
 is [`RESULTS.md`](RESULTS.md); reproducibility entry points are documented in
-[`REPRODUCIBILITY.md`](REPRODUCIBILITY.md); the ACL-style write-up is
+[`REPRODUCIBILITY.md`](REPRODUCIBILITY.md); the current repository report is
+[`reports/repo_report/report.pdf`](reports/repo_report/report.pdf), with
+[`report.html`](reports/repo_report/report.html) kept alongside it; the compact
+ACL-style findings write-up is
 [`reports/acl_findings/report.pdf`](reports/acl_findings/report.pdf).
 
 ## Results at a glance
@@ -45,7 +48,8 @@ is [`RESULTS.md`](RESULTS.md); reproducibility entry points are documented in
 
 The repository includes runnable code plus written analysis artifacts:
 
-- [`reports/acl_findings/report.pdf`](reports/acl_findings/report.pdf) — compact ACL-style experimental report.
+- [`reports/repo_report/report.pdf`](reports/repo_report/report.pdf) / [`report.html`](reports/repo_report/report.html) — repository report with the current engineering surface and historical experiment results.
+- [`reports/acl_findings/report.pdf`](reports/acl_findings/report.pdf) — compact ACL-style experimental findings report.
 - [`RESULTS.md`](RESULTS.md) — headline metrics, statistical intervals, and interpretation limits.
 - [`REPRODUCIBILITY.md`](REPRODUCIBILITY.md) — setup, checks, run artifacts, and reproduction commands.
 - [`docs/experiments.md`](docs/experiments.md) — stage-by-stage experiment narrative and caveats.
@@ -58,7 +62,6 @@ The repository includes runnable code plus written analysis artifacts:
 - [`docs/rag_triad_evaluation.md`](docs/rag_triad_evaluation.md) — context relevance, groundedness, and answer relevance report protocol.
 - [`docs/input_validation.md`](docs/input_validation.md) — run-file, JSONL, prompt, and serving input validation contract.
 - [`notebooks/rag_eval_demo.ipynb`](notebooks/rag_eval_demo.ipynb) — lightweight evaluation workflow demo.
-- [`reports/repo_report/report.pdf`](reports/repo_report/report.pdf) / [`report.html`](reports/repo_report/report.html) — repository report with the current engineering surface and historical experiment results.
 
 ## Engineering surface
 
@@ -141,6 +144,11 @@ auditing the experiments:
   headline metrics, CI, tracking, and serving support.
 
 See [§2 Directory layout](#2-directory-layout) for the full breakdown.
+
+User-facing experiment sections use compact W-stage aliases only as
+chronological report labels. Filesystem artifacts use descriptive directory
+names such as `outputs/bm25_baseline/`, `outputs/dense_retrieval/`, and
+`outputs/cross_encoder_rerank/`.
 
 Refresh report table fragments after metrics artifacts change:
 
@@ -778,11 +786,10 @@ All knobs live in [`configs/baseline.yaml`](configs/baseline.yaml). Key ones:
 | Artifact manifest | wired | `src/msmarco_genqa/util/manifest.py` writes `outputs/<stage>/manifest.json` alongside `metrics.json`. Captures git commit + dirty flag, command, config hash, dependency-file hashes, per-output sha256 (truncated). |
 | Historical experiment numbers in `reports/repo_report/report.pdf` | historical | Reflect the dev environment at tag `v1.0-first-report`. Current dependencies are security-refreshed; use the first-report tag for archival reproduction. |
 
-**Historical output-path naming.** Historical snapshot anchors now use
-stage-oriented names such as `outputs/bm25_baseline/`, `outputs/dense_retrieval/`,
-and `outputs/cross_encoder_rerank/`. Their committed `provenance.backfill.json`
-files remain the archival reproduction anchors for tag
-`v1.0-first-report`.
+**Artifact path naming.** Current snapshot anchors use descriptive stage names
+such as `outputs/bm25_baseline/`, `outputs/dense_retrieval/`, and
+`outputs/cross_encoder_rerank/`. Their committed `provenance.backfill.json`
+files remain the archival reproduction anchors for tag `v1.0-first-report`.
 
 Limitations to be aware of:
 

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -122,5 +122,6 @@ Use these comparisons as:
 ## Reported Results
 
 The main result summary is in `RESULTS.md`. Stage-by-stage experiment notes
-are in `docs/experiments.md`, and the compact paper-style write-up is in
-`reports/acl_findings/report.pdf`.
+are in `docs/experiments.md`, the repository report is in
+`reports/repo_report/report.pdf`, and the compact paper-style findings write-up
+is in `reports/acl_findings/report.pdf`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,10 @@ Important outputs:
 - `outputs/dense_retrieval/run.tsv`
 - `outputs/cross_encoder_rerank/run.tsv`
 
+Report prose may use compact W-stage aliases for chronological milestones, but
+artifact directories should stay descriptive and stage-oriented. The directory
+name is the reproducibility contract; the W label is only a report shortcut.
+
 The dense stage uses a qrels-anchored sample. Absolute dense metrics should
 not be compared against full-corpus BM25; only same-sample comparisons are
 valid.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -11,6 +11,10 @@ update some downstream numbers is flagged inline as **In flight**.
 Provenance for each number (commit hash, manifest) is recorded under
 *Reproducing the experiment line* at the bottom.
 
+This document uses Stage 1, Stage 2, and so on for runnable pipeline stages.
+The longer repository report may use W-stage aliases for chronological analysis
+milestones, while output directories stay descriptive and reproducibility-first.
+
 ## Pipeline overview
 
 ```
@@ -358,7 +362,7 @@ loose [`requirements.txt`](../requirements.txt). Historical report
 numbers are tied to the frozen tag below; dependency refreshes should be
 accepted only after rerunning the relevant checks or smoke tests.
 
-The frozen reference snapshot is
+The first reference snapshot is
 [`reports/repo_report/report.pdf`](../reports/repo_report/report.pdf)
-at tag `v1.0-first-report`; numbers in this document supersede that
-snapshot only where annotated **In flight**.
+at tag `v1.0-first-report`; numbers in this document supersede that snapshot
+only where annotated **In flight**.


### PR DESCRIPTION
## Summary

- Promote the repository report to the primary report reference in README and reproducibility docs.
- Document the current convention: W-stage aliases are report labels, while artifact directories use descriptive names.
- Reword the archival snapshot note around `v1.0-first-report`.

## Checks

- `git diff --check`
- strict text scan for legacy report and stage naming traces
- UTF-8 replacement/mojibake scan on touched docs
- `python scripts/check_secrets.py`
- `ruff check .`
- `pytest -q`

Closes #132