### PR TITLE
chore: align lint target with supported Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ markers = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 extend-exclude = [
     "data",
     "outputs",


### PR DESCRIPTION
## Why

The project now requires Python 3.10 or newer, but the ruff configuration still targeted Python 3.9. Aligning the lint target keeps static analysis consistent with the supported runtime floor.

Refs #50.

## What changed

- Set 	ool.ruff.target-version to py310 in pyproject.toml.

## Validation

- C:\Users\gioia.zheng\anaconda3\Scripts\ruff.exe check --no-cache src tests experiments scripts passed.
- git diff --check passed.
- Public-file scan for tool/source-generation markers and mojibake patterns returned no matches.
- pytest -q and a focused pytest subset reached 100% locally, but the Windows Anaconda process did not return cleanly and had to be stopped; no assertion failures were printed before the hang.

## Risk / follow-up

Low risk. This changes lint parsing only and does not affect runtime code, metrics, manifests, or report artifacts. Full #50 remains open for broader ruff rule and mypy CI work.