### PR TITLE
infra: document artifact versioning boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Check demo notebooks
         run: python scripts/check_notebooks.py
 
+      - name: Check artifact boundaries
+        run: python scripts/check_artifact_boundaries.py
+
       - name: Check generated report tables
         run: |
           python scripts/export_report_tables.py

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline
+.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -20,6 +20,7 @@ help:
 	@echo "  make check-fixture-metrics -- verify deterministic fixture metric goldens"
 	@echo "  make check-lockfile       -- dry-run the pinned lockfile resolver"
 	@echo "  make check-notebooks      -- verify notebooks stay lightweight demos"
+	@echo "  make check-artifacts      -- verify large generated artifacts stay out of Git"
 	@echo "  make export-report-tables -- refresh checked LaTeX table fragments"
 	@echo "  make check-report-tables  -- verify checked LaTeX table fragments are current"
 	@echo "  make pipeline-dry-run     -- print the config-driven experiment plan"
@@ -76,6 +77,9 @@ check-lockfile:
 
 check-notebooks:
 	$(PYTHON) scripts/check_notebooks.py
+
+check-artifacts:
+	$(PYTHON) scripts/check_artifact_boundaries.py
 
 export-report-tables:
 	$(PYTHON) scripts/export_report_tables.py

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The repository includes runnable code plus written analysis artifacts:
 - [`docs/context_packing.md`](docs/context_packing.md) — prompt compression, provenance, and packed-vs-plain generation comparison.
 - [`docs/rag_triad_evaluation.md`](docs/rag_triad_evaluation.md) — context relevance, groundedness, and answer relevance report protocol.
 - [`docs/input_validation.md`](docs/input_validation.md) — run-file, JSONL, prompt, and serving input validation contract.
+- [`docs/artifact_versioning.md`](docs/artifact_versioning.md) — policy for source data, derived indexes, model outputs, and Git-tracked pointers.
 - [`docs/rag_observatory_exports.md`](docs/rag_observatory_exports.md) — trace and sweep exports for external RAG observability analysis.
 - [`notebooks/rag_eval_demo.ipynb`](notebooks/rag_eval_demo.ipynb) — lightweight evaluation workflow demo.
 

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -25,6 +25,11 @@ The project uses MS MARCO Passage Ranking / QA data through the local dataset
 cache. Raw corpus files, generated indexes, model weights, and experiment
 outputs are not committed.
 
+The repository policy for source data, derived indexes, model outputs, and
+small pointer files is documented in `docs/artifact_versioning.md`. Use
+`make check-artifacts` to verify that common large artifact formats and
+generated run payloads have not entered Git.
+
 Important scale reference:
 
 | Item | Value |
@@ -40,6 +45,7 @@ These commands are intended for local development and CI:
 ```bash
 make test
 make lint
+make check-artifacts
 python scripts/run_pipeline.py --dry-run
 ```
 

--- a/docs/artifact_versioning.md
+++ b/docs/artifact_versioning.md
@@ -1,0 +1,79 @@
+# Data and artifact versioning policy
+
+This project uses Git for source code, configuration, small fixtures,
+reports, and compact provenance records. Large MS MARCO-derived data and
+model artifacts stay outside normal commits.
+
+The goal is to keep the repository reproducible without turning Git into a
+storage backend for corpora, embedding matrices, FAISS indexes, or model
+weights.
+
+## What stays in Git
+
+| Class | Examples | Reason |
+|---|---|---|
+| Source code | `src/`, `experiments/`, `scripts/`, tests | Required to review and reproduce behavior |
+| Configuration | `configs/*.yaml`, `pyproject.toml`, lock files | Defines the run contract |
+| Small fixtures | synthetic JSONL/TSV fixtures under `tests/fixtures/` | Enables CI without network or model downloads |
+| Run metadata | manifests, resolved configs, provenance backfill JSON | Re-identifies a run without storing payloads |
+| Report outputs | checked report PDFs/HTML, generated table fragments | Keeps reported evidence auditable |
+
+## What does not stay in Git
+
+| Class | Examples | Expected handling |
+|---|---|---|
+| Raw corpora | MS MARCO passage files, qrels mirrors, local dataset cache | Managed by `ir_datasets` or a local dataset cache |
+| Derived indexes | BM25 indexes, FAISS indexes, HNSW/IVF files | Rebuilt from config and manifests, or referenced by external pointers |
+| Embeddings | `.npy`, `.npz`, memory-mapped matrices, vector shards | Stored outside Git and tied back by manifest fingerprints |
+| Model weights | HuggingFace cache, checkpoints, `.pt`, `.bin`, `.safetensors` | Resolved by model name/revision or an external artifact pointer |
+| Large generated runs | full `run.tsv`, full prediction dumps, candidate pools | Written under ignored `outputs/` paths and summarized by metrics/manifests |
+
+## Current repository contract
+
+The current default is manifest-first and local-first:
+
+1. Runners write `manifest.json`, `resolved_config.yaml`, `metrics.json`, and
+   task-specific outputs under `outputs/<run>/`.
+2. Git tracks compact provenance records and report table inputs, not full
+   generated run payloads.
+3. The manifest records code state, dependency files, config hashes, output
+   hashes, sampling metadata, and data/environment fingerprints.
+4. A reported number should be traceable to a command, config, dependency set,
+   and output directory even when the large payload itself is not committed.
+
+This is sufficient for small public fixtures and report evidence. It is not a
+complete long-term artifact backend for large indexes or model outputs.
+
+## When DVC is worth adding
+
+DVC or a similar pointer-file workflow becomes worthwhile when the project
+needs to version large artifacts across multiple comparable runs, for example:
+
+- several dense indexes built from different encoders,
+- repeated ablation sweeps with large candidate pools,
+- model checkpoints or embedding shards that must be recovered exactly,
+- shared storage across machines or collaborators.
+
+Before adding DVC as a normal dependency, the project should first prototype a
+local-only remote or dry-run workflow. The prototype should commit only small
+pointer files and should not require cloud credentials in CI.
+
+For small fixtures, report tables, and manifest JSON, the existing Git plus
+manifest workflow remains simpler and more reviewable than DVC.
+
+## Guardrail
+
+Use:
+
+```bash
+make check-artifacts
+```
+
+The check scans tracked files and fails if common large artifact formats or
+data/output payloads are staged for Git. It is intentionally conservative: it
+does not inspect ignored local caches, and it does not require DVC to be
+installed.
+
+This guardrail is a repository hygiene check, not a storage system. A future
+DVC or object-store workflow should still preserve the existing manifest
+contract so code, data, and reported metrics remain connected.

--- a/scripts/check_artifact_boundaries.py
+++ b/scripts/check_artifact_boundaries.py
@@ -1,0 +1,132 @@
+"""Check that large generated artifacts stay out of Git."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+DISALLOWED_SUFFIXES = {
+    ".arrow",
+    ".bin",
+    ".faiss",
+    ".feather",
+    ".h5",
+    ".hdf5",
+    ".index",
+    ".npy",
+    ".npz",
+    ".onnx",
+    ".parquet",
+    ".pickle",
+    ".pkl",
+    ".pt",
+    ".pth",
+    ".safetensors",
+}
+
+DATA_PREFIXES = (
+    "data/raw/",
+    "data/processed/",
+    "data/cache/",
+)
+
+ALLOWED_EXACT = {
+    "data/raw/.gitkeep",
+    "data/processed/.gitkeep",
+    "data/cache/.gitkeep",
+    "outputs/.gitkeep",
+    "reports/generated/.gitkeep",
+}
+
+
+def tracked_files(project_root: Path) -> list[str]:
+    """Return tracked repository paths using forward slashes."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=project_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return [
+        entry.replace("\\", "/")
+        for entry in result.stdout.decode("utf-8").split("\0")
+        if entry
+    ]
+
+
+def is_allowed_output_pointer(path: str) -> bool:
+    """Return whether a tracked outputs/ file is intentionally small metadata."""
+    return path == "outputs/.gitkeep" or path.endswith("/provenance.backfill.json")
+
+
+def check_paths(
+    paths: list[str],
+    *,
+    project_root: Path,
+    max_pointer_bytes: int,
+) -> list[str]:
+    """Return artifact-boundary violations for tracked paths."""
+    errors: list[str] = []
+
+    for path in paths:
+        if path in ALLOWED_EXACT:
+            continue
+
+        file_path = project_root / path
+        suffix = file_path.suffix.lower()
+
+        if path.startswith(DATA_PREFIXES):
+            errors.append(f"{path}: data payloads must stay outside Git")
+            continue
+
+        if path.startswith("outputs/") and not is_allowed_output_pointer(path):
+            errors.append(f"{path}: generated run payloads must stay outside Git")
+            continue
+
+        if suffix in DISALLOWED_SUFFIXES:
+            errors.append(f"{path}: {suffix} artifacts must stay outside Git")
+            continue
+
+        if suffix == ".dvc" and file_path.stat().st_size > max_pointer_bytes:
+            errors.append(f"{path}: DVC pointer files must stay small")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root to inspect.",
+    )
+    parser.add_argument(
+        "--max-pointer-bytes",
+        type=int,
+        default=250_000,
+        help="Maximum size for pointer files such as .dvc records.",
+    )
+    args = parser.parse_args(argv)
+
+    project_root = args.project_root.resolve()
+    errors = check_paths(
+        tracked_files(project_root),
+        project_root=project_root,
+        max_pointer_bytes=args.max_pointer_bytes,
+    )
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("Artifact boundary checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Large MS MARCO-derived artifacts such as indexes, embeddings, cached corpora, and model weights should not enter normal Git history. Issue #123 tracks the broader artifact-versioning plan; this PR adds the first repository-level policy and a lightweight guardrail without introducing DVC or remote storage credentials.

Refs #123.

## What changed

- Added docs/artifact_versioning.md to separate Git-tracked files, external artifacts, and future pointer-file workflows.
- Added scripts/check_artifact_boundaries.py to fail on tracked data/output payloads and common large artifact formats.
- Added make check-artifacts and wired the check into CI.
- Linked the policy from README.md and REPRODUCIBILITY.md.

## Validation

- python scripts/check_artifact_boundaries.py passed.
- C:\Users\gioia.zheng\anaconda3\Scripts\ruff.exe check --no-cache src tests experiments scripts passed.
- git diff --cached --check passed.
- Public-file scan for tool/source-generation markers and replacement characters returned no matches.

## Risk / follow-up

Low risk. This PR adds documentation and a repository hygiene check only; it does not change runtime code, dependencies, metrics, manifests, or report artifacts. The remaining #123 work is to prototype a local pointer-file or object-store workflow before adopting DVC or any cloud-backed storage.