### PR TITLE
Integrate TREC-DL retrieval runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,25 @@ Console names: `mgq-transform-queries`, `mgq-query-transform-ablation`,
 `mgq-rerank`, `mgq-generate`, `mgq-trec-eval`.
 The examples below use the script form.
 
+### TREC-DL 2019/2020 full-corpus retrieval
+
+The BM25 and cross-encoder runners accept the judged TREC-DL passage tracks
+without changing the shared MS MARCO corpus index or model configuration:
+
+```bash
+mgq-retrieve --dataset msmarco-passage/trec-dl-2019/judged --resume
+mgq-rerank --dataset msmarco-passage/trec-dl-2019/judged --resume
+
+mgq-retrieve --dataset msmarco-passage/trec-dl-2020/judged --resume
+mgq-rerank --dataset msmarco-passage/trec-dl-2020/judged --resume
+```
+
+The default outputs are separated under `outputs/trec_dl_2019/` and
+`outputs/trec_dl_2020/`. These commands currently preserve the established
+binary metric view at relevance threshold 2; graded nDCG and its independent
+evaluator cross-check are a separate evaluation step. See
+[`docs/trec_dl_external_validity.md`](docs/trec_dl_external_validity.md).
+
 ### Independent TREC metric cross-check
 
 Install the optional standard evaluator and export the MS MARCO dev/small

--- a/docs/trec_dl_external_validity.md
+++ b/docs/trec_dl_external_validity.md
@@ -28,7 +28,34 @@ use the **same schema as the MS MARCO loader**, so the existing
 `evaluate_retrieval` / `mrr@k` / `ndcg@k` / `recall@k` functions in
 `msmarco_genqa.evaluation.retrieval` run on them unchanged. The full graded
 labels are additionally preserved on `graded_qrels`
-(`{qid: {doc_id: label}}`) for future graded-nDCG work.
+(`{qid: {doc_id: label}}`) for the graded evaluation work tracked in #153.
+
+## Full-corpus runner commands
+
+Both tracks are first-class options on the existing BM25 and cross-encoder
+runners. They reuse the same full MS MARCO passage index; only the selected
+queries and qrels change.
+
+```bash
+# TREC-DL 2019
+mgq-retrieve --dataset msmarco-passage/trec-dl-2019/judged --resume
+mgq-rerank --dataset msmarco-passage/trec-dl-2019/judged --resume
+
+# TREC-DL 2020
+mgq-retrieve --dataset msmarco-passage/trec-dl-2020/judged --resume
+mgq-rerank --dataset msmarco-passage/trec-dl-2020/judged --resume
+```
+
+Default outputs are isolated by track:
+
+- `outputs/trec_dl_2019/bm25` and
+  `outputs/trec_dl_2019/cross_encoder_rerank`
+- `outputs/trec_dl_2020/bm25` and
+  `outputs/trec_dl_2020/cross_encoder_rerank`
+
+Each `metrics.json` and manifest records the dataset id, track year, judged
+topic count, corpus scope, and upstream run. The existing dev/small defaults
+remain unchanged when `--dataset` is omitted.
 
 ## Judgment depth and binarization
 
@@ -72,6 +99,9 @@ suite never depends on a multi-gigabyte download.
 
 ## Scope note
 
-This adds the loaders and the metric wiring only. The full multi-encoder
-calibration sweep over these deep qrels (many dense encoders × k-values ×
-sampling strategies) is GPU-bound and stays out of scope here.
+The runner integration deliberately keeps the BM25 tokenizer, full-corpus
+index, cross-encoder weights, candidate depth, and prompt/generation code
+unchanged. At this stage, the runners still report the existing binary metric
+view at `rel_threshold = 2`; reportable graded nDCG and the independent
+evaluator cross-check are tracked separately in #153. Dense retrieval and
+multi-encoder calibration are not part of this benchmark step.

--- a/experiments/run_reranker.py
+++ b/experiments/run_reranker.py
@@ -1,11 +1,11 @@
-"""Cross-encoder reranking on top of the dense retrieval run.
+"""Cross-encoder reranking for MS MARCO dev/small or TREC-DL judged topics.
 
 Pipeline:
 
-1. Load a first-stage ``run.tsv`` (defaults to the dense run) and
+1. Load a first-stage ``run.tsv`` (dense for dev/small, BM25 for TREC-DL) and
    truncate to top-K per query (default K = 100).
-2. Load the dense run's sample doc_id pool + sample-restricted qrels (so the
-   evaluation is apples-to-apples with the dense numbers).
+2. Load the matching query/qrels set. Sample-restricted qrels remain available
+   for the historical dense dev/small run.
 3. Resolve passage texts via ``ir_datasets``' docs_store, one chunk at
    a time so memory stays bounded.
 4. Score (query, passage) pairs with ``cross-encoder/ms-marco-MiniLM-L-6-v2``,
@@ -14,7 +14,7 @@ Pipeline:
 5. ``--resume`` reads the existing ``run.tsv``, identifies qids that
    already have a complete top-K block, prunes any half-written ones,
    and only scores the remainder. Mirrors the BM25 resume pattern.
-6. Evaluate dense (input) and dense+CE (reranked) on the SAME qrels and
+6. Evaluate the input and reranked orders on the SAME qrels and
    the SAME query set, so the delta is purely the reranker effect.
 7. Persist:
    - ``<output-dir>/metrics.json``   (dense vs rerank deltas)
@@ -52,13 +52,25 @@ import argparse
 import json
 import logging
 import random
-import resource
+try:
+    import resource
+except ImportError:  # pragma: no cover - exercised on Windows hosts.
+    resource = None
 import sys
 import time
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+from msmarco_genqa.data.benchmark import (
+    MSMARCO_DEV_SMALL,
+    SUPPORTED_DATASETS,
+    BenchmarkSpec,
+    default_retrieval_output_dir,
+    default_reranker_output_dir,
+    get_benchmark_spec,
+    load_benchmark_queries,
+)
 from msmarco_genqa.data.msmarco import get_docs_store, load_msmarco_passage
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
 from msmarco_genqa.reranking.cross_encoder import CrossEncoderReranker
@@ -91,7 +103,7 @@ def load_config(path: Path) -> dict:
         return yaml.safe_load(f)
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--config",
@@ -99,16 +111,28 @@ def parse_args() -> argparse.Namespace:
         default=PROJECT_ROOT / "configs/baseline.yaml",
     )
     parser.add_argument(
+        "--dataset",
+        choices=SUPPORTED_DATASETS,
+        default=MSMARCO_DEV_SMALL,
+        help="Query/qrels set associated with the first-stage run.",
+    )
+    parser.add_argument(
         "--input-run",
         type=Path,
-        default=PROJECT_ROOT / "outputs/dense_retrieval/run.tsv",
-        help="First-stage run.tsv to rerank. Defaults to the dense run.",
+        default=None,
+        help=(
+            "First-stage run.tsv to rerank. Defaults to the historical dense run for "
+            "dev/small and the matching year-specific BM25 run for TREC-DL."
+        ),
     )
     parser.add_argument(
         "--input-stage",
         type=str,
-        default="dense_retrieval",
-        help="Output dir name of the input retriever (used to find sample_doc_ids.json).",
+        default=None,
+        help=(
+            "Legacy output dir name used to find sample_doc_ids.json. By default the "
+            "input run's parent directory is used."
+        ),
     )
     parser.add_argument(
         "--rerank-top-k",
@@ -181,7 +205,110 @@ def parse_args() -> argparse.Namespace:
             "leave this off so missing reproducibility fields fail loudly."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def resolve_input_run(
+    args: argparse.Namespace,
+    cfg: dict,
+    spec: BenchmarkSpec,
+    project_root: Path = PROJECT_ROOT,
+) -> Path:
+    if args.input_run is not None:
+        return args.input_run if args.input_run.is_absolute() else project_root / args.input_run
+    if spec.is_trec_dl:
+        path = default_retrieval_output_dir(spec, cfg["eval_retrieval"]["output_dir"])
+        return project_root / path / "run.tsv"
+    return project_root / "outputs/dense_retrieval/run.tsv"
+
+
+def resolve_input_stage_dir(
+    args: argparse.Namespace,
+    input_run_path: Path,
+    project_root: Path = PROJECT_ROOT,
+) -> Path:
+    if args.input_stage is None:
+        return input_run_path.parent
+    return project_root / "outputs" / args.input_stage
+
+
+def resolve_output_dir(
+    args: argparse.Namespace,
+    cfg: dict,
+    spec: BenchmarkSpec,
+    project_root: Path = PROJECT_ROOT,
+) -> Path:
+    configured = cfg.get("reranker", {}).get(
+        "output_dir", "outputs/cross_encoder_rerank"
+    )
+    path = args.output_dir or default_reranker_output_dir(spec, configured)
+    return path if path.is_absolute() else project_root / path
+
+
+def first_stage_label(spec: BenchmarkSpec, input_run_path: Path) -> str:
+    if spec.is_trec_dl or "bm25" in str(input_run_path).lower():
+        return "bm25"
+    if "dense" in str(input_run_path).lower():
+        return "dense"
+    return "input"
+
+
+def select_eval_qids(
+    runs: dict[str, list[tuple[str, float]]],
+    queries: dict[str, str],
+    qrels: dict[str, set[str]],
+) -> list[str]:
+    """Keep run topics that belong to the selected benchmark.
+
+    Membership, rather than a non-empty positive set, is intentional: TREC-DL
+    judged topics can have no document above the binary relevance threshold and
+    still need a reranked run for the later graded evaluation path.
+    """
+    return [qid for qid in runs if qid in qrels and qid in queries]
+
+
+def load_upstream_benchmark_metadata(input_stage_dir: Path) -> dict[str, object]:
+    metrics_path = input_stage_dir / "metrics.json"
+    if not metrics_path.exists():
+        return {}
+    with open(metrics_path, encoding="utf-8") as f:
+        payload = json.load(f)
+    metadata = payload.get("benchmark", {})
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def validate_trec_input_run(
+    spec: BenchmarkSpec,
+    runs: dict[str, list[tuple[str, float]]],
+    benchmark_queries: dict[str, str],
+    upstream_metadata: dict[str, object],
+) -> None:
+    """Fail before model loading when a TREC run has the wrong topic scope."""
+    if not spec.is_trec_dl:
+        return
+
+    upstream_dataset = upstream_metadata.get("dataset_id")
+    if upstream_dataset is not None and upstream_dataset != spec.dataset_id:
+        raise SystemExit(
+            f"Input run metadata names {upstream_dataset!r}, but --dataset selects "
+            f"{spec.dataset_id!r}. Refusing to mix benchmark tracks."
+        )
+
+    expected = set(benchmark_queries)
+    observed = set(runs)
+    missing = sorted(expected - observed)
+    unexpected = sorted(observed - expected)
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append(f"missing {len(missing)} topics (for example {missing[:3]})")
+        if unexpected:
+            details.append(
+                f"contains {len(unexpected)} unexpected topics (for example {unexpected[:3]})"
+            )
+        raise SystemExit(
+            f"Input run does not match {spec.dataset_id}: " + "; ".join(details)
+        )
 
 
 def _peak_memory_mb() -> float:
@@ -189,6 +316,8 @@ def _peak_memory_mb() -> float:
 
     ``resource.getrusage`` reports bytes on macOS, kilobytes on Linux.
     """
+    if resource is None:
+        return 0.0
     rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     if sys.platform == "darwin":
         return rss / (1024 * 1024)
@@ -240,6 +369,7 @@ def main() -> None:
     )
     args = parse_args()
     cfg = load_config(args.config)
+    benchmark_spec = get_benchmark_spec(args.dataset)
     seed = cfg.get("seed", 42)
     seed_coverage = set_global_seed(seed)
 
@@ -250,15 +380,7 @@ def main() -> None:
     rerank_top_k = int(args.rerank_top_k or rerank_cfg.get("rerank_top_k", 100))
     batch_size = int(args.batch_size or rerank_cfg.get("batch_size", 64))
     max_length = int(rerank_cfg.get("max_length", 512))
-    cfg_output_dir = rerank_cfg.get("output_dir", "outputs/cross_encoder_rerank")
-    if args.output_dir is not None:
-        output_dir = (
-            args.output_dir
-            if args.output_dir.is_absolute()
-            else PROJECT_ROOT / args.output_dir
-        )
-    else:
-        output_dir = PROJECT_ROOT / cfg_output_dir
+    output_dir = resolve_output_dir(args, cfg, benchmark_spec)
     chunk_size = int(
         args.rerank_chunk_size
         or rerank_cfg.get("chunk_size", 200)
@@ -267,13 +389,14 @@ def main() -> None:
     cache_dir = PROJECT_ROOT / cfg["data"].get("cache_dir", "data/raw")
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    input_run_path = args.input_run
+    input_run_path = resolve_input_run(args, cfg, benchmark_spec)
     if not input_run_path.exists():
         raise SystemExit(
             f"Input run not found at {input_run_path}.\n"
-            "Run experiments/run_dense_retrieval.py first (or pass --input-run)."
+            "Run the matching first-stage retriever first (or pass --input-run)."
         )
-    input_stage_dir = PROJECT_ROOT / "outputs" / args.input_stage
+    input_stage_dir = resolve_input_stage_dir(args, input_run_path)
+    input_label = first_stage_label(benchmark_spec, input_run_path)
 
     # ---------------------------------------------------------------- #
     # 1. Load first-stage run + truncate to top-K
@@ -297,17 +420,29 @@ def main() -> None:
     # ---------------------------------------------------------------- #
     # 2. Queries + qrels
     # ---------------------------------------------------------------- #
-    data = load_msmarco_passage(cache_dir=cache_dir, load_corpus=False)
-    docs_store = data.docs_store or get_docs_store(cache_dir=cache_dir)
-    sample_qrels = _load_sample_qrels(input_stage_dir, data.qrels)
+    corpus_data = load_msmarco_passage(cache_dir=cache_dir, load_corpus=False)
+    docs_store = corpus_data.docs_store or get_docs_store(cache_dir=cache_dir)
+    benchmark = load_benchmark_queries(
+        args.dataset,
+        cache_dir=cache_dir,
+        msmarco_data=corpus_data,
+    )
+    upstream_benchmark = load_upstream_benchmark_metadata(input_stage_dir)
+    validate_trec_input_run(
+        benchmark_spec,
+        runs_topk,
+        benchmark.queries,
+        upstream_benchmark,
+    )
+    sample_qrels = (
+        benchmark.qrels
+        if benchmark_spec.is_trec_dl
+        else _load_sample_qrels(input_stage_dir, benchmark.qrels)
+    )
 
-    # Restrict to queries that have at least one positive qrel AND have a
-    # text in the queries map. ``runs_topk`` already only contains queries
-    # the first-stage retrieved for, so the intersection is what matters.
-    eval_qids = [
-        q for q in runs_topk
-        if q in sample_qrels and q in data.queries
-    ]
+    # Restrict to topics in the selected query and qrels maps. TREC-DL keeps
+    # judged topics even when no label reaches the binary threshold.
+    eval_qids = select_eval_qids(runs_topk, benchmark.queries, sample_qrels)
     skipped = len(runs_topk) - len(eval_qids)
     if skipped:
         logger.info(
@@ -392,7 +527,7 @@ def main() -> None:
         text_by_id = _resolve_passages(needed, docs_store)
         resolve_seconds += time.time() - t0
 
-        queries_text_chunk = [data.queries[q] for q in chunk_qids]
+        queries_text_chunk = [benchmark.queries[q] for q in chunk_qids]
         candidates_chunk = [
             [(d, text_by_id[d]) for d, _ in chunk_runs[q]]
             for q in chunk_qids
@@ -410,7 +545,7 @@ def main() -> None:
             chunk_qids,
             [[d for d, _ in row] for row in chunk_reranked],
             [[s for _, s in row] for row in chunk_reranked],
-            system_name="dense+ce_minilm_l6",
+            system_name=f"{input_label}+ce_minilm_l6",
         )
 
         total_pairs_scored += chunk_info["n_pairs"]
@@ -465,14 +600,14 @@ def main() -> None:
         )
 
     # ---------------------------------------------------------------- #
-    # 6. Evaluate dense (input order) AND reranked, on the same query set
+    # 6. Evaluate input order AND reranked order on the same query set
     # ---------------------------------------------------------------- #
-    dense_runs_eval = {q: [d for d, _ in runs_topk[q]] for q in eval_qids}
+    input_runs_eval = {q: [d for d, _ in runs_topk[q]] for q in eval_qids}
 
-    dense_metrics = evaluate_retrieval(dense_runs_eval, sample_qrels)
+    input_metrics = evaluate_retrieval(input_runs_eval, sample_qrels)
     rerank_metrics = evaluate_retrieval(rerank_runs_eval, sample_qrels)
-    logger.info("Dense (input)   metrics: %s", dense_metrics)
-    logger.info("Dense + CE rerank metrics: %s", rerank_metrics)
+    logger.info("%s (input) metrics: %s", input_label, input_metrics)
+    logger.info("%s + CE rerank metrics: %s", input_label, rerank_metrics)
 
     # ---------------------------------------------------------------- #
     # 7. Qualitative examples (before vs after) — reads reranked from disk
@@ -501,16 +636,16 @@ def main() -> None:
     with open(examples_path, "w") as f:
         for qid in sample_qids_for_examples:
             relevant = sample_qrels.get(qid, set())
-            dense_block = _block(runs_topk[qid], relevant)
+            input_block = _block(runs_topk[qid], relevant)
             # final_runs[qid] is the disk-materialised reranked block (doc, score).
             ce_block = _block(final_runs.get(qid, []), relevant)
             entry = {
                 "query_id": qid,
-                "query": data.queries[qid],
+                "query": benchmark.queries[qid],
                 "relevant_doc_ids": sorted(relevant),
-                "dense_top10": dense_block,
+                f"{input_label}_top10": input_block,
                 "rerank_top10": ce_block,
-                "dense_first_rank_in_top10": _first_rank(dense_block),
+                f"{input_label}_first_rank_in_top10": _first_rank(input_block),
                 "rerank_first_rank_in_top10": _first_rank(ce_block),
             }
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
@@ -523,26 +658,43 @@ def main() -> None:
     # ---------------------------------------------------------------- #
     # 8. metrics.json (unified schema)
     # ---------------------------------------------------------------- #
-    n_queries = dense_metrics.pop("n_queries", None)
+    n_queries = input_metrics.pop("n_queries", None)
     rerank_metrics.pop("n_queries", None)
+
+    benchmark_metadata = benchmark.metadata()
+    benchmark_metadata.update(
+        {
+            "corpus_id": "msmarco-passage",
+            "corpus_scope": upstream_benchmark.get("corpus_scope", "unknown"),
+            "input_run_topic_count": len(runs_topk),
+            "reranked_topic_count": len(final_runs),
+            "judged_topic_coverage": (
+                len(set(final_runs) & set(benchmark.graded_qrels))
+                / len(benchmark.graded_qrels)
+                if benchmark.graded_qrels
+                else 0.0
+            ),
+        }
+    )
 
     payload = {
         "task": "reranking",
-        "dataset": "msmarco-passage/dev/small (qrels-anchored sample, via dense run)",
+        "dataset": benchmark_spec.dataset_id,
+        "benchmark": benchmark_metadata,
         "n_examples": n_queries,
         "config": cfg,
         "rerank": {
             "input_run": str(input_run_path.relative_to(PROJECT_ROOT))
             if input_run_path.is_relative_to(PROJECT_ROOT)
             else str(input_run_path),
-            "input_stage": args.input_stage,
+            "input_stage": input_label,
             "rerank_top_k": rerank_top_k,
             "model_name": model_name,
             "batch_size": batch_size,
             "max_length": max_length,
         },
         "metrics": {
-            "dense": dense_metrics,
+            input_label: input_metrics,
             "rerank": rerank_metrics,
         },
         "wall_clock_seconds": {
@@ -566,8 +718,8 @@ def main() -> None:
     }
     # Reranker inherits sampling state from its upstream first-stage run:
     # presence of input_stage_dir/sample_doc_ids.json indicates the upstream
-    # eval was qrels-anchored. The eval (dense_metrics + rerank_metrics) is
-    # then over sample_qrels rather than the full qrels.
+    # eval was qrels-anchored. The input and rerank metrics are then over
+    # sample_qrels rather than the full qrels.
     upstream_sample_path = input_stage_dir / "sample_doc_ids.json"
     if upstream_sample_path.exists():
         with open(upstream_sample_path) as f:
@@ -611,6 +763,10 @@ def main() -> None:
             if input_run_path.is_relative_to(PROJECT_ROOT)
             else str(input_run_path),
             "resumed": bool(args.resume) and len(done_qids) > 0,
+            "dataset": benchmark_spec.dataset_id,
+            "track_year": benchmark_spec.track_year,
+            "judged_topic_count": benchmark.judged_topic_count,
+            "input_stage": input_label,
             "seed": seed,
             "seed_coverage": seed_coverage,
             "resolved_config_hash": resolved_config_hash,
@@ -624,7 +780,7 @@ def main() -> None:
     # ---------------------------------------------------------------- #
     # 9. Friendly summary
     # ---------------------------------------------------------------- #
-    print("\n=== cross-encoder reranking ===")
+    print(f"\n=== cross-encoder reranking: {benchmark_spec.dataset_id} ===")
     print(f"input run:   {input_run_path}")
     print(f"rerank model: {model_name}")
     print(
@@ -641,9 +797,9 @@ def main() -> None:
             f"(+ {resolve_seconds:.1f} s text resolve)"
         )
     print(f"peak RSS:    {peak_mem_mb:.0f} MiB")
-    print(f"  {'metric':14s}  {'dense':>10s}  {'+CE':>10s}  {'Δ':>9s}")
+    print(f"  {'metric':14s}  {input_label:>10s}  {'+CE':>10s}  {'Δ':>9s}")
     for key in ("mrr@10", "ndcg@10", "recall@100", "recall@1000"):
-        d = dense_metrics.get(key)
+        d = input_metrics.get(key)
         r = rerank_metrics.get(key)
         delta = (r - d) if (d is not None and r is not None) else None
         d_s = f"{d:.4f}" if d is not None else "  —  "

--- a/experiments/run_reranker.py
+++ b/experiments/run_reranker.py
@@ -17,7 +17,7 @@ Pipeline:
 6. Evaluate the input and reranked orders on the SAME qrels and
    the SAME query set, so the delta is purely the reranker effect.
 7. Persist:
-   - ``<output-dir>/metrics.json``   (dense vs rerank deltas)
+   - ``<output-dir>/metrics.json``   (first-stage vs rerank deltas)
    - ``<output-dir>/run.tsv``        (reranked TREC run, append-built)
    - ``<output-dir>/examples.jsonl`` (before/after per query)
    - ``<output-dir>/manifest.json``  (git/config/dep hashes + extras)
@@ -766,6 +766,10 @@ def main() -> None:
             "dataset": benchmark_spec.dataset_id,
             "track_year": benchmark_spec.track_year,
             "judged_topic_count": benchmark.judged_topic_count,
+            "judged_topic_coverage": benchmark_metadata["judged_topic_coverage"],
+            "corpus_scope": benchmark_metadata["corpus_scope"],
+            "input_run_topic_count": benchmark_metadata["input_run_topic_count"],
+            "reranked_topic_count": benchmark_metadata["reranked_topic_count"],
             "input_stage": input_label,
             "seed": seed,
             "seed_coverage": seed_coverage,

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -1,10 +1,10 @@
-"""Build the official BM25 baseline on MS MARCO Passage / dev/small.
+"""Run full-corpus BM25 on MS MARCO dev/small or TREC-DL judged topics.
 
 End-to-end:
 
-1. Load corpus, dev/small queries, and qrels via ``ir_datasets``.
+1. Load the shared MS MARCO passage corpus and the selected query/qrels set.
 2. Build (or load from cache) a ``bm25s`` index over the corpus.
-3. Retrieve top-k for every dev query, in chunks; append each chunk to
+3. Retrieve top-k for every selected query, in chunks; append each chunk to
    ``run.tsv`` so a killed run can be resumed instead of restarting from
    query 0.
 4. Compute MRR@10, Recall@100, Recall@1000.
@@ -33,6 +33,14 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+from msmarco_genqa.data.benchmark import (
+    MSMARCO_DEV_SMALL,
+    SUPPORTED_DATASETS,
+    BenchmarkSpec,
+    default_retrieval_output_dir,
+    get_benchmark_spec,
+    load_benchmark_queries,
+)
 from msmarco_genqa.data.msmarco import load_msmarco_passage
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
 from msmarco_genqa.retrieval.bm25 import BM25Retriever
@@ -59,12 +67,27 @@ def load_config(path: Path) -> dict:
         return yaml.safe_load(f)
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--config",
         type=Path,
         default=PROJECT_ROOT / "configs/baseline.yaml",
+    )
+    parser.add_argument(
+        "--dataset",
+        choices=SUPPORTED_DATASETS,
+        default=MSMARCO_DEV_SMALL,
+        help="Query/qrels set to run against the shared MS MARCO passage corpus.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Output directory override. TREC-DL defaults to isolated, year-specific "
+            "directories; dev/small keeps eval_retrieval.output_dir."
+        ),
     )
     parser.add_argument(
         "--rebuild-index",
@@ -98,7 +121,18 @@ def parse_args() -> argparse.Namespace:
             "leave this off so missing reproducibility fields fail loudly."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def resolve_output_dir(
+    args: argparse.Namespace,
+    cfg: dict,
+    spec: BenchmarkSpec,
+    project_root: Path = PROJECT_ROOT,
+) -> Path:
+    configured = cfg["eval_retrieval"]["output_dir"]
+    path = args.output_dir or default_retrieval_output_dir(spec, configured)
+    return path if path.is_absolute() else project_root / path
 
 
 def _read_done_qids(run_path: Path, top_k: int) -> set[str]:
@@ -147,10 +181,11 @@ def main() -> None:
     )
     args = parse_args()
     cfg = load_config(args.config)
+    benchmark_spec = get_benchmark_spec(args.dataset)
     seed = cfg.get("seed", 42)
     seed_coverage = set_global_seed(seed)
 
-    output_dir = PROJECT_ROOT / cfg["eval_retrieval"]["output_dir"]
+    output_dir = resolve_output_dir(args, cfg, benchmark_spec)
     index_dir = PROJECT_ROOT / cfg["retrieval"]["index_dir"]
     cache_dir = PROJECT_ROOT / cfg["data"].get("cache_dir", "data/raw")
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -167,14 +202,19 @@ def main() -> None:
 
     # ---- 1. Data ----
     have_index = (index_dir / "config.json").exists() and not args.rebuild_index
-    data = load_msmarco_passage(
+    corpus_data = load_msmarco_passage(
         cache_dir=cache_dir,
         load_corpus=not have_index,
         limit=corpus_limit,
     )
+    benchmark = load_benchmark_queries(
+        args.dataset,
+        cache_dir=cache_dir,
+        msmarco_data=corpus_data,
+    )
     query_text_by_qid, query_transform_summary, query_transform_outputs = (
         materialize_query_transform(
-            data.queries,
+            benchmark.queries,
             cfg.get("query_transform"),
             output_dir=output_dir / "query_transform",
         )
@@ -207,8 +247,8 @@ def main() -> None:
         )
     else:
         retriever = BM25Retriever(
-            corpus_texts=data.corpus_texts,
-            doc_ids=data.corpus_doc_ids,
+            corpus_texts=corpus_data.corpus_texts,
+            doc_ids=corpus_data.corpus_doc_ids,
             k1=float(cfg["retrieval"]["k1"]),
             b=float(cfg["retrieval"]["b"]),
             stopwords=cfg["retrieval"].get("stopwords", "en"),
@@ -221,7 +261,7 @@ def main() -> None:
         retriever.save(index_dir)
 
     # ---- 3. Plan retrieval ----
-    qids = list(data.queries.keys())
+    qids = list(benchmark.queries.keys())
     run_path = output_dir / "run.tsv"
 
     if args.resume:
@@ -267,7 +307,7 @@ def main() -> None:
     # resumed mid-run. We capture top-10 doc_ids+scores per sampled qid as we
     # go (cheap; bounded size) but otherwise rely on run.tsv for evaluation.
     rng = random.Random(seed)
-    eligible = [q for q in qids if data.qrels.get(q)]
+    eligible = [q for q in qids if benchmark.qrels.get(q)]
     sample_qids = rng.sample(eligible, min(n_examples, len(eligible)))
 
     # ---- 4. Chunked retrieval ----
@@ -338,7 +378,7 @@ def main() -> None:
 
     metrics = evaluate_retrieval(
         runs=runs,
-        qrels=data.qrels,
+        qrels=benchmark.qrels,
         ks_mrr=ks_mrr,
         ks_recall=ks_recall,
         ks_ndcg=ks_ndcg,
@@ -348,8 +388,8 @@ def main() -> None:
     # ---- 6. Qualitative examples ----
     # Resolve passage text. If we built the index in this run, the corpus is
     # in memory; otherwise we use the docs_store for random access.
-    if data.corpus_texts:
-        id_to_text = dict(zip(data.corpus_doc_ids, data.corpus_texts))
+    if corpus_data.corpus_texts:
+        id_to_text = dict(zip(corpus_data.corpus_doc_ids, corpus_data.corpus_texts))
 
         def get_text(doc_id: str) -> str:
             return id_to_text.get(doc_id, "")
@@ -367,7 +407,7 @@ def main() -> None:
     examples_path = output_dir / "examples.jsonl"
     with open(examples_path, "w") as f:
         for qid in sample_qids:
-            relevant = data.qrels.get(qid, set())
+            relevant = benchmark.qrels.get(qid, set())
             ranked_doc_ids = runs.get(qid, [])
             ranked_scores = scores_by_qid.get(qid, [])
             top_doc_ids = ranked_doc_ids[:10]
@@ -388,7 +428,7 @@ def main() -> None:
             )
             example = {
                 "query_id": qid,
-                "query": data.queries[qid],
+                "query": benchmark.queries[qid],
                 "relevant_doc_ids": sorted(relevant),
                 "first_relevant_rank_in_top10": first_rank,
                 "top_results": top_results,
@@ -409,9 +449,22 @@ def main() -> None:
         method="first-N-truncated" if corpus_limit is not None else None,
         sample_size=corpus_limit,
     )
+    benchmark_metadata = benchmark.metadata()
+    judged_qids = set(benchmark.graded_qrels)
+    benchmark_metadata.update(
+        {
+            "corpus_id": "msmarco-passage",
+            "corpus_scope": "first-N-truncated" if corpus_limit is not None else "full",
+            "run_topic_count": len(set(runs) & set(benchmark.queries)),
+            "judged_topic_coverage": (
+                len(set(runs) & judged_qids) / len(judged_qids) if judged_qids else 0.0
+            ),
+        }
+    )
     payload = {
         "task": "retrieval",
-        "dataset": "msmarco-passage/dev/small",
+        "dataset": benchmark_spec.dataset_id,
+        "benchmark": benchmark_metadata,
         "n_examples": n_examples,
         "config": cfg,
         "metrics": metrics,
@@ -451,7 +504,13 @@ def main() -> None:
             "b": cfg["retrieval"].get("b"),
             "stopwords": cfg["retrieval"].get("stopwords"),
             "top_k": top_k,
-            "n_eval_queries": n_examples,
+            "n_eval_queries": len(qids),
+            "n_metric_queries": n_examples,
+            "dataset": benchmark_spec.dataset_id,
+            "track_year": benchmark_spec.track_year,
+            "judged_topic_count": benchmark.judged_topic_count,
+            "run_topic_count": len(set(runs) & set(benchmark.queries)),
+            "corpus_scope": benchmark_metadata["corpus_scope"],
             "resumed": bool(args.resume and (set(qids) - set(pending_qids))),
             "seed": seed,
             "seed_coverage": seed_coverage,
@@ -465,7 +524,7 @@ def main() -> None:
     )
 
     # ---- 8. Friendly summary ----
-    print("\n=== BM25 baseline ===")
+    print(f"\n=== BM25 baseline: {benchmark_spec.dataset_id} ===")
     print(f"queries evaluated: {n_examples}")
     for key in ("mrr@10", "ndcg@10", "recall@100", "recall@1000"):
         if key in metrics:

--- a/src/msmarco_genqa/data/benchmark.py
+++ b/src/msmarco_genqa/data/benchmark.py
@@ -1,0 +1,112 @@
+"""Dataset selection shared by the full-corpus retrieval runners."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from msmarco_genqa.data.msmarco import MSMarcoPassage, load_msmarco_passage
+from msmarco_genqa.data.trec_dl import DEFAULT_REL_THRESHOLD, TREC_DL_DATASETS, load_trec_dl
+
+
+MSMARCO_DEV_SMALL = "msmarco-passage/dev/small"
+SUPPORTED_DATASETS = (MSMARCO_DEV_SMALL, *TREC_DL_DATASETS.values())
+
+
+@dataclass(frozen=True)
+class BenchmarkSpec:
+    """Stable identity and output conventions for one retrieval benchmark."""
+
+    dataset_id: str
+    output_slug: str
+    track_year: int | None = None
+    rel_threshold: int | None = None
+
+    @property
+    def is_trec_dl(self) -> bool:
+        return self.track_year is not None
+
+
+@dataclass
+class BenchmarkQueries:
+    """Query text and judgments normalized across supported benchmarks."""
+
+    spec: BenchmarkSpec
+    queries: dict[str, str]
+    qrels: dict[str, set[str]]
+    graded_qrels: dict[str, dict[str, int]]
+
+    @property
+    def judged_topic_count(self) -> int:
+        return len(self.graded_qrels)
+
+    @property
+    def positive_topic_count(self) -> int:
+        return sum(bool(doc_ids) for doc_ids in self.qrels.values())
+
+    def metadata(self) -> dict[str, object]:
+        return {
+            "dataset_id": self.spec.dataset_id,
+            "track_year": self.spec.track_year,
+            "topic_scope": "judged" if self.spec.is_trec_dl else "dev/small",
+            "query_count": len(self.queries),
+            "judged_topic_count": self.judged_topic_count,
+            "positive_topic_count": self.positive_topic_count,
+            "qrels_type": "graded" if self.spec.is_trec_dl else "binary",
+            "relevance_threshold": self.spec.rel_threshold,
+        }
+
+
+def get_benchmark_spec(dataset_id: str) -> BenchmarkSpec:
+    if dataset_id == MSMARCO_DEV_SMALL:
+        return BenchmarkSpec(dataset_id=dataset_id, output_slug="msmarco_dev_small")
+    for year, candidate in TREC_DL_DATASETS.items():
+        if dataset_id == candidate:
+            return BenchmarkSpec(
+                dataset_id=dataset_id,
+                output_slug=f"trec_dl_{year}",
+                track_year=year,
+                rel_threshold=DEFAULT_REL_THRESHOLD,
+            )
+    raise ValueError(
+        f"unsupported dataset {dataset_id!r}; expected one of {SUPPORTED_DATASETS}"
+    )
+
+
+def load_benchmark_queries(
+    dataset_id: str,
+    *,
+    cache_dir: Path | str | None = None,
+    msmarco_data: MSMarcoPassage | None = None,
+) -> BenchmarkQueries:
+    """Load query text and qrels without loading the passage corpus eagerly."""
+    spec = get_benchmark_spec(dataset_id)
+    if not spec.is_trec_dl:
+        data = msmarco_data or load_msmarco_passage(
+            cache_dir=cache_dir,
+            load_corpus=False,
+        )
+        graded_qrels = {
+            qid: {doc_id: 1 for doc_id in doc_ids}
+            for qid, doc_ids in data.qrels.items()
+        }
+        return BenchmarkQueries(spec, data.queries, data.qrels, graded_qrels)
+
+    data = load_trec_dl(
+        spec.track_year,
+        cache_dir=cache_dir,
+        rel_threshold=spec.rel_threshold or DEFAULT_REL_THRESHOLD,
+    )
+    return BenchmarkQueries(spec, data.queries, data.qrels, data.graded_qrels)
+
+
+def default_retrieval_output_dir(spec: BenchmarkSpec, configured: str) -> Path:
+    if not spec.is_trec_dl:
+        return Path(configured)
+    return Path("outputs") / spec.output_slug / "bm25"
+
+
+def default_reranker_output_dir(spec: BenchmarkSpec, configured: str) -> Path:
+    if not spec.is_trec_dl:
+        return Path(configured)
+    return Path("outputs") / spec.output_slug / "cross_encoder_rerank"

--- a/tests/test_benchmark_dataset_selection.py
+++ b/tests/test_benchmark_dataset_selection.py
@@ -57,7 +57,13 @@ def test_trec_tracks_load_through_shared_selector_without_network(year, monkeypa
     assert selected.queries == bundle.queries
     assert selected.qrels == bundle.qrels
     assert selected.graded_qrels == bundle.graded_qrels
-    assert selected.metadata()["topic_scope"] == "judged"
+    metadata = selected.metadata()
+    assert metadata["dataset_id"] == TREC_DL_DATASETS[year]
+    assert metadata["track_year"] == year
+    assert metadata["topic_scope"] == "judged"
+    assert metadata["judged_topic_count"] == len(bundle.graded_qrels)
+    assert metadata["qrels_type"] == "graded"
+    assert metadata["relevance_threshold"] == 2
 
 
 def test_supported_datasets_keep_dev_small_as_default():

--- a/tests/test_benchmark_dataset_selection.py
+++ b/tests/test_benchmark_dataset_selection.py
@@ -1,0 +1,152 @@
+"""Offline coverage for dataset selection in the full-corpus runners."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from experiments.run_reranker import (
+    first_stage_label,
+    load_upstream_benchmark_metadata,
+    parse_args as parse_reranker_args,
+    resolve_input_run,
+    resolve_output_dir as resolve_reranker_output_dir,
+    select_eval_qids,
+    validate_trec_input_run,
+)
+from experiments.run_retrieval import (
+    parse_args as parse_retrieval_args,
+    resolve_output_dir as resolve_retrieval_output_dir,
+)
+from msmarco_genqa.data import benchmark as benchmark_module
+from msmarco_genqa.data.benchmark import (
+    MSMARCO_DEV_SMALL,
+    SUPPORTED_DATASETS,
+    get_benchmark_spec,
+    load_benchmark_queries,
+)
+from msmarco_genqa.data.trec_dl import TREC_DL_DATASETS, load_trec_dl_from_files
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "trec_dl"
+
+
+@pytest.fixture
+def cfg() -> dict:
+    return {
+        "eval_retrieval": {"output_dir": "outputs/bm25_baseline"},
+        "reranker": {"output_dir": "outputs/cross_encoder_rerank"},
+    }
+
+
+@pytest.mark.parametrize("year", [2019, 2020])
+def test_trec_tracks_load_through_shared_selector_without_network(year, monkeypatch):
+    bundle = load_trec_dl_from_files(
+        FIXTURES / f"queries_{year}.tsv",
+        FIXTURES / f"qrels_{year}.txt",
+        year=year,
+        dataset_name=TREC_DL_DATASETS[year],
+    )
+    monkeypatch.setattr(benchmark_module, "load_trec_dl", lambda *args, **kwargs: bundle)
+
+    selected = load_benchmark_queries(TREC_DL_DATASETS[year])
+
+    assert selected.spec.track_year == year
+    assert selected.spec.dataset_id == TREC_DL_DATASETS[year]
+    assert selected.queries == bundle.queries
+    assert selected.qrels == bundle.qrels
+    assert selected.graded_qrels == bundle.graded_qrels
+    assert selected.metadata()["topic_scope"] == "judged"
+
+
+def test_supported_datasets_keep_dev_small_as_default():
+    assert SUPPORTED_DATASETS == (
+        MSMARCO_DEV_SMALL,
+        TREC_DL_DATASETS[2019],
+        TREC_DL_DATASETS[2020],
+    )
+    assert parse_retrieval_args([]).dataset == MSMARCO_DEV_SMALL
+    assert parse_reranker_args([]).dataset == MSMARCO_DEV_SMALL
+
+
+@pytest.mark.parametrize("year", [2019, 2020])
+def test_trec_default_outputs_are_isolated_by_year(year, cfg, tmp_path):
+    dataset_id = TREC_DL_DATASETS[year]
+    spec = get_benchmark_spec(dataset_id)
+    retrieval_args = parse_retrieval_args(["--dataset", dataset_id])
+    reranker_args = parse_reranker_args(["--dataset", dataset_id])
+
+    retrieval_dir = resolve_retrieval_output_dir(
+        retrieval_args,
+        cfg,
+        spec,
+        project_root=tmp_path,
+    )
+    reranker_dir = resolve_reranker_output_dir(
+        reranker_args,
+        cfg,
+        spec,
+        project_root=tmp_path,
+    )
+
+    assert retrieval_dir == tmp_path / "outputs" / f"trec_dl_{year}" / "bm25"
+    assert reranker_dir == (
+        tmp_path / "outputs" / f"trec_dl_{year}" / "cross_encoder_rerank"
+    )
+    assert resolve_input_run(reranker_args, cfg, spec, project_root=tmp_path) == (
+        retrieval_dir / "run.tsv"
+    )
+    assert first_stage_label(spec, retrieval_dir / "run.tsv") == "bm25"
+
+
+def test_dev_small_paths_remain_backward_compatible(cfg, tmp_path):
+    spec = get_benchmark_spec(MSMARCO_DEV_SMALL)
+    retrieval_args = parse_retrieval_args([])
+    reranker_args = parse_reranker_args([])
+
+    assert resolve_retrieval_output_dir(
+        retrieval_args, cfg, spec, project_root=tmp_path
+    ) == (tmp_path / "outputs" / "bm25_baseline")
+    assert resolve_reranker_output_dir(
+        reranker_args, cfg, spec, project_root=tmp_path
+    ) == (tmp_path / "outputs" / "cross_encoder_rerank")
+    assert resolve_input_run(reranker_args, cfg, spec, project_root=tmp_path) == (
+        tmp_path / "outputs" / "dense_retrieval" / "run.tsv"
+    )
+
+
+def test_selected_trec_topics_include_empty_binary_positive_sets():
+    runs = {"q1": [("d1", 1.0)], "q2": [("d2", 1.0)], "other": [("d9", 1.0)]}
+    queries = {"q1": "one", "q2": "two"}
+    qrels = {"q1": {"d1"}, "q2": set()}
+
+    assert select_eval_qids(runs, queries, qrels) == ["q1", "q2"]
+
+
+def test_trec_reranker_rejects_missing_or_cross_track_topics():
+    spec = get_benchmark_spec(TREC_DL_DATASETS[2019])
+    queries = {"q1": "one", "q2": "two"}
+
+    with pytest.raises(SystemExit, match="missing 1 topics"):
+        validate_trec_input_run(spec, {"q1": [("d1", 1.0)]}, queries, {})
+
+    with pytest.raises(SystemExit, match="Refusing to mix benchmark tracks"):
+        validate_trec_input_run(
+            spec,
+            {"q1": [("d1", 1.0)], "q2": [("d2", 1.0)]},
+            queries,
+            {"dataset_id": TREC_DL_DATASETS[2020]},
+        )
+
+
+def test_upstream_corpus_scope_is_read_from_metrics(tmp_path):
+    (tmp_path / "metrics.json").write_text(
+        '{"benchmark":{"dataset_id":"track","corpus_scope":"first-N-truncated"}}',
+        encoding="utf-8",
+    )
+
+    assert load_upstream_benchmark_metadata(tmp_path) == {
+        "dataset_id": "track",
+        "corpus_scope": "first-N-truncated",
+    }


### PR DESCRIPTION
## Why

The TREC-DL 2019 and 2020 loaders already preserve judged query text and graded qrels, but the production BM25 and cross-encoder runners still load MS MARCO dev/small directly. That prevents the existing full-corpus retrieval stack from producing isolated, traceable runs for the two TREC-DL passage tracks.

Closes #152.

## What changed

- Added a shared benchmark selector for MS MARCO dev/small and the judged TREC-DL 2019/2020 passage tracks.
- Added `--dataset` support to `mgq-retrieve` and `mgq-rerank` while preserving the current dev/small defaults.
- Reused the existing full MS MARCO BM25 index and isolated TREC-DL outputs by year.
- Made the reranker default to the matching year-specific BM25 run and reject missing topics or cross-track input metadata before model loading.
- Recorded dataset id, track year, judged-topic coverage, corpus scope, and upstream run provenance in metrics and manifests.
- Added deterministic offline coverage for both tracks, output routing, backward compatibility, and qid alignment.
- Documented the full-corpus BM25 and reranking commands.

## Validation

- `161 passed` across benchmark selection, TREC-DL loading, reranking, retrieval metrics, BM25 index validation, and manifest tests.
- `ruff check` passed on all changed Python files.
- Python compileall passed for the changed modules and tests.
- `python scripts/check_secrets.py` passed.
- `git diff --check` passed.
- Public-file scan for assistant/tool attribution markers returned no matches.

## Risk / follow-up

The runners still expose the existing binary metric view at relevance threshold 2. Reportable graded nDCG, evaluator cross-checks, and official topic-scope averaging remain separate work in #153. This PR does not change BM25 tokenization, index parameters, cross-encoder weights, prompts, generation, or dense retrieval.