### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MS MARCO GenQA
 
+[![CI status](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/ci.yml?query=branch%3Amain)
+
 ## TL;DR
 
 This repository is a reproducible research-engineering implementation of an


### PR DESCRIPTION
## Summary

Add the repository's GitHub Actions CI badge directly below the README title. The badge is pinned to the `main` branch and links to the corresponding filtered workflow view.

## Why

The repository already treats CI as part of its reproducibility contract, but that status was not visible from the project landing page. Showing the live workflow state makes the engineering health immediately inspectable without adding a decorative or third-party badge.

## Validation

- confirmed `.github/workflows/ci.yml` is the main push/PR workflow for `main`
- badge endpoint returns HTTP 200 with `image/svg+xml` and currently reports `passing`
- workflow link returns HTTP 200 and preserves the `main` branch filter
- `git diff --cached --check`

Documentation-only change; no runtime behavior is modified.