### PR TITLE
Add project metadata badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # MS MARCO GenQA
 
 [![CI status](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/ci.yml?query=branch%3Amain)
+[![Secret scan](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/secret-scan.yml/badge.svg?branch=main)](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/secret-scan.yml?query=branch%3Amain)
+[![Latest release](https://img.shields.io/github/v/release/GioiaZheng/msmarco-genqa?display_name=tag)](https://github.com/GioiaZheng/msmarco-genqa/releases/latest)
+[![Python](https://img.shields.io/badge/python-%E2%89%A53.10-3776AB?logo=python&logoColor=white)](https://github.com/GioiaZheng/msmarco-genqa/blob/main/pyproject.toml)
+[![License](https://img.shields.io/github/license/GioiaZheng/msmarco-genqa)](https://github.com/GioiaZheng/msmarco-genqa/blob/main/LICENSE)
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary

Add four source-backed badges alongside the existing CI status badge:

- Secret scan workflow status
- latest GitHub Release
- supported Python version
- MIT license

Each badge links to the corresponding workflow, release, or repository metadata rather than to a generic landing page.

## Why

The README currently exposes CI health but leaves other useful project signals implicit. These badges make security automation, release state, runtime compatibility, and licensing visible without claiming coverage, package publication, or documentation services that the repository does not currently provide.

## Validation

- verified all four SVG endpoints return HTTP 200
- confirmed the Secret scan badge reports `passing`
- confirmed the release badge resolves to `v2.0-reproducibility-protocol`
- confirmed Python `>=3.10` against `pyproject.toml`
- confirmed GitHub recognizes the repository license as MIT
- verified all four badge links return HTTP 200
- ran `git diff --check`