### PR TITLE
Publish reproducible TREC-DL baseline bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,7 +220,9 @@ data/cache/*
 # Local caches and intermediate artifacts (root-level only,
 # so we don't accidentally swallow data/cache/.gitkeep)
 /cache/
-/artifacts/
+/artifacts/*
+!/artifacts/README.md
+!/artifacts/*.json
 
 # Experiment results (structured outputs from run_*.py scripts)
 results/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline
+.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline reproduce-trec-eval build-trec-release
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -29,6 +29,8 @@ help:
 	@echo "  make serve-dev            -- start the optional FastAPI generation service"
 	@echo "  make reproduce-small      -- build the tiny trace-export interop fixture"
 	@echo "  make reproduce-baseline   -- re-run + verify the BM25 baseline (~30 min CPU laptop)"
+	@echo "  make reproduce-trec-eval  -- fetch + verify published TREC-DL runs and metrics"
+	@echo "  make build-trec-release   -- build the maintainer release ZIP from canonical runs"
 
 # ----------------------------------------------------------------------------- #
 # Install
@@ -134,3 +136,15 @@ reproduce-small:
 reproduce-baseline: install
 	mgq-retrieve --require-clean-tree
 	$(PYTHON) scripts/verify_reproduction.py outputs/bm25_baseline
+
+# Fast evidence reproduction: download the public text-only run bundle,
+# verify both archive and member hashes, recover the public judged qrels via
+# ir_datasets, and recompute the four reported TREC-DL result rows. This does
+# not rebuild the 8.8M-passage index or rerun the cross-encoder.
+reproduce-trec-eval:
+	$(PYTHON) -m msmarco_genqa.cli.trec_release reproduce
+
+# Maintainer-only packaging target. The generated ZIP remains under ignored
+# outputs/; its exact hash and size are pinned by artifacts/trec_dl_baselines_v1.json.
+build-trec-release:
+	$(PYTHON) -m msmarco_genqa.cli.trec_release build --output outputs/releases/trec-dl-baselines-v1.zip

--- a/README.md
+++ b/README.md
@@ -281,6 +281,22 @@ top-100 candidate set. All four runs cover every judged topic, and independent
 documents per topic, so CE Recall@1000 is intentionally not reported. See the
 [full protocol, runtime, provenance, and error review](docs/trec_dl_external_validity.md).
 
+The four text-only ranked runs are also published as a checksummed
+[GitHub Release bundle](https://github.com/GioiaZheng/msmarco-genqa/releases/tag/v2.1-trec-dl-baselines).
+Recompute the table without rebuilding the 8.8M-passage index or rerunning the
+cross-encoder:
+
+```bash
+make reproduce-trec-eval
+```
+
+The command follows the pinned
+[`artifacts/trec_dl_baselines_v1.json`](artifacts/trec_dl_baselines_v1.json)
+pointer, verifies the archive and every member, obtains public qrels through
+`ir_datasets`, and fails if any reproduced metric differs by more than
+`1e-12`. The release excludes passage/query text, qrels mirrors, model caches,
+and machine-local manifests.
+
 ### Generation × retrieval source
 
 Cross-stage comparison on **full dev/small (6 980 queries)**: same
@@ -541,7 +557,7 @@ Console names: `mgq-transform-queries`, `mgq-query-transform-ablation`,
 `mgq-context-packing-report`,
 `mgq-rag-triad`,
 `mgq-export-rag-observatory`,
-`mgq-rerank`, `mgq-generate`, `mgq-trec-eval`.
+`mgq-rerank`, `mgq-generate`, `mgq-trec-eval`, `mgq-trec-release`.
 The examples below use whichever of the script or console forms makes the
 dataset and stage boundary clearest.
 

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -103,6 +103,33 @@ Expected headline value:
 First-run runtime is about 30 minutes on a recent CPU laptop. Later runs can
 reuse the cached BM25 index and finish faster.
 
+## Reproducing the Published TREC-DL Evidence
+
+The fast external-evidence target is:
+
+```bash
+make reproduce-trec-eval
+```
+
+It downloads the pinned GitHub Release asset, verifies the ZIP size and
+SHA-256 digest, validates every member against the bundle manifest, and
+recomputes the BM25 and BM25-plus-cross-encoder metrics for TREC-DL 2019 and
+2020. Public qrels are recovered through `ir_datasets`; no private credentials
+are required. The command writes checked outputs under
+`outputs/reproductions/trec_dl_baselines_v1/evaluation/`.
+
+This is an evidence reproduction, not a new model run: it takes the published
+rankings as input and avoids rebuilding the full 8.8M-passage index or
+rerunning the cross-encoder. Use the full-corpus commands in
+`docs/trec_dl_external_validity.md` when the retrieval pipeline itself must be
+rerun.
+
+The Git-tracked pointer is
+`artifacts/trec_dl_baselines_v1.json`. It pins the immutable release tag, asset
+name, byte size, archive hash, experiment commit, and compact source record.
+The release contains document identifiers and scores only; it does not
+redistribute MS MARCO passage/query text, qrels mirrors, or model weights.
+
 ## Full Pipeline Plan
 
 Print the executable plan:

--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -1,0 +1,14 @@
+# External artifact pointers
+
+This directory contains small, reviewable pointers to immutable experiment
+assets. Payloads remain outside Git; each pointer pins the release tag, asset
+name, byte size, and SHA-256 digest needed to recover it without private
+credentials.
+
+Published assets are never replaced in place. A changed payload receives a
+new tag, asset name, and pointer so prior report evidence remains recoverable.
+
+Current pointer:
+
+- `trec_dl_baselines_v1.json` — text-only BM25 and BM25-plus-cross-encoder
+  TREC-DL 2019/2020 ranked runs.

--- a/artifacts/trec_dl_baselines_v1.json
+++ b/artifacts/trec_dl_baselines_v1.json
@@ -1,0 +1,32 @@
+{
+  "schema": "msmarco-genqa.external-artifact-pointer.v1",
+  "artifact_id": "trec-dl-bm25-ce-2019-2020-v1",
+  "kind": "trec_run_bundle",
+  "release": {
+    "repository": "GioiaZheng/msmarco-genqa",
+    "tag": "v2.1-trec-dl-baselines",
+    "asset": "trec-dl-baselines-v1.zip"
+  },
+  "download": {
+    "url": "https://github.com/GioiaZheng/msmarco-genqa/releases/download/v2.1-trec-dl-baselines/trec-dl-baselines-v1.zip",
+    "bytes": 1041738,
+    "sha256": "e7001a943beb1b1a220ef4a58fae445569725682dc0dbbcb0d9300473a360aa3"
+  },
+  "source": {
+    "experiment_commit": "0362a48bb4d000a93f5af5c26a4de934db37e74f",
+    "record": "reports/generated/artifacts/trec_dl_bm25_ce.json",
+    "record_sha256": "d9487673dd69c7e4b5cf6a8ef5c06aae0d6da2004748904b259ead31d4c44eab"
+  },
+  "contents": {
+    "tracks": [2019, 2020],
+    "systems": ["bm25", "bm25_ce"],
+    "run_files": 4,
+    "contains_msmarco_text": false,
+    "contains_model_weights": false
+  },
+  "reproduce": {
+    "command": "make reproduce-trec-eval",
+    "requires_private_credentials": false,
+    "rebuilds_full_index": false
+  }
+}

--- a/docs/artifact_versioning.md
+++ b/docs/artifact_versioning.md
@@ -44,6 +44,27 @@ The current default is manifest-first and local-first:
 This is sufficient for small public fixtures and report evidence. It is not a
 complete long-term artifact backend for large indexes or model outputs.
 
+## Public release backend
+
+GitHub Releases is the current no-credential backend for compact, public,
+text-only experiment outputs. The first published bundle contains four
+TREC-DL ranked runs (BM25 and BM25-plus-cross-encoder for 2019 and 2020).
+Git tracks only `artifacts/trec_dl_baselines_v1.json`, which pins the release
+tag, asset name, byte size, archive SHA-256 digest, source experiment commit,
+and compact report record.
+
+`make reproduce-trec-eval` resolves that pointer, verifies the outer archive
+and all inner files, recovers public qrels with `ir_datasets`, and recomputes
+the reported metrics without rebuilding the full index. The bundle excludes
+passage/query text, qrels mirrors, model caches, and machine-local manifests.
+This keeps the public evidence useful while respecting the repository's data
+boundary.
+
+Use a new immutable tag and pointer for every changed payload; never replace a
+published asset in place. Hugging Face Datasets remains a reasonable future
+backend if the project accumulates many tabular prediction splits that need
+streaming or dataset-card discovery. It is not needed for this 1 MiB release.
+
 ## When DVC is worth adding
 
 DVC or a similar pointer-file workflow becomes worthwhile when the project

--- a/docs/trec_dl_external_validity.md
+++ b/docs/trec_dl_external_validity.md
@@ -103,6 +103,30 @@ lift counts, commit/config identifiers, and SHA-256 digests of every local
 run, manifest, cross-check, and lift artifact is
 [`reports/generated/artifacts/trec_dl_bm25_ce.json`](../reports/generated/artifacts/trec_dl_bm25_ce.json).
 
+## Published run bundle
+
+The exact four ranked runs behind the tables are published in the
+[`v2.1-trec-dl-baselines`](https://github.com/GioiaZheng/msmarco-genqa/releases/tag/v2.1-trec-dl-baselines)
+GitHub Release. The checked pointer is
+[`artifacts/trec_dl_baselines_v1.json`](../artifacts/trec_dl_baselines_v1.json).
+
+From a configured clone:
+
+```bash
+make reproduce-trec-eval
+```
+
+This fast path downloads about 1 MiB, verifies the archive and all member
+digests, recovers the public judged qrels through `ir_datasets`, and recomputes
+all four result rows at tolerance `1e-12`. It does not rebuild the passage
+index or rerun either retrieval system. The release contains ranked document
+identifiers and scores only; passage/query text, qrels mirrors, model weights,
+and machine-local manifests are excluded.
+
+For a full computational reproduction, use the runner commands below. That
+path recreates the rankings from the 8,841,823-passage corpus and is therefore
+substantially more expensive than verifying the published evidence.
+
 ## What the loader provides
 
 `msmarco_genqa.data.trec_dl` exposes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ mgq-pipeline = "msmarco_genqa.cli.pipeline:main"
 mgq-serve    = "msmarco_genqa.service.app:main"
 rag-eval     = "msmarco_genqa.cli.rag_eval:main"
 mgq-trec-eval = "msmarco_genqa.cli.trec_eval:main"
+mgq-trec-release = "msmarco_genqa.cli.trec_release:main"
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/check_artifact_boundaries.py
+++ b/scripts/check_artifact_boundaries.py
@@ -32,6 +32,7 @@ DATA_PREFIXES = (
     "data/processed/",
     "data/cache/",
 )
+ARTIFACT_POINTER_PREFIX = "artifacts/"
 
 ALLOWED_EXACT = {
     "data/raw/.gitkeep",
@@ -78,6 +79,14 @@ def check_paths(
 
         file_path = project_root / path
         suffix = file_path.suffix.lower()
+
+        if path.startswith(ARTIFACT_POINTER_PREFIX):
+            if path != "artifacts/README.md" and suffix != ".json":
+                errors.append(f"{path}: artifacts/ may contain only JSON pointers and README.md")
+                continue
+            if file_path.stat().st_size > max_pointer_bytes:
+                errors.append(f"{path}: external artifact pointers must stay small")
+            continue
 
         if path.startswith(DATA_PREFIXES):
             errors.append(f"{path}: data payloads must stay outside Git")

--- a/src/msmarco_genqa/cli/trec_release.py
+++ b/src/msmarco_genqa/cli/trec_release.py
@@ -1,0 +1,132 @@
+"""Manage the public TREC-DL baseline release bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from msmarco_genqa.reproducibility.trec_release import (
+    ReleaseArtifactError,
+    build_release_bundle,
+    evaluate_release_bundle,
+    fetch_release_bundle,
+    verify_release_archive,
+)
+
+
+DEFAULT_POINTER = Path("artifacts/trec_dl_baselines_v1.json")
+DEFAULT_OUTPUT = Path("outputs/reproductions/trec_dl_baselines_v1")
+
+
+def _add_qrels_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--qrels-2019",
+        type=Path,
+        help="Optional local TREC-format qrels; otherwise use ir_datasets.",
+    )
+    parser.add_argument(
+        "--qrels-2020",
+        type=Path,
+        help="Optional local TREC-format qrels; otherwise use ir_datasets.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        help="Optional IR_DATASETS_HOME used to recover public qrels.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="Build the deterministic release ZIP.")
+    build.add_argument(
+        "--source-record",
+        type=Path,
+        default=Path("reports/generated/artifacts/trec_dl_bm25_ce.json"),
+    )
+    build.add_argument("--project-root", type=Path, default=Path.cwd())
+    build.add_argument("--output", type=Path, required=True)
+
+    verify = subparsers.add_parser("verify", help="Verify an existing release ZIP.")
+    verify.add_argument("archive", type=Path)
+    verify.add_argument("--sha256")
+    verify.add_argument("--bytes", type=int)
+
+    fetch = subparsers.add_parser("fetch", help="Download and extract the pinned release.")
+    fetch.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
+    fetch.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+
+    evaluate = subparsers.add_parser("evaluate", help="Recompute metrics from an extracted bundle.")
+    evaluate.add_argument("--bundle-dir", type=Path, required=True)
+    evaluate.add_argument("--output-dir", type=Path, required=True)
+    _add_qrels_arguments(evaluate)
+
+    reproduce = subparsers.add_parser(
+        "reproduce",
+        help="Download, verify, and recompute the published metrics.",
+    )
+    reproduce.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
+    reproduce.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+    _add_qrels_arguments(reproduce)
+    return parser
+
+
+def _qrels_paths(args: argparse.Namespace) -> dict[int, Path] | None:
+    paths = {
+        year: path
+        for year, path in ((2019, args.qrels_2019), (2020, args.qrels_2020))
+        if path is not None
+    }
+    return paths or None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "build":
+            result = build_release_bundle(
+                source_record_path=args.source_record,
+                project_root=args.project_root,
+                output_archive=args.output,
+            )
+        elif args.command == "verify":
+            result = verify_release_archive(
+                args.archive,
+                expected_sha256=args.sha256,
+                expected_bytes=args.bytes,
+            )
+        elif args.command == "fetch":
+            result = fetch_release_bundle(
+                pointer_path=args.pointer,
+                output_dir=args.output_dir,
+            )
+        elif args.command == "evaluate":
+            result = evaluate_release_bundle(
+                bundle_dir=args.bundle_dir,
+                output_dir=args.output_dir,
+                qrels_paths=_qrels_paths(args),
+                cache_dir=args.cache_dir,
+            )
+        else:
+            fetched = fetch_release_bundle(
+                pointer_path=args.pointer,
+                output_dir=args.output_dir,
+            )
+            result = evaluate_release_bundle(
+                bundle_dir=fetched["bundle_dir"],
+                output_dir=Path(args.output_dir) / "evaluation",
+                qrels_paths=_qrels_paths(args),
+                cache_dir=args.cache_dir,
+            )
+    except (OSError, ReleaseArtifactError, ValueError) as exc:
+        parser.exit(2, f"error: {exc}\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/msmarco_genqa/reproducibility/__init__.py
+++ b/src/msmarco_genqa/reproducibility/__init__.py
@@ -1,0 +1,23 @@
+"""Utilities for recovering and validating published experiment artifacts."""
+
+from msmarco_genqa.reproducibility.trec_release import (
+    BUNDLE_SCHEMA,
+    POINTER_SCHEMA,
+    ReleaseArtifactError,
+    build_release_bundle,
+    evaluate_release_bundle,
+    fetch_release_bundle,
+    load_release_pointer,
+    verify_release_archive,
+)
+
+__all__ = [
+    "BUNDLE_SCHEMA",
+    "POINTER_SCHEMA",
+    "ReleaseArtifactError",
+    "build_release_bundle",
+    "evaluate_release_bundle",
+    "fetch_release_bundle",
+    "load_release_pointer",
+    "verify_release_archive",
+]

--- a/src/msmarco_genqa/reproducibility/trec_release.py
+++ b/src/msmarco_genqa/reproducibility/trec_release.py
@@ -1,0 +1,738 @@
+"""Build, recover, and re-evaluate the public TREC-DL run bundle.
+
+The release bundle deliberately contains only ranked document identifiers,
+scores, compact metadata, and checksums. It excludes passage/query text,
+dataset mirrors, model caches, and machine-local run manifests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from msmarco_genqa.data.trec_dl import DEFAULT_REL_THRESHOLD, load_trec_dl
+from msmarco_genqa.evaluation.trec import evaluate_internal_trec_scope, read_qrels
+from msmarco_genqa.reranking.io import read_run_tsv
+
+
+BUNDLE_SCHEMA = "msmarco-genqa.trec-dl-release-bundle.v1"
+POINTER_SCHEMA = "msmarco-genqa.external-artifact-pointer.v1"
+REPRODUCTION_SCHEMA = "msmarco-genqa.trec-dl-reproduction.v1"
+SOURCE_RECORD_SCHEMA = "msmarco-genqa.table-artifact.v1"
+MANIFEST_NAME = "bundle_manifest.json"
+README_NAME = "README.md"
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+DEFAULT_TOLERANCE = 1e-12
+MAX_MANIFEST_BYTES = 1_000_000
+MAX_MEMBER_BYTES = 50_000_000
+MAX_TOTAL_MEMBER_BYTES = 100_000_000
+WINDOWS_DEVICE_NAMES = {
+    "AUX",
+    "CON",
+    "NUL",
+    "PRN",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+}
+
+
+class ReleaseArtifactError(RuntimeError):
+    """Raised when a release artifact fails validation or reproduction."""
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    year: int
+    system: str
+    source_key: str
+    result_key: str
+    archive_path: str
+
+
+RUN_SPECS = (
+    RunSpec(2019, "bm25", "bm25_run", "bm25", "runs/trec_dl_2019_bm25.tsv"),
+    RunSpec(
+        2019,
+        "bm25_ce",
+        "rerank_run",
+        "bm25_ce",
+        "runs/trec_dl_2019_bm25_ce.tsv",
+    ),
+    RunSpec(2020, "bm25", "bm25_run", "bm25", "runs/trec_dl_2020_bm25.tsv"),
+    RunSpec(
+        2020,
+        "bm25_ce",
+        "rerank_run",
+        "bm25_ce",
+        "runs/trec_dl_2020_bm25_ce.tsv",
+    ),
+)
+
+
+def _load_json_object(path: Path | str) -> dict[str, Any]:
+    source = Path(path)
+    try:
+        value = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReleaseArtifactError(f"cannot read JSON object {source}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ReleaseArtifactError(f"{source}: expected a JSON object")
+    return value
+
+
+def _canonical_json_bytes(value: dict[str, Any]) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def sha256_bytes(data: bytes) -> str:
+    """Return the lowercase SHA-256 digest for *data*."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path | str) -> str:
+    """Return the lowercase SHA-256 digest for a file without loading it all."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _safe_archive_name(name: str) -> str:
+    if not name or "\\" in name or "\x00" in name:
+        raise ReleaseArtifactError(f"unsafe archive member name: {name!r}")
+    path = PurePosixPath(name)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ReleaseArtifactError(f"unsafe archive member name: {name!r}")
+    for part in path.parts:
+        stem = part.split(".", 1)[0].upper()
+        if ":" in part or part.rstrip(" .") != part or stem in WINDOWS_DEVICE_NAMES:
+            raise ReleaseArtifactError(f"unsafe archive member name: {name!r}")
+    return path.as_posix()
+
+
+def _member_record(path: str, data: bytes, **metadata: Any) -> dict[str, Any]:
+    return {
+        "path": _safe_archive_name(path),
+        "bytes": len(data),
+        "sha256": sha256_bytes(data),
+        **metadata,
+    }
+
+
+def _run_statistics(path: Path) -> tuple[int, int, int]:
+    run = read_run_tsv(path)
+    if not run:
+        raise ReleaseArtifactError(f"{path}: run contains no records")
+    row_count = sum(len(rows) for rows in run.values())
+    max_depth = max(len(rows) for rows in run.values())
+    return len(run), row_count, max_depth
+
+
+def _expected_metrics(result: dict[str, Any]) -> dict[str, float]:
+    names = ("mrr@10", "ndcg@10", "recall@100", "recall@1000")
+    metrics = {
+        name: float(result[name])
+        for name in names
+        if name in result
+    }
+    if not metrics:
+        raise ReleaseArtifactError("source record contains no headline metrics")
+    return metrics
+
+
+def _bundle_readme(artifact_id: str, experiment_commit: str) -> bytes:
+    text = f"""# TREC-DL baseline run bundle
+
+Artifact: `{artifact_id}`
+
+Experiment commit: `{experiment_commit}`
+
+This archive contains the BM25 and BM25-plus-cross-encoder ranked run files
+for the judged TREC-DL 2019 and 2020 passage tracks. It contains document
+identifiers and scores, but no passage text, query text, qrels mirror, model
+weights, or machine-local paths.
+
+From a clone of `GioiaZheng/msmarco-genqa`, run:
+
+```bash
+make reproduce-trec-eval
+```
+
+The command verifies the archive and member SHA-256 digests, obtains the
+public judgments through `ir_datasets`, recomputes the headline metrics, and
+checks them against `bundle_manifest.json`. This validates the published
+retrieval evidence without rebuilding the 8.8M-passage index or rerunning the
+cross-encoder.
+"""
+    return text.encode("utf-8")
+
+
+def _write_deterministic_zip(path: Path, members: dict[str, bytes]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent, delete=False
+    ) as handle:
+        temporary = Path(handle.name)
+    try:
+        with zipfile.ZipFile(
+            temporary,
+            mode="w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
+        ) as archive:
+            for name in sorted(members):
+                safe_name = _safe_archive_name(name)
+                info = zipfile.ZipInfo(safe_name, date_time=ZIP_TIMESTAMP)
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = 0o100644 << 16
+                info.create_system = 3
+                archive.writestr(info, members[name], compresslevel=9)
+        temporary.replace(path)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def build_release_bundle(
+    *,
+    source_record_path: Path | str,
+    project_root: Path | str,
+    output_archive: Path | str,
+    artifact_id: str = "trec-dl-bm25-ce-2019-2020-v1",
+) -> dict[str, Any]:
+    """Build a deterministic, text-only release archive from canonical runs."""
+    root = Path(project_root).resolve()
+    source_record_path = Path(source_record_path).resolve()
+    try:
+        source_record_relative = source_record_path.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ReleaseArtifactError(
+            f"source record must be inside the project root: {source_record_path}"
+        ) from exc
+    source_record = _load_json_object(source_record_path)
+    if source_record.get("schema") != SOURCE_RECORD_SCHEMA:
+        raise ReleaseArtifactError(
+            f"{source_record_path}: expected schema {SOURCE_RECORD_SCHEMA!r}"
+        )
+
+    experiment = source_record.get("experiment")
+    if not isinstance(experiment, dict) or not experiment.get("git_commit"):
+        raise ReleaseArtifactError("source record is missing experiment.git_commit")
+    experiment_commit = str(experiment["git_commit"])
+
+    members: dict[str, bytes] = {}
+    run_records: list[dict[str, Any]] = []
+    results = source_record.get("results")
+    if not isinstance(results, dict):
+        raise ReleaseArtifactError("source record is missing results")
+
+    for spec in RUN_SPECS:
+        year_result = results.get(str(spec.year))
+        if not isinstance(year_result, dict):
+            raise ReleaseArtifactError(f"source record is missing results.{spec.year}")
+        artifact_paths = year_result.get("artifact_paths")
+        artifact_hashes = year_result.get("artifact_sha256")
+        system_result = year_result.get(spec.result_key)
+        if not all(isinstance(value, dict) for value in (artifact_paths, artifact_hashes, system_result)):
+            raise ReleaseArtifactError(
+                f"source record has incomplete {spec.year} {spec.system} metadata"
+            )
+
+        relative_source = artifact_paths.get(spec.source_key)
+        expected_source_hash = artifact_hashes.get(spec.source_key)
+        if not isinstance(relative_source, str) or not isinstance(expected_source_hash, str):
+            raise ReleaseArtifactError(
+                f"source record has no path/hash for {spec.year} {spec.system}"
+            )
+        source_path = (root / relative_source).resolve()
+        try:
+            source_path.relative_to(root)
+        except ValueError as exc:
+            raise ReleaseArtifactError(
+                f"source path escapes project root: {relative_source}"
+            ) from exc
+        if not source_path.is_file():
+            raise ReleaseArtifactError(f"missing canonical run: {relative_source}")
+        data = source_path.read_bytes()
+        actual_source_hash = sha256_bytes(data)
+        if actual_source_hash != expected_source_hash.lower():
+            raise ReleaseArtifactError(
+                f"{relative_source}: SHA-256 mismatch; expected "
+                f"{expected_source_hash}, got {actual_source_hash}"
+            )
+        query_count, row_count, max_depth = _run_statistics(source_path)
+        judged_topics = int(year_result.get("judged_topics", 0))
+        if query_count != judged_topics:
+            raise ReleaseArtifactError(
+                f"{relative_source}: found {query_count} queries; "
+                f"source record declares {judged_topics}"
+            )
+
+        members[spec.archive_path] = data
+        run_records.append(
+            _member_record(
+                spec.archive_path,
+                data,
+                kind="trec_run",
+                year=spec.year,
+                system=spec.system,
+                query_count=query_count,
+                row_count=row_count,
+                max_depth=max_depth,
+                expected_metrics=_expected_metrics(system_result),
+            )
+        )
+
+    readme = _bundle_readme(artifact_id, experiment_commit)
+    members[README_NAME] = readme
+    readme_record = _member_record(README_NAME, readme, kind="documentation")
+    manifest = {
+        "schema": BUNDLE_SCHEMA,
+        "artifact_id": artifact_id,
+        "experiment_commit": experiment_commit,
+        "source_record": {
+            "repository_path": source_record_relative,
+            "sha256": sha256_file(source_record_path),
+        },
+        "scope": {
+            "datasets": [
+                "msmarco-passage/trec-dl-2019/judged",
+                "msmarco-passage/trec-dl-2020/judged",
+            ],
+            "systems": ["bm25", "bm25_ce"],
+            "binary_relevance_threshold": DEFAULT_REL_THRESHOLD,
+            "metric_tolerance": DEFAULT_TOLERANCE,
+        },
+        "redistribution": {
+            "included": "ranked document identifiers, ranks, scores, and checksums",
+            "excluded": [
+                "MS MARCO passage text",
+                "query text",
+                "qrels mirrors",
+                "model weights and caches",
+                "machine-local paths",
+            ],
+            "qrels_recovery": "ir_datasets judged TREC-DL subsets",
+        },
+        "members": [readme_record, *run_records],
+    }
+    members[MANIFEST_NAME] = _canonical_json_bytes(manifest)
+
+    archive_path = Path(output_archive).resolve()
+    _write_deterministic_zip(archive_path, members)
+    return {
+        "archive": str(archive_path),
+        "bytes": archive_path.stat().st_size,
+        "sha256": sha256_file(archive_path),
+        "manifest": manifest,
+    }
+
+
+def _read_archive_manifest(archive: zipfile.ZipFile) -> dict[str, Any]:
+    try:
+        if archive.getinfo(MANIFEST_NAME).file_size > MAX_MANIFEST_BYTES:
+            raise ReleaseArtifactError(f"{MANIFEST_NAME} exceeds the size limit")
+        raw = archive.read(MANIFEST_NAME)
+        manifest = json.loads(raw.decode("utf-8"))
+    except KeyError as exc:
+        raise ReleaseArtifactError(f"archive is missing {MANIFEST_NAME}") from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReleaseArtifactError(f"invalid {MANIFEST_NAME}: {exc}") from exc
+    if not isinstance(manifest, dict) or manifest.get("schema") != BUNDLE_SCHEMA:
+        raise ReleaseArtifactError(f"archive does not use {BUNDLE_SCHEMA}")
+    return manifest
+
+
+def _manifest_members(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw_members = manifest.get("members")
+    if not isinstance(raw_members, list) or not raw_members:
+        raise ReleaseArtifactError("bundle manifest has no members")
+    members: dict[str, dict[str, Any]] = {}
+    total_bytes = 0
+    for record in raw_members:
+        if not isinstance(record, dict):
+            raise ReleaseArtifactError("bundle manifest member is not an object")
+        name = record.get("path")
+        if not isinstance(name, str):
+            raise ReleaseArtifactError("bundle manifest member has no path")
+        safe_name = _safe_archive_name(name)
+        if safe_name in members:
+            raise ReleaseArtifactError(f"duplicate bundle manifest member: {safe_name}")
+        if not isinstance(record.get("sha256"), str) or not isinstance(record.get("bytes"), int):
+            raise ReleaseArtifactError(f"incomplete member record: {safe_name}")
+        member_bytes = int(record["bytes"])
+        if member_bytes < 0 or member_bytes > MAX_MEMBER_BYTES:
+            raise ReleaseArtifactError(f"invalid member size: {safe_name}")
+        total_bytes += member_bytes
+        if total_bytes > MAX_TOTAL_MEMBER_BYTES:
+            raise ReleaseArtifactError("bundle members exceed the total size limit")
+        members[safe_name] = record
+    return members
+
+
+def verify_release_archive(
+    archive_path: Path | str,
+    *,
+    expected_sha256: str | None = None,
+    expected_bytes: int | None = None,
+) -> dict[str, Any]:
+    """Verify outer archive identity, safe paths, and every member checksum."""
+    source = Path(archive_path)
+    if not source.is_file():
+        raise ReleaseArtifactError(f"release archive not found: {source}")
+    actual_sha256 = sha256_file(source)
+    actual_bytes = source.stat().st_size
+    if expected_sha256 is not None and actual_sha256 != expected_sha256.lower():
+        raise ReleaseArtifactError(
+            f"{source}: archive SHA-256 mismatch; expected {expected_sha256}, got {actual_sha256}"
+        )
+    if expected_bytes is not None and actual_bytes != expected_bytes:
+        raise ReleaseArtifactError(
+            f"{source}: archive size mismatch; expected {expected_bytes}, got {actual_bytes}"
+        )
+
+    try:
+        with zipfile.ZipFile(source) as archive:
+            infos = archive.infolist()
+            names = [_safe_archive_name(info.filename) for info in infos]
+            if len(names) != len(set(names)):
+                raise ReleaseArtifactError("archive contains duplicate member names")
+            manifest = _read_archive_manifest(archive)
+            member_records = _manifest_members(manifest)
+            expected_names = {MANIFEST_NAME, *member_records}
+            if set(names) != expected_names:
+                missing = sorted(expected_names - set(names))
+                extra = sorted(set(names) - expected_names)
+                raise ReleaseArtifactError(
+                    f"archive member set mismatch; missing={missing}, extra={extra}"
+                )
+            for name, record in member_records.items():
+                data = archive.read(name)
+                if len(data) != record["bytes"]:
+                    raise ReleaseArtifactError(f"{name}: member size mismatch")
+                actual_member_hash = sha256_bytes(data)
+                if actual_member_hash != str(record["sha256"]).lower():
+                    raise ReleaseArtifactError(f"{name}: member SHA-256 mismatch")
+    except zipfile.BadZipFile as exc:
+        raise ReleaseArtifactError(f"invalid ZIP archive {source}: {exc}") from exc
+
+    return {
+        "archive": str(source.resolve()),
+        "bytes": actual_bytes,
+        "sha256": actual_sha256,
+        "manifest": manifest,
+    }
+
+
+def load_release_pointer(pointer_path: Path | str) -> dict[str, Any]:
+    """Load and validate a Git-tracked external-artifact pointer."""
+    pointer = _load_json_object(pointer_path)
+    if pointer.get("schema") != POINTER_SCHEMA:
+        raise ReleaseArtifactError(f"pointer does not use {POINTER_SCHEMA}")
+    if not isinstance(pointer.get("artifact_id"), str) or not pointer["artifact_id"]:
+        raise ReleaseArtifactError("pointer is missing artifact_id")
+    release = pointer.get("release")
+    download = pointer.get("download")
+    if not isinstance(release, dict) or not isinstance(download, dict):
+        raise ReleaseArtifactError("pointer is missing release/download metadata")
+    required_release = ("repository", "tag", "asset")
+    required_download = ("url", "sha256", "bytes")
+    if any(not isinstance(release.get(key), str) or not release[key] for key in required_release):
+        raise ReleaseArtifactError("pointer has incomplete release metadata")
+    if any(download.get(key) is None or download.get(key) == "" for key in required_download):
+        raise ReleaseArtifactError("pointer has incomplete download metadata")
+    if not isinstance(download["url"], str) or not download["url"].startswith(
+        ("https://", "file://")
+    ):
+        raise ReleaseArtifactError(
+            "pointer download.url must use HTTPS (file:// is for local validation)"
+        )
+    if (
+        isinstance(download["bytes"], bool)
+        or not isinstance(download["bytes"], int)
+        or download["bytes"] < 1
+    ):
+        raise ReleaseArtifactError("pointer download.bytes must be a positive integer")
+    if not isinstance(download["sha256"], str):
+        raise ReleaseArtifactError("pointer download.sha256 is not a SHA-256 digest")
+    digest = download["sha256"].lower()
+    if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+        raise ReleaseArtifactError("pointer download.sha256 is not a SHA-256 digest")
+    return pointer
+
+
+def _download(
+    url: str,
+    destination: Path,
+    *,
+    expected_bytes: int,
+    timeout: float,
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    request = urllib.request.Request(url, headers={"User-Agent": "msmarco-genqa/trec-release"})
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{destination.name}.", suffix=".part", dir=destination.parent, delete=False
+    ) as handle:
+        temporary = Path(handle.name)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response, temporary.open("wb") as out:
+            copied = 0
+            while True:
+                block = response.read(min(1024 * 1024, expected_bytes - copied + 1))
+                if not block:
+                    break
+                copied += len(block)
+                if copied > expected_bytes:
+                    raise ReleaseArtifactError(
+                        f"download exceeds the pinned size of {expected_bytes} bytes"
+                    )
+                out.write(block)
+            if copied != expected_bytes:
+                raise ReleaseArtifactError(
+                    f"download size mismatch; expected {expected_bytes}, got {copied}"
+                )
+        temporary.replace(destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _verify_extracted_directory(bundle_dir: Path, manifest: dict[str, Any]) -> None:
+    for name, record in _manifest_members(manifest).items():
+        target = _safe_extraction_target(bundle_dir, name)
+        if not target.is_file():
+            raise ReleaseArtifactError(f"extracted bundle is missing {name}")
+        if target.stat().st_size != record["bytes"] or sha256_file(target) != str(
+            record["sha256"]
+        ).lower():
+            raise ReleaseArtifactError(f"extracted bundle member failed validation: {name}")
+
+
+def _safe_extraction_target(bundle_dir: Path, name: str) -> Path:
+    safe_name = _safe_archive_name(name)
+    root = bundle_dir.resolve()
+    target = bundle_dir.joinpath(*PurePosixPath(safe_name).parts)
+    for parent in target.parents:
+        if parent == bundle_dir.parent:
+            break
+        if parent.exists() and parent.is_symlink():
+            raise ReleaseArtifactError(f"refusing to extract through a symlink: {parent}")
+    if target.exists() and target.is_symlink():
+        raise ReleaseArtifactError(f"refusing to overwrite a symlink: {target}")
+    try:
+        target.parent.resolve().relative_to(root)
+    except ValueError as exc:
+        raise ReleaseArtifactError(f"archive member escapes extraction root: {name}") from exc
+    return target
+
+
+def _extract_verified_archive(archive_path: Path, bundle_dir: Path) -> dict[str, Any]:
+    verified = verify_release_archive(archive_path)
+    manifest = verified["manifest"]
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path) as archive:
+        for name in sorted({MANIFEST_NAME, *_manifest_members(manifest)}):
+            target = _safe_extraction_target(bundle_dir, name)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            data = archive.read(name)
+            if target.exists():
+                if not target.is_file() or target.read_bytes() != data:
+                    raise ReleaseArtifactError(
+                        f"refusing to overwrite different existing bundle member: {target}"
+                    )
+                continue
+            with tempfile.NamedTemporaryFile(
+                prefix=f".{target.name}.", suffix=".part", dir=target.parent, delete=False
+            ) as handle:
+                temporary = Path(handle.name)
+                handle.write(data)
+            temporary.replace(target)
+    _verify_extracted_directory(bundle_dir, manifest)
+    return verified
+
+
+def fetch_release_bundle(
+    *,
+    pointer_path: Path | str,
+    output_dir: Path | str,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Download, verify, and safely extract the release selected by a pointer."""
+    pointer = load_release_pointer(pointer_path)
+    release = pointer["release"]
+    download = pointer["download"]
+    destination = Path(output_dir).resolve()
+    asset_name = _safe_archive_name(str(release["asset"]))
+    if "/" in asset_name:
+        raise ReleaseArtifactError("release asset must be a file name, not a path")
+    archive_path = destination / asset_name
+    expected_hash = str(download["sha256"]).lower()
+    expected_bytes = int(download["bytes"])
+    if archive_path.exists():
+        verify_release_archive(
+            archive_path,
+            expected_sha256=expected_hash,
+            expected_bytes=expected_bytes,
+        )
+    else:
+        try:
+            _download(
+                str(download["url"]),
+                archive_path,
+                expected_bytes=expected_bytes,
+                timeout=timeout,
+            )
+        except (OSError, urllib.error.URLError) as exc:
+            raise ReleaseArtifactError(
+                f"cannot download {download['url']}: {exc}"
+            ) from exc
+        verify_release_archive(
+            archive_path,
+            expected_sha256=expected_hash,
+            expected_bytes=expected_bytes,
+        )
+    bundle_dir = destination / "bundle"
+    verified = _extract_verified_archive(archive_path, bundle_dir)
+    if verified["manifest"].get("artifact_id") != pointer["artifact_id"]:
+        raise ReleaseArtifactError(
+            "release bundle artifact_id does not match the Git-tracked pointer"
+        )
+    return {
+        **verified,
+        "bundle_dir": str(bundle_dir),
+        "release": release,
+    }
+
+
+def _load_qrels_for_year(
+    year: int,
+    *,
+    qrels_paths: dict[int, Path] | None,
+    cache_dir: Path | None,
+) -> tuple[dict[str, dict[str, int]], str]:
+    if qrels_paths and year in qrels_paths:
+        path = qrels_paths[year]
+        return read_qrels(path, qrels_format="trec"), str(path)
+    dataset = load_trec_dl(year, cache_dir=cache_dir, rel_threshold=DEFAULT_REL_THRESHOLD)
+    return dataset.graded_qrels, dataset.dataset_name
+
+
+def _write_reproduction_table(path: Path, results: dict[str, Any]) -> None:
+    lines = [
+        "# Reproduced TREC-DL metrics",
+        "",
+        "| Track | System | MRR@10 | nDCG@10 | Recall@100 | Recall@1000 | Max abs. delta |",
+        "|---|---|---:|---:|---:|---:|---:|",
+    ]
+    for key in sorted(results):
+        record = results[key]
+        metrics = record["metrics"]
+        lines.append(
+            "| {year} | {system} | {mrr:.4f} | {ndcg:.4f} | {r100:.4f} | {r1000} | {delta:.2e} |".format(
+                year=record["year"],
+                system=record["system"],
+                mrr=metrics["mrr@10"],
+                ndcg=metrics["ndcg@10"],
+                r100=metrics["recall@100"],
+                r1000=f"{metrics['recall@1000']:.4f}" if "recall@1000" in metrics else "n/a",
+                delta=record["max_abs_delta"],
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def evaluate_release_bundle(
+    *,
+    bundle_dir: Path | str,
+    output_dir: Path | str,
+    qrels_paths: dict[int, Path] | None = None,
+    cache_dir: Path | str | None = None,
+    tolerance: float = DEFAULT_TOLERANCE,
+) -> dict[str, Any]:
+    """Recompute every published metric and fail on any out-of-tolerance delta."""
+    if tolerance < 0 or not math.isfinite(tolerance):
+        raise ReleaseArtifactError("tolerance must be finite and non-negative")
+    source = Path(bundle_dir).resolve()
+    manifest = _load_json_object(source / MANIFEST_NAME)
+    if manifest.get("schema") != BUNDLE_SCHEMA:
+        raise ReleaseArtifactError(f"bundle directory does not use {BUNDLE_SCHEMA}")
+    _verify_extracted_directory(source, manifest)
+
+    qrels_by_year: dict[int, dict[str, dict[str, int]]] = {}
+    qrels_sources: dict[int, str] = {}
+    cache_path = Path(cache_dir).resolve() if cache_dir is not None else None
+    run_members = [
+        record
+        for record in _manifest_members(manifest).values()
+        if record.get("kind") == "trec_run"
+    ]
+    results: dict[str, Any] = {}
+    global_max_delta = 0.0
+    for record in run_members:
+        year = int(record["year"])
+        if year not in qrels_by_year:
+            qrels_by_year[year], qrels_sources[year] = _load_qrels_for_year(
+                year,
+                qrels_paths=qrels_paths,
+                cache_dir=cache_path,
+            )
+        run = read_run_tsv(source / str(record["path"]))
+        metrics = evaluate_internal_trec_scope(
+            run,
+            qrels_by_year[year],
+            rel_threshold=DEFAULT_REL_THRESHOLD,
+        )
+        expected_metrics = record.get("expected_metrics")
+        if not isinstance(expected_metrics, dict) or not expected_metrics:
+            raise ReleaseArtifactError(f"{record['path']}: expected metrics are missing")
+        deltas = {
+            name: abs(float(metrics[name]) - float(expected))
+            for name, expected in expected_metrics.items()
+        }
+        max_delta = max(deltas.values(), default=0.0)
+        if max_delta > tolerance:
+            raise ReleaseArtifactError(
+                f"{record['path']}: reproduced metrics differ from the release record; "
+                f"max delta {max_delta:.3g} exceeds {tolerance:g}"
+            )
+        global_max_delta = max(global_max_delta, max_delta)
+        key = f"{year}_{record['system']}"
+        reproduced_metrics = {
+            name: float(metrics[name])
+            for name in expected_metrics
+        }
+        reproduced_metrics["n_queries"] = int(metrics["n_queries"])
+        results[key] = {
+            "year": year,
+            "system": record["system"],
+            "run": record["path"],
+            "qrels_source": qrels_sources[year],
+            "metrics": reproduced_metrics,
+            "expected_metrics": expected_metrics,
+            "absolute_deltas": deltas,
+            "max_abs_delta": max_delta,
+        }
+
+    report = {
+        "schema": REPRODUCTION_SCHEMA,
+        "artifact_id": manifest.get("artifact_id"),
+        "experiment_commit": manifest.get("experiment_commit"),
+        "verified": True,
+        "tolerance": tolerance,
+        "max_abs_delta": global_max_delta,
+        "results": results,
+    }
+    destination = Path(output_dir).resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+    (destination / "metrics.json").write_bytes(_canonical_json_bytes(report))
+    _write_reproduction_table(destination / "metrics.md", results)
+    return report

--- a/tests/test_check_artifact_boundaries.py
+++ b/tests/test_check_artifact_boundaries.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_CHECK_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_artifact_boundaries.py"
+_spec = importlib.util.spec_from_file_location("check_artifact_boundaries", _CHECK_PATH)
+check_artifact_boundaries = importlib.util.module_from_spec(_spec)
+sys.modules["check_artifact_boundaries"] = check_artifact_boundaries
+_spec.loader.exec_module(check_artifact_boundaries)  # type: ignore[union-attr]
+
+
+def test_allows_small_external_artifact_pointer(tmp_path: Path) -> None:
+    pointer = tmp_path / "artifacts" / "run.json"
+    pointer.parent.mkdir()
+    pointer.write_text("{}\n", encoding="utf-8")
+
+    errors = check_artifact_boundaries.check_paths(
+        ["artifacts/run.json"],
+        project_root=tmp_path,
+        max_pointer_bytes=100,
+    )
+
+    assert errors == []
+
+
+def test_rejects_oversized_external_artifact_pointer(tmp_path: Path) -> None:
+    pointer = tmp_path / "artifacts" / "run.json"
+    pointer.parent.mkdir()
+    pointer.write_text("x" * 101, encoding="utf-8")
+
+    errors = check_artifact_boundaries.check_paths(
+        ["artifacts/run.json"],
+        project_root=tmp_path,
+        max_pointer_bytes=100,
+    )
+
+    assert errors == ["artifacts/run.json: external artifact pointers must stay small"]
+
+
+def test_rejects_payload_file_in_external_artifact_directory(tmp_path: Path) -> None:
+    payload = tmp_path / "artifacts" / "run.tsv"
+    payload.parent.mkdir()
+    payload.write_text("qid Q0 doc 1 1.0 run\n", encoding="utf-8")
+
+    errors = check_artifact_boundaries.check_paths(
+        ["artifacts/run.tsv"],
+        project_root=tmp_path,
+        max_pointer_bytes=100,
+    )
+
+    assert errors == [
+        "artifacts/run.tsv: artifacts/ may contain only JSON pointers and README.md"
+    ]

--- a/tests/test_trec_release.py
+++ b/tests/test_trec_release.py
@@ -1,0 +1,236 @@
+"""Tests for the public TREC-DL release and recovery workflow."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from msmarco_genqa.evaluation.trec import evaluate_internal_trec_scope, read_qrels
+from msmarco_genqa.reproducibility.trec_release import (
+    POINTER_SCHEMA,
+    ReleaseArtifactError,
+    build_release_bundle,
+    evaluate_release_bundle,
+    fetch_release_bundle,
+    load_release_pointer,
+    sha256_file,
+    verify_release_archive,
+)
+from msmarco_genqa.reranking.io import read_run_tsv
+
+
+def _write_run(path: Path, rows: list[tuple[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"{qid}\tQ0\t{doc_id}\t1\t1.0\ttest"
+        for qid, doc_id in rows
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def _make_release_sources(root: Path) -> tuple[Path, dict[int, Path]]:
+    qrels_paths: dict[int, Path] = {}
+    year_rows = {
+        2019: {
+            "qrels": "q1 0 d1 3\nq1 0 dx 0\nq2 0 d2 2\n",
+            "bm25": [("q1", "d1"), ("q2", "miss")],
+            "bm25_ce": [("q1", "d1"), ("q2", "d2")],
+        },
+        2020: {
+            "qrels": "q3 0 d3 3\nq3 0 dy 1\nq4 0 d4 2\n",
+            "bm25": [("q3", "miss"), ("q4", "d4")],
+            "bm25_ce": [("q3", "d3"), ("q4", "d4")],
+        },
+    }
+    results: dict[str, object] = {}
+    for year, values in year_rows.items():
+        qrels_path = root / "qrels" / f"{year}.qrels"
+        qrels_path.parent.mkdir(parents=True, exist_ok=True)
+        qrels_path.write_text(str(values["qrels"]), encoding="utf-8", newline="\n")
+        qrels_paths[year] = qrels_path
+        qrels = read_qrels(qrels_path, qrels_format="trec")
+
+        bm25_path = root / "outputs" / f"trec_dl_{year}" / "bm25" / "run.tsv"
+        rerank_path = (
+            root / "outputs" / f"trec_dl_{year}" / "cross_encoder_rerank" / "run.tsv"
+        )
+        _write_run(bm25_path, values["bm25"])
+        _write_run(rerank_path, values["bm25_ce"])
+        bm25_metrics = evaluate_internal_trec_scope(
+            read_run_tsv(bm25_path), qrels, rel_threshold=2
+        )
+        rerank_metrics = evaluate_internal_trec_scope(
+            read_run_tsv(rerank_path), qrels, rel_threshold=2
+        )
+        rerank_metrics.pop("recall@1000")
+        results[str(year)] = {
+            "judged_topics": 2,
+            "bm25": bm25_metrics,
+            "bm25_ce": rerank_metrics,
+            "artifact_paths": {
+                "bm25_run": bm25_path.relative_to(root).as_posix(),
+                "rerank_run": rerank_path.relative_to(root).as_posix(),
+            },
+            "artifact_sha256": {
+                "bm25_run": sha256_file(bm25_path),
+                "rerank_run": sha256_file(rerank_path),
+            },
+        }
+
+    source_record = {
+        "schema": "msmarco-genqa.table-artifact.v1",
+        "experiment": {"git_commit": "a" * 40},
+        "results": results,
+    }
+    record_path = root / "reports" / "generated" / "artifacts" / "trec.json"
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_text(
+        json.dumps(source_record, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return record_path, qrels_paths
+
+
+def test_release_build_is_deterministic_and_text_only(tmp_path: Path) -> None:
+    source_record, _qrels = _make_release_sources(tmp_path)
+    first = tmp_path / "first.zip"
+    second = tmp_path / "second.zip"
+
+    first_result = build_release_bundle(
+        source_record_path=source_record,
+        project_root=tmp_path,
+        output_archive=first,
+    )
+    second_result = build_release_bundle(
+        source_record_path=source_record,
+        project_root=tmp_path,
+        output_archive=second,
+    )
+
+    assert first_result["sha256"] == second_result["sha256"]
+    assert first.read_bytes() == second.read_bytes()
+    verified = verify_release_archive(first)
+    with zipfile.ZipFile(first) as archive:
+        assert set(archive.namelist()) == {
+            "README.md",
+            "bundle_manifest.json",
+            "runs/trec_dl_2019_bm25.tsv",
+            "runs/trec_dl_2019_bm25_ce.tsv",
+            "runs/trec_dl_2020_bm25.tsv",
+            "runs/trec_dl_2020_bm25_ce.tsv",
+        }
+        contents = b"\n".join(archive.read(name) for name in archive.namelist())
+    assert verified["manifest"]["redistribution"]["qrels_recovery"].startswith(
+        "ir_datasets"
+    )
+    assert b"passage text" in contents
+    assert b"C:\\Users" not in contents
+
+
+def test_verify_release_rejects_outer_hash_mismatch(tmp_path: Path) -> None:
+    source_record, _qrels = _make_release_sources(tmp_path)
+    archive = tmp_path / "release.zip"
+    result = build_release_bundle(
+        source_record_path=source_record,
+        project_root=tmp_path,
+        output_archive=archive,
+    )
+    archive.write_bytes(archive.read_bytes() + b"tampered")
+
+    with pytest.raises(ReleaseArtifactError, match="archive SHA-256 mismatch"):
+        verify_release_archive(archive, expected_sha256=result["sha256"])
+
+
+def test_verify_release_rejects_unsafe_member(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("../outside.txt", "no")
+
+    with pytest.raises(ReleaseArtifactError, match="unsafe archive member"):
+        verify_release_archive(archive)
+
+
+def test_fetch_and_evaluate_release_without_private_credentials(tmp_path: Path) -> None:
+    source_record, qrels_paths = _make_release_sources(tmp_path)
+    archive = tmp_path / "release.zip"
+    built = build_release_bundle(
+        source_record_path=source_record,
+        project_root=tmp_path,
+        output_archive=archive,
+    )
+    pointer = {
+        "schema": POINTER_SCHEMA,
+        "artifact_id": built["manifest"]["artifact_id"],
+        "release": {
+            "repository": "GioiaZheng/msmarco-genqa",
+            "tag": "test",
+            "asset": archive.name,
+        },
+        "download": {
+            "url": archive.as_uri(),
+            "sha256": built["sha256"],
+            "bytes": built["bytes"],
+        },
+    }
+    pointer_path = tmp_path / "pointer.json"
+    pointer_path.write_text(json.dumps(pointer), encoding="utf-8")
+
+    fetched = fetch_release_bundle(
+        pointer_path=pointer_path,
+        output_dir=tmp_path / "recovered",
+    )
+    report = evaluate_release_bundle(
+        bundle_dir=fetched["bundle_dir"],
+        output_dir=tmp_path / "evaluation",
+        qrels_paths=qrels_paths,
+    )
+
+    assert report["verified"] is True
+    assert report["max_abs_delta"] == 0.0
+    assert set(report["results"]) == {
+        "2019_bm25",
+        "2019_bm25_ce",
+        "2020_bm25",
+        "2020_bm25_ce",
+    }
+    assert "recall@1000" not in report["results"]["2019_bm25_ce"]["metrics"]
+    assert report["results"]["2019_bm25"]["metrics"]["n_queries"] == 2
+    assert (tmp_path / "evaluation" / "metrics.json").is_file()
+    assert (tmp_path / "evaluation" / "metrics.md").is_file()
+    table = (tmp_path / "evaluation" / "metrics.md").read_text(encoding="utf-8")
+    assert "Max abs. delta" in table
+    assert "|Δ|" not in table
+
+
+def test_release_build_rejects_run_hash_drift(tmp_path: Path) -> None:
+    source_record, _qrels = _make_release_sources(tmp_path)
+    run = tmp_path / "outputs" / "trec_dl_2019" / "bm25" / "run.tsv"
+    run.write_text(run.read_text(encoding="utf-8") + "q3 Q0 d3 1 1.0 test\n")
+
+    with pytest.raises(ReleaseArtifactError, match="SHA-256 mismatch"):
+        build_release_bundle(
+            source_record_path=source_record,
+            project_root=tmp_path,
+            output_archive=tmp_path / "release.zip",
+        )
+
+
+def test_tracked_release_pointer_is_internally_consistent() -> None:
+    project_root = Path(__file__).parents[1]
+    pointer = load_release_pointer(
+        project_root / "artifacts" / "trec_dl_baselines_v1.json"
+    )
+    release = pointer["release"]
+    download = pointer["download"]
+
+    assert release["repository"] == "GioiaZheng/msmarco-genqa"
+    assert f"/{release['tag']}/{release['asset']}" in download["url"]
+    assert pointer["reproduce"] == {
+        "command": "make reproduce-trec-eval",
+        "requires_private_credentials": False,
+        "rebuilds_full_index": False,
+    }


### PR DESCRIPTION
## What

- add a deterministic, text-only release bundle for the four TREC-DL 2019/2020 BM25 and BM25+CE runs
- add a small Git-tracked pointer with the release URL, byte size, SHA-256 digest, experiment commit, and source record
- add `make reproduce-trec-eval` to download, verify, and recompute the reported metrics without rebuilding the 8.8M-passage index
- tighten archive download/extraction checks and the repository artifact boundary
- document the distinction between fast evidence reproduction and the full computational rerun

## Why

The TREC-DL results are traceable locally, but an external reader still cannot recover the exact ranked runs from a fresh clone. This closes that gap while keeping MS MARCO text, qrels mirrors, model caches, and machine-local manifests out of the release.

The implementation follows the artifact policy in #123 and remains compatible with the registry work in #18. The issue is intentionally not auto-closed by this PR: the release asset still needs to be published from merged `main` and downloaded back from its public URL before #123 is complete.

## Planned release

- tag: `v2.1-trec-dl-baselines`
- asset: `trec-dl-baselines-v1.zip`
- size: 1,041,738 bytes
- SHA-256: `e7001a943beb1b1a220ef4a58fae445569725682dc0dbbcb0d9300473a360aa3`
- contents: four ranked run files, bundle manifest, and README; no corpus/query text or model weights

## Checks

- `551 passed, 5 skipped, 1 deselected`
- Ruff: passed
- headline and fixture metric regression checks: passed
- artifact boundary and secret scans: passed
- real four-run local recovery: all reproduced metric deltas exactly `0.0`
- deterministic rebuild: archive size and SHA-256 stable

Refs #123
Related to #18