### PR TITLE
docs: separate validated results from pending work

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ ACL-style findings write-up is
 | Does retrieval lift transfer to generation? | BM25 top-3 → T5-small vs reranked top-3 → T5-small | Token-F1 0.1966 → 0.3677 |
 | Is the generation lift statistically reliable? | 6,980 paired qids, 10,000 bootstrap resamples | ΔToken-F1 +0.1711, 95% CI [+0.1632, +0.1789] |
 
+## Evidence status
+
+| Status | What can be claimed | Evidence and boundary |
+|---|---|---|
+| Validated result | On MS MARCO `dev/small`, reranked dense top-3 improves T5-small surface metrics over BM25 top-3 on 6,980 paired queries. | [`RESULTS.md`](RESULTS.md) reports the paired metrics and confidence intervals. Dense retrieval and reranking use the documented 50k qrels-anchored candidate pool, not a full-corpus dense first stage. |
+| Validated external retrieval benchmark | On TREC-DL 2019 and 2020, cross-encoder reranking improves MRR@10 and graded nDCG@10 over a full-corpus BM25 first stage on all 43 and 54 judged topics. | [`docs/trec_dl_external_validity.md`](docs/trec_dl_external_validity.md) records the run commit, models, candidate depths, runtimes, independent `ir-measures` cross-check, and links to the checked artifact. This is retrieval evidence, not generation evidence. |
+| Implemented, evaluation pending | The T5-base generator-capacity sweep driver and configurable alternative-generator paths exist. | [`scripts/run_generator_capacity_sweep.py`](scripts/run_generator_capacity_sweep.py) and the Phase A protocol are implemented, but no T5-base or FLAN-T5 headline result is claimed until a complete versioned run lands. |
+| Not established | TREC-DL retrieval gains transfer to grounded generation; dense retrieval beats BM25 under a fair full-corpus candidate condition; or the findings generalize beyond the MS MARCO passage collection. | These remain research questions, not conclusions of the committed artifacts. |
+
 ## Implemented components
 
 | Area | What is included |

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -66,6 +66,27 @@ Reranking reorders dense top-100 results:
 Recall@100 is unchanged because reranking only changes order within the
 retrieved top-100.
 
+## External Retrieval Benchmark: TREC-DL 2019/2020
+
+The full-corpus BM25 first stage and fixed top-100 cross-encoder reranker were
+also evaluated on the deeply judged TREC-DL passage tracks:
+
+| Track | Metric | BM25 | BM25 + CE | Delta |
+|---|---|---:|---:|---:|
+| 2019 (43 topics) | MRR@10, rel >= 2 | 0.5471 | 0.8787 | +0.3315 |
+| 2019 (43 topics) | nDCG@10, graded | 0.4239 | 0.7210 | +0.2971 |
+| 2020 (54 topics) | MRR@10, rel >= 2 | 0.6280 | 0.8256 | +0.1976 |
+| 2020 (54 topics) | nDCG@10, graded | 0.4773 | 0.6801 | +0.2027 |
+
+All judged topics remain in the denominator, and an independent `ir-measures`
+cross-check reproduced the metrics with a maximum absolute delta of
+`2.22e-16`. The complete protocol, runtime notes, query-level lift analysis,
+and artifact hashes are in
+[`docs/trec_dl_external_validity.md`](docs/trec_dl_external_validity.md).
+
+These are validated retrieval results. They do not show that the retrieval
+gain transfers to answer generation on TREC-DL.
+
 ## Query-Type Slice
 
 Token-F1 lift by query type:
@@ -95,6 +116,14 @@ have different evaluation boundaries:
 The dense sample includes all dev relevant documents by construction. This is
 useful for isolating model behavior, but it is optimistic relative to full
 corpus retrieval.
+
+### Conclusion Boundary
+
+| Status | Boundary |
+|---|---|
+| Validated | The paired T5-small generation comparison on MS MARCO `dev/small`; full-corpus BM25 plus cross-encoder retrieval on TREC-DL 2019/2020. |
+| Implemented but not yet evaluated | The T5-base generator-capacity sweep and configurable alternative-generator paths. Their existence is not an empirical result. |
+| Not supported by current evidence | TREC-DL retrieval lift transfers to generation; a fair full-corpus dense-vs-BM25 conclusion; cross-domain RAG generalization. |
 
 ## Grounding
 


### PR DESCRIPTION
## Summary

- add an evidence-status table to the README
- add the completed TREC-DL 2019/2020 retrieval benchmark to `RESULTS.md`
- distinguish validated results, implemented-but-pending generator work, and unsupported conclusions

## Evidence boundary

The TREC-DL runs validate full-corpus BM25 plus cross-encoder retrieval under deep graded judgments. They do not establish downstream generation lift, a fair full-corpus dense comparison, or cross-domain generalization.

## Verification

- reported TREC-DL values match `reports/generated/artifacts/trec_dl_bm25_ce.json`
- `26 passed, 2 skipped` for the offline TREC-DL and metric cross-check tests
- Markdown diff check passed