### PR TITLE
Build a canonical registry for headline artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -76,6 +78,9 @@ jobs:
 
       - name: Check artifact boundaries
         run: python scripts/check_artifact_boundaries.py
+
+      - name: Check canonical artifact registry
+        run: python scripts/check_artifact_registry.py
 
       - name: Check generated report tables
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline reproduce-trec-eval build-trec-release
+.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts check-registry export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline reproduce-trec-eval build-trec-release
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -21,6 +21,7 @@ help:
 	@echo "  make check-lockfile       -- dry-run the pinned lockfile resolver"
 	@echo "  make check-notebooks      -- verify notebooks stay lightweight demos"
 	@echo "  make check-artifacts      -- verify large generated artifacts stay out of Git"
+	@echo "  make check-registry       -- validate canonical artifact evidence and history"
 	@echo "  make export-report-tables -- refresh checked LaTeX table fragments"
 	@echo "  make check-report-tables  -- verify checked LaTeX table fragments are current"
 	@echo "  make pipeline-dry-run     -- print the config-driven experiment plan"
@@ -82,6 +83,9 @@ check-notebooks:
 
 check-artifacts:
 	$(PYTHON) scripts/check_artifact_boundaries.py
+
+check-registry:
+	$(PYTHON) scripts/check_artifact_registry.py
 
 export-report-tables:
 	$(PYTHON) scripts/export_report_tables.py

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The repository includes runnable code plus written analysis artifacts:
 - [`docs/rag_triad_evaluation.md`](docs/rag_triad_evaluation.md) — context relevance, groundedness, and answer relevance report protocol.
 - [`docs/input_validation.md`](docs/input_validation.md) — run-file, JSONL, prompt, and serving input validation contract.
 - [`docs/artifact_versioning.md`](docs/artifact_versioning.md) — policy for source data, derived indexes, model outputs, and Git-tracked pointers.
+- [`docs/artifact_registry.md`](docs/artifact_registry.md) — canonical result-to-commit, config, lockfile, and manifest evidence contract.
+- [`docs/lockfile_reproduction.md`](docs/lockfile_reproduction.md) — dependency snapshot update and reproduction policy.
 - [`docs/rag_observatory_exports.md`](docs/rag_observatory_exports.md) — trace and sweep exports for external RAG observability analysis.
 - [`docs/trec_dl_external_validity.md`](docs/trec_dl_external_validity.md) — TREC-DL dataset contract, runner commands, metric boundaries, and benchmark follow-ups.
 - [`notebooks/rag_eval_demo.ipynb`](notebooks/rag_eval_demo.ipynb) — lightweight evaluation workflow demo.

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -30,6 +30,12 @@ small pointer files is documented in `docs/artifact_versioning.md`. Use
 `make check-artifacts` to verify that common large artifact formats and
 generated run payloads have not entered Git.
 
+The canonical headline-evidence index is `artifacts/registry.json`. It joins
+the checked metric artifacts to commits, configuration and lockfile snapshots,
+manifest availability, and explicit provenance limitations. Its contract is
+documented in `docs/artifact_registry.md`; dependency snapshot changes follow
+`docs/lockfile_reproduction.md`.
+
 Important scale reference:
 
 | Item | Value |
@@ -46,6 +52,7 @@ These commands are intended for local development and CI:
 make test
 make lint
 make check-artifacts
+make check-registry
 python scripts/run_pipeline.py --dry-run
 ```
 

--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -1,14 +1,17 @@
 # External artifact pointers
 
-This directory contains small, reviewable pointers to immutable experiment
-assets. Payloads remain outside Git; each pointer pins the release tag, asset
-name, byte size, and SHA-256 digest needed to recover it without private
-credentials.
+This directory contains small, reviewable experiment-evidence records and
+pointers to immutable assets. Payloads remain outside Git; each external
+pointer pins the release tag, asset name, byte size, and SHA-256 digest needed
+to recover it without private credentials.
 
 Published assets are never replaced in place. A changed payload receives a
 new tag, asset name, and pointer so prior report evidence remains recoverable.
 
-Current pointer:
+Current records:
 
+- `registry.json` — canonical headline-evidence registry joining report
+  artifacts to commits, configuration and lockfile snapshots, manifest
+  availability, and explicit provenance limits.
 - `trec_dl_baselines_v1.json` — text-only BM25 and BM25-plus-cross-encoder
   TREC-DL 2019/2020 ranked runs.

--- a/artifacts/registry.json
+++ b/artifacts/registry.json
@@ -1,0 +1,280 @@
+{
+  "schema": "msmarco-genqa.artifact-registry.v1",
+  "registry_id": "canonical-headline-evidence",
+  "hash_convention": "sha256_lf normalizes CRLF and CR text newlines to LF before hashing",
+  "current_lockfile": {
+    "path": "requirements-lock.txt",
+    "sha256_lf": "cc0420bbd69869b353ad2a74e6e62b23370e2ecb5718ae333d8d6302b1497715",
+    "last_dependency_change_commit": "fe7077994b9a4eea643a7a1db51ae431a05b3c8e",
+    "reproduction_note": "docs/lockfile_reproduction.md",
+    "validation": [
+      "python -m pip install --dry-run -r requirements-lock.txt",
+      "python scripts/check_fixture_headline_metrics.py",
+      "python scripts/export_report_tables.py"
+    ]
+  },
+  "entries": [
+    {
+      "id": "bm25-full-corpus-dev-small",
+      "artifact_record": {
+        "path": "reports/generated/artifacts/bm25_full_corpus.json",
+        "sha256_lf": "d9fad7666d70b48a75d62591b6704f49f1696c6d6e5a779f33b965cec84b0603",
+        "schema": "msmarco-genqa.table-artifact.v1",
+        "artifact_id": "bm25_full_corpus"
+      },
+      "provenance": {
+        "status": "historical_partial",
+        "production_commit": null,
+        "evidence_commits": [
+          "3c8c912e2195e4cea24a1519d841648c8751db11"
+        ],
+        "report_anchor": {
+          "tag": "v1.0-first-report",
+          "commit": "cd8edec45f14236f9836dc7f55aabbb01bde75f5"
+        },
+        "manifests": [
+          {
+            "path": "outputs/bm25_baseline/provenance.backfill.json",
+            "kind": "backfill",
+            "availability": "local_only"
+          }
+        ]
+      },
+      "config_snapshots": [
+        {
+          "path": "configs/baseline.yaml",
+          "commit": "3c8c912e2195e4cea24a1519d841648c8751db11",
+          "sha256_lf": "41925d3df7592f95810e357fd0a9c089d8b10fee2da10686da59c2065aaaabc7",
+          "runtime_use": "unknown"
+        }
+      ],
+      "lockfile_snapshots": [
+        {
+          "path": "requirements-lock.txt",
+          "commit": "3c8c912e2195e4cea24a1519d841648c8751db11",
+          "sha256_lf": null,
+          "status": "not_present"
+        }
+      ],
+      "metric_summary": {
+        "mrr@10": 0.1703,
+        "recall@100": 0.6212,
+        "recall@1000": 0.8154
+      },
+      "notes": [
+        "The original production commit and installed environment were not captured.",
+        "The evidence commit is the earliest retained commit that explicitly identifies 0.1703 as the official baseline; it is not asserted to be the production commit."
+      ]
+    },
+    {
+      "id": "dense-sample-and-cross-encoder",
+      "artifact_record": {
+        "path": "reports/generated/artifacts/retrieval_dense_rerank.json",
+        "sha256_lf": "1b60a7eaaf93794937abfed0d2a07deec8d777b5631884ad21677a6b8ad8e123",
+        "schema": "msmarco-genqa.table-artifact.v1",
+        "artifact_id": "retrieval_dense_rerank"
+      },
+      "provenance": {
+        "status": "historical_partial",
+        "production_commit": null,
+        "evidence_commits": [
+          "8acfc0c63259112f65dfe7b2ddab308e123c7862",
+          "4048943726b702341def761febc096d66393904f"
+        ],
+        "report_anchor": {
+          "tag": "v1.0-first-report",
+          "commit": "cd8edec45f14236f9836dc7f55aabbb01bde75f5"
+        },
+        "manifests": [
+          {
+            "path": "outputs/dense_retrieval/provenance.backfill.json",
+            "kind": "backfill",
+            "availability": "local_only"
+          },
+          {
+            "path": "outputs/cross_encoder_rerank/provenance.backfill.json",
+            "kind": "backfill",
+            "availability": "local_only"
+          }
+        ]
+      },
+      "config_snapshots": [
+        {
+          "path": "configs/baseline.yaml",
+          "commit": "8acfc0c63259112f65dfe7b2ddab308e123c7862",
+          "sha256_lf": "e731b977c655f54f26e6a8c3189d30cc0fca6f38feac094d95c87c858c1e221c",
+          "runtime_use": "unknown"
+        },
+        {
+          "path": "configs/baseline.yaml",
+          "commit": "4048943726b702341def761febc096d66393904f",
+          "sha256_lf": "cc47bf91733b801da8537adf4311b6e68a247c98b937b8cca17552bbfe3eb2a1",
+          "runtime_use": "unknown"
+        }
+      ],
+      "lockfile_snapshots": [
+        {
+          "path": "requirements-lock.txt",
+          "commit": "8acfc0c63259112f65dfe7b2ddab308e123c7862",
+          "sha256_lf": null,
+          "status": "not_present"
+        },
+        {
+          "path": "requirements-lock.txt",
+          "commit": "4048943726b702341def761febc096d66393904f",
+          "sha256_lf": "947ec2cd5b5cf0cc85b687787023a5046d1406c29fbf8de1986b1150b4447a67",
+          "status": "repository_snapshot"
+        }
+      ],
+      "metric_summary": {
+        "bm25_sample_mrr@10": 0.6948,
+        "dense_mrr@10": 0.883,
+        "dense_ndcg@10": 0.9041,
+        "dense_recall@100": 0.9946,
+        "dense_ce_mrr@10": 0.9304,
+        "dense_ce_ndcg@10": 0.9434
+      },
+      "notes": [
+        "Dense and BM25 sample metrics use the same qrels-anchored 50k passage sample and are not directly comparable to full-corpus BM25.",
+        "Backfills enumerate the missing production commit, argv, package, input-byte, and effective-seeding evidence."
+      ]
+    },
+    {
+      "id": "generation-full-dev-paired",
+      "artifact_record": {
+        "path": "reports/generated/artifacts/generation_surface.json",
+        "sha256_lf": "8703a291a16be9f5bc8fc80d0e8436fbbaf8e256c90b4079993fd39493c85728",
+        "schema": "msmarco-genqa.table-artifact.v1",
+        "artifact_id": "generation_surface"
+      },
+      "provenance": {
+        "status": "historical_partial",
+        "production_commit": null,
+        "evidence_commits": [
+          "16f4d8283354f9db79198831f6b83e2980e81eb1"
+        ],
+        "report_anchor": {
+          "tag": "v1.0-first-report",
+          "commit": "cd8edec45f14236f9836dc7f55aabbb01bde75f5"
+        },
+        "manifests": [
+          {
+            "path": "outputs/generation_bm25_full/manifest.json",
+            "kind": "runtime_manifest",
+            "availability": "not_preserved"
+          },
+          {
+            "path": "outputs/generation_reranked_full/manifest.json",
+            "kind": "runtime_manifest",
+            "availability": "not_preserved"
+          },
+          {
+            "path": "outputs/generation_bootstrap_full/metrics.json",
+            "kind": "evaluation_record",
+            "availability": "not_preserved"
+          }
+        ]
+      },
+      "config_snapshots": [
+        {
+          "path": "configs/baseline.yaml",
+          "commit": "16f4d8283354f9db79198831f6b83e2980e81eb1",
+          "sha256_lf": "cc47bf91733b801da8537adf4311b6e68a247c98b937b8cca17552bbfe3eb2a1",
+          "runtime_use": "unknown"
+        }
+      ],
+      "lockfile_snapshots": [
+        {
+          "path": "requirements-lock.txt",
+          "commit": "16f4d8283354f9db79198831f6b83e2980e81eb1",
+          "sha256_lf": "947ec2cd5b5cf0cc85b687787023a5046d1406c29fbf8de1986b1150b4447a67",
+          "status": "repository_snapshot"
+        }
+      ],
+      "metric_summary": {
+        "bm25_token_f1": 0.1966,
+        "reranked_token_f1": 0.3677,
+        "token_f1_delta": 0.1711,
+        "token_f1_delta_ci95_low": 0.1632,
+        "token_f1_delta_ci95_high": 0.1789,
+        "rouge_l_delta": 0.1742
+      },
+      "notes": [
+        "Both generation arms cover the same 6,980 query ids; the upstream retrieval source is the controlled difference.",
+        "The evidence commit records the complete reported comparison, but the runtime manifests and original installed environment were not preserved."
+      ]
+    },
+    {
+      "id": "trec-dl-2019-2020-bm25-ce",
+      "artifact_record": {
+        "path": "reports/generated/artifacts/trec_dl_bm25_ce.json",
+        "sha256_lf": "0f103e4eb0b0bf658b7b053010b6c146940fcc9d60655f0bffdf742a339af25c",
+        "schema": "msmarco-genqa.table-artifact.v1",
+        "artifact_id": "trec_dl_bm25_ce"
+      },
+      "external_pointer": {
+        "path": "artifacts/trec_dl_baselines_v1.json",
+        "sha256_lf": "dc3b85d353de7c69ce2cbb7d7f0dde26027525befaf96ff6aea74d38652c8566",
+        "schema": "msmarco-genqa.external-artifact-pointer.v1",
+        "artifact_id": "trec-dl-bm25-ce-2019-2020-v1"
+      },
+      "provenance": {
+        "status": "exact",
+        "production_commit": "0362a48bb4d000a93f5af5c26a4de934db37e74f",
+        "evidence_commits": [
+          "1d12d5131f8c130d52389ce61e2a88007b5c294f"
+        ],
+        "manifests": [
+          {
+            "path": "outputs/trec_dl_2019/bm25/manifest.json",
+            "kind": "runtime_manifest",
+            "availability": "local_only"
+          },
+          {
+            "path": "outputs/trec_dl_2019/cross_encoder_rerank/manifest.json",
+            "kind": "runtime_manifest",
+            "availability": "local_only"
+          },
+          {
+            "path": "outputs/trec_dl_2020/bm25/manifest.json",
+            "kind": "runtime_manifest",
+            "availability": "local_only"
+          },
+          {
+            "path": "outputs/trec_dl_2020/cross_encoder_rerank/manifest.json",
+            "kind": "runtime_manifest",
+            "availability": "local_only"
+          }
+        ]
+      },
+      "config_snapshots": [
+        {
+          "path": "outputs/trec_dl_2019/bm25/resolved_config.yaml",
+          "commit": "0362a48bb4d000a93f5af5c26a4de934db37e74f",
+          "sha256_lf": "d65f5719d5999fb339de97f5f06115d9c08324042ed7b508c701659dfbf4e23d",
+          "runtime_use": "exact_local_artifact"
+        }
+      ],
+      "lockfile_snapshots": [
+        {
+          "path": "requirements-lock.txt",
+          "commit": "0362a48bb4d000a93f5af5c26a4de934db37e74f",
+          "sha256_lf": "cc0420bbd69869b353ad2a74e6e62b23370e2ecb5718ae333d8d6302b1497715",
+          "status": "repository_snapshot"
+        }
+      ],
+      "metric_summary": {
+        "2019_bm25_mrr@10": 0.5471483942414175,
+        "2019_bm25_ce_mrr@10": 0.8786821705426356,
+        "2019_bm25_ce_ndcg@10": 0.7210235158468563,
+        "2020_bm25_mrr@10": 0.6280055849500293,
+        "2020_bm25_ce_mrr@10": 0.8256172839506173,
+        "2020_bm25_ce_ndcg@10": 0.6800565227602772
+      },
+      "notes": [
+        "The public release pointer recovers the exact four ranked runs without private credentials.",
+        "Runtime manifests and resolved configs remain local because they contain machine-specific paths; their hashes are retained in the checked artifact record."
+      ]
+    }
+  ]
+}

--- a/docs/artifact_registry.md
+++ b/docs/artifact_registry.md
@@ -1,0 +1,84 @@
+# Canonical artifact registry
+
+`artifacts/registry.json` is the machine-readable index for the experiment
+evidence behind the repository's headline results. It does not duplicate run
+payloads. Instead, it joins each checked report artifact to the strongest
+provenance that the repository can actually support: commits, configuration
+and lockfile snapshots, runtime-manifest locations, external pointers, metric
+summaries, and explicit limitations.
+
+Run the consistency check with:
+
+```bash
+make check-registry
+```
+
+The check validates schemas, repository-relative paths, normalized hashes,
+artifact identifiers, provenance boundaries, and metric values. When a Git
+executable is available in a full clone, it also verifies that commits exist,
+report tags resolve to the recorded commits, and historical configuration and
+lockfile hashes match the files at those commits. CI uses a full-history
+checkout so these Git checks are always active there. On systems where Git is
+not on `PATH`, set `GIT_EXECUTABLE` or pass `--git-executable` to the checker.
+
+## Evidence levels
+
+Every entry declares one of two provenance states:
+
+| State | Meaning |
+|---|---|
+| `exact` | The production commit is known and agrees with the checked artifact record. |
+| `historical_partial` | The reported result is retained, but the original production commit or runtime evidence is incomplete. `production_commit` must be `null`; evidence commits and a report anchor are recorded without presenting them as the run commit. |
+
+Manifest availability is recorded separately:
+
+| Availability | Meaning |
+|---|---|
+| `tracked` | The record is committed and the path must exist. |
+| `local_only` | The record exists in the maintainer's local output tree but is intentionally outside Git. |
+| `not_preserved` | The historical report names the path, but the original file is no longer available. |
+
+This distinction matters for the pre-protocol baselines. Legacy local
+backfills name `5a35de9c18ea` as a run commit, but that object is not present in
+the retained repository history. The registry therefore does not promote that
+value to a production commit. The `v1.0-first-report` tag and the earliest
+verifiable evidence commits are recorded separately.
+
+## Hash convention
+
+Registry text hashes use `sha256_lf`: CRLF and bare CR newlines are normalized
+to LF before SHA-256 is computed. This makes the same JSON, YAML, or lockfile
+hash identically on Windows and Linux. Binary release payloads keep ordinary
+byte-for-byte SHA-256 in their external pointer.
+
+## Entry contract
+
+Each canonical entry contains:
+
+- a checked table artifact and its `sha256_lf`;
+- exact or explicitly partial provenance;
+- the relevant configuration snapshot(s);
+- the lockfile state at the evidence commit(s);
+- a compact numeric metric summary; and
+- notes defining comparison or recovery limits.
+
+External release assets add an immutable pointer containing the tag, asset
+name, byte size, and byte-level SHA-256. Large run files, model weights, raw
+datasets, indexes, and machine-specific manifests remain outside Git.
+
+## Updating the registry
+
+1. Add or update the small checked report artifact. Do not copy a large run
+   payload into `artifacts/`.
+2. Identify the production commit only from a runtime manifest or equivalent
+   primary evidence. If it cannot be established, use `historical_partial`.
+3. Hash the relevant artifact, configuration, and lockfile snapshots using the
+   LF-normalized convention.
+4. Add a concise metric summary and state sampling or comparison boundaries in
+   `notes`.
+5. Run `make check-registry`, `make check-report-tables`, and the relevant
+   experiment verification before review.
+
+Published metrics are never silently rewritten to match a new environment. A
+new run receives a new evidence record; historical entries retain their
+original status and limitations.

--- a/docs/lockfile_reproduction.md
+++ b/docs/lockfile_reproduction.md
@@ -1,0 +1,55 @@
+# Lockfile reproduction policy
+
+The dependency files serve two different purposes:
+
+- `requirements.txt` and `pyproject.toml` define the supported dependency
+  ranges for development and installation;
+- `requirements-lock.txt` records the pinned direct dependency snapshot used
+  for reproducibility checks.
+
+The current normalized lockfile hash and the commit of its most recent
+dependency change are recorded in `artifacts/registry.json`. CI verifies the
+current file against that hash and re-reads historical lockfiles from Git for
+each canonical experiment entry.
+
+## Change protocol
+
+A lockfile update must be intentional and reviewable. The pull request should
+state why the dependency changed, whether it can affect model or metric
+behavior, which validation was run, and whether new experiment evidence is
+needed.
+
+| Change type | Minimum evidence |
+|---|---|
+| Tooling-only dependency | Resolver dry run, default tests, lint, artifact registry check. |
+| Evaluation or numerical library | Above checks plus fixture metric goldens and affected evaluation tests. |
+| Torch, Transformers, SentenceTransformers, tokenizer, or model revision | Above checks plus `scripts/smoke_model_stack.py`; rerun the affected headline experiment or open a linked follow-up before treating old and new results as comparable. |
+| Security remediation with forced transitive changes | Record the vulnerability and constrained package set, run the affected smoke/evaluation checks, and document any unavoidable reproduction boundary. |
+
+At minimum, run:
+
+```bash
+python -m pip install --dry-run -r requirements-lock.txt
+python scripts/check_fixture_headline_metrics.py
+python scripts/check_artifact_registry.py
+python scripts/export_report_tables.py
+```
+
+The registry hash must be updated in the same change as the lockfile. That
+mechanical update does not by itself validate numerical equivalence.
+
+## Historical boundary
+
+A newer lockfile does not rebaseline an older result. Each canonical entry
+records the lockfile available at its evidence or production commit:
+
+- `repository_snapshot` means the file existed and its historical hash is
+  verified from Git;
+- `not_present` means the commit predates the lockfile;
+- absence of the original installed environment remains a stated limitation,
+  even when a repository lockfile is available.
+
+Dependency vulnerability triage should prefer the smallest compatible change.
+If a safe resolution requires a model-stack change, preserve the old record,
+produce new evidence under the new environment, and compare the two rather
+than silently replacing the headline number.

--- a/reports/generated/artifacts/bm25_full_corpus.json
+++ b/reports/generated/artifacts/bm25_full_corpus.json
@@ -1,0 +1,30 @@
+{
+  "schema": "msmarco-genqa.table-artifact.v1",
+  "artifact_id": "bm25_full_corpus",
+  "metric_schema": "retrieval.full_corpus_bm25.v1",
+  "query_set": {
+    "id": "msmarco-passage-dev-small",
+    "n_queries": 6980
+  },
+  "model_revision": {
+    "backend": "bm25s",
+    "corpus": "msmarco-passage",
+    "corpus_scope": "full",
+    "corpus_size": 8841823,
+    "retrieval_depth": 1000
+  },
+  "tables": [
+    {
+      "id": "bm25_full_corpus",
+      "columns": [
+        {"heading": "Metric", "align": "l"},
+        {"heading": "\\bmtwofive{}", "align": "r"}
+      ],
+      "rows": [
+        {"cells": ["\\mrr{}", "0.1703"]},
+        {"cells": ["\\recallH{}", "0.6212"]},
+        {"cells": ["\\recallK{}", "0.8154"]}
+      ]
+    }
+  ]
+}

--- a/reports/generated/tables/bm25_full_corpus.sources.json
+++ b/reports/generated/tables/bm25_full_corpus.sources.json
@@ -1,0 +1,25 @@
+{
+  "schema": "msmarco-genqa.table-sources.v1",
+  "table_id": "bm25_full_corpus",
+  "hash_convention": "sha256_lf",
+  "sources": [
+    {
+      "path": "reports/generated/artifacts/bm25_full_corpus.json",
+      "sha256_16": "d9fad7666d70b48a",
+      "artifact_schema": "msmarco-genqa.table-artifact.v1",
+      "artifact_id": "bm25_full_corpus",
+      "metric_schema": "retrieval.full_corpus_bm25.v1",
+      "query_set": {
+        "id": "msmarco-passage-dev-small",
+        "n_queries": 6980
+      },
+      "model_revision": {
+        "backend": "bm25s",
+        "corpus": "msmarco-passage",
+        "corpus_scope": "full",
+        "corpus_size": 8841823,
+        "retrieval_depth": 1000
+      }
+    }
+  ]
+}

--- a/reports/generated/tables/bm25_full_corpus.tex
+++ b/reports/generated/tables/bm25_full_corpus.tex
@@ -1,0 +1,10 @@
+% Refresh with: python scripts/export_report_tables.py
+\begin{tabular}{lr}
+    \toprule
+    Metric & \bmtwofive{} \\
+    \midrule
+    \mrr{} & 0.1703 \\
+    \recallH{} & 0.6212 \\
+    \recallK{} & 0.8154 \\
+    \bottomrule
+\end{tabular}

--- a/reports/generated/tables/dense_retrieval_sample.sources.json
+++ b/reports/generated/tables/dense_retrieval_sample.sources.json
@@ -1,6 +1,7 @@
 {
   "schema": "msmarco-genqa.table-sources.v1",
   "table_id": "dense_retrieval_sample",
+  "hash_convention": "sha256_lf",
   "sources": [
     {
       "path": "reports/generated/artifacts/retrieval_dense_rerank.json",

--- a/reports/generated/tables/generation_bootstrap_ci.sources.json
+++ b/reports/generated/tables/generation_bootstrap_ci.sources.json
@@ -1,6 +1,7 @@
 {
   "schema": "msmarco-genqa.table-sources.v1",
   "table_id": "generation_bootstrap_ci",
+  "hash_convention": "sha256_lf",
   "sources": [
     {
       "path": "reports/generated/artifacts/generation_surface.json",

--- a/reports/generated/tables/generation_headline.sources.json
+++ b/reports/generated/tables/generation_headline.sources.json
@@ -1,6 +1,7 @@
 {
   "schema": "msmarco-genqa.table-sources.v1",
   "table_id": "generation_headline",
+  "hash_convention": "sha256_lf",
   "sources": [
     {
       "path": "reports/generated/artifacts/generation_surface.json",

--- a/reports/generated/tables/rerank_vs_dense.sources.json
+++ b/reports/generated/tables/rerank_vs_dense.sources.json
@@ -1,6 +1,7 @@
 {
   "schema": "msmarco-genqa.table-sources.v1",
   "table_id": "rerank_vs_dense",
+  "hash_convention": "sha256_lf",
   "sources": [
     {
       "path": "reports/generated/artifacts/retrieval_dense_rerank.json",

--- a/reports/generated/tables/trec_dl_2019_bm25_ce.sources.json
+++ b/reports/generated/tables/trec_dl_2019_bm25_ce.sources.json
@@ -1,6 +1,7 @@
 {
   "schema": "msmarco-genqa.table-sources.v1",
   "table_id": "trec_dl_2019_bm25_ce",
+  "hash_convention": "sha256_lf",
   "sources": [
     {
       "path": "reports/generated/artifacts/trec_dl_bm25_ce.json",

--- a/reports/generated/tables/trec_dl_2020_bm25_ce.sources.json
+++ b/reports/generated/tables/trec_dl_2020_bm25_ce.sources.json
@@ -1,6 +1,7 @@
 {
   "schema": "msmarco-genqa.table-sources.v1",
   "table_id": "trec_dl_2020_bm25_ce",
+  "hash_convention": "sha256_lf",
   "sources": [
     {
       "path": "reports/generated/artifacts/trec_dl_bm25_ce.json",

--- a/scripts/check_artifact_boundaries.py
+++ b/scripts/check_artifact_boundaries.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -43,10 +45,10 @@ ALLOWED_EXACT = {
 }
 
 
-def tracked_files(project_root: Path) -> list[str]:
+def tracked_files(project_root: Path, *, git_executable: str = "git") -> list[str]:
     """Return tracked repository paths using forward slashes."""
     result = subprocess.run(
-        ["git", "ls-files", "-z"],
+        [git_executable, "ls-files", "-z"],
         cwd=project_root,
         check=True,
         stdout=subprocess.PIPE,
@@ -120,11 +122,22 @@ def main(argv: list[str] | None = None) -> int:
         default=250_000,
         help="Maximum size for pointer files such as .dvc records.",
     )
+    parser.add_argument(
+        "--git-executable",
+        default=None,
+        help="Git executable used to enumerate tracked files.",
+    )
     args = parser.parse_args(argv)
 
     project_root = args.project_root.resolve()
+    git_executable = (
+        args.git_executable
+        or os.environ.get("GIT_EXECUTABLE")
+        or shutil.which("git")
+        or "git"
+    )
     errors = check_paths(
-        tracked_files(project_root),
+        tracked_files(project_root, git_executable=git_executable),
         project_root=project_root,
         max_pointer_bytes=args.max_pointer_bytes,
     )

--- a/scripts/check_artifact_registry.py
+++ b/scripts/check_artifact_registry.py
@@ -1,0 +1,581 @@
+"""Validate the canonical artifact registry and all tracked references."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+REGISTRY_SCHEMA = "msmarco-genqa.artifact-registry.v1"
+TABLE_ARTIFACT_SCHEMA = "msmarco-genqa.table-artifact.v1"
+POINTER_SCHEMA = "msmarco-genqa.external-artifact-pointer.v1"
+HEX_40 = re.compile(r"^[0-9a-f]{40}$")
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+ENTRY_ID = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+MANIFEST_AVAILABILITY = {"tracked", "local_only", "not_preserved"}
+PROVENANCE_STATUS = {"exact", "historical_partial"}
+CONFIG_RUNTIME_USE = {"unknown", "exact_local_artifact"}
+LOCKFILE_STATUS = {"not_present", "repository_snapshot"}
+
+
+def normalized_bytes_sha256(data: bytes) -> str:
+    """Hash text bytes after normalizing CRLF/CR to LF."""
+    normalized = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return hashlib.sha256(normalized).hexdigest()
+
+
+def normalized_text_sha256(path: Path) -> str:
+    """Hash text bytes after normalizing CRLF/CR to LF."""
+    return normalized_bytes_sha256(path.read_bytes())
+
+
+class GitHistory:
+    """Read immutable evidence from a local Git object database."""
+
+    def __init__(self, project_root: Path, executable: str) -> None:
+        self.project_root = project_root
+        self.executable = executable
+        self._commit_cache: dict[str, bool] = {}
+        self._file_cache: dict[tuple[str, str], bytes | None] = {}
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.run(
+            [self.executable, "-C", str(self.project_root), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def commit_exists(self, commit: str) -> bool:
+        if commit not in self._commit_cache:
+            result = self._run("cat-file", "-e", f"{commit}^{{commit}}")
+            self._commit_cache[commit] = result.returncode == 0
+        return self._commit_cache[commit]
+
+    def resolve_commit(self, ref: str) -> str | None:
+        result = self._run("rev-parse", "--verify", f"{ref}^{{commit}}")
+        if result.returncode != 0:
+            return None
+        return result.stdout.decode("ascii").strip()
+
+    def file_bytes(self, commit: str, path: str) -> bytes | None:
+        key = (commit, path)
+        if key not in self._file_cache:
+            result = self._run("show", f"{commit}:{path}")
+            self._file_cache[key] = result.stdout if result.returncode == 0 else None
+        return self._file_cache[key]
+
+
+def _load_json(path: Path, *, label: str, errors: list[str]) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"{label}: cannot read JSON: {exc}")
+        return None
+    if not isinstance(value, dict):
+        errors.append(f"{label}: expected a JSON object")
+        return None
+    return value
+
+
+def _resolve_path(
+    project_root: Path,
+    value: Any,
+    *,
+    label: str,
+    errors: list[str],
+    must_exist: bool,
+) -> Path | None:
+    if not isinstance(value, str) or not value or "\\" in value:
+        errors.append(f"{label}: path must be a non-empty repository-relative POSIX path")
+        return None
+    pure = PurePosixPath(value)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        errors.append(f"{label}: unsafe repository-relative path {value!r}")
+        return None
+    path = project_root.joinpath(*pure.parts)
+    try:
+        path.resolve().relative_to(project_root)
+    except ValueError:
+        errors.append(f"{label}: path escapes the repository: {value!r}")
+        return None
+    if must_exist and not path.is_file():
+        errors.append(f"{label}: referenced file does not exist: {value}")
+    return path
+
+
+def _require_hex(value: Any, pattern: re.Pattern[str], *, label: str, errors: list[str]) -> None:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        errors.append(f"{label}: expected lowercase {pattern.pattern[1:-1]}")
+
+
+def _check_hashed_json(
+    record: Any,
+    *,
+    project_root: Path,
+    label: str,
+    expected_schema: str,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    if not isinstance(record, dict):
+        errors.append(f"{label}: expected an object")
+        return None
+    path = _resolve_path(
+        project_root,
+        record.get("path"),
+        label=f"{label}.path",
+        errors=errors,
+        must_exist=True,
+    )
+    expected_hash = record.get("sha256_lf")
+    _require_hex(expected_hash, HEX_64, label=f"{label}.sha256_lf", errors=errors)
+    if path is None or not path.is_file():
+        return None
+    actual_hash = normalized_text_sha256(path)
+    if isinstance(expected_hash, str) and actual_hash != expected_hash:
+        errors.append(
+            f"{label}: sha256_lf mismatch for {record.get('path')}; "
+            f"expected {expected_hash}, got {actual_hash}"
+        )
+    payload = _load_json(path, label=label, errors=errors)
+    if payload is None:
+        return None
+    if record.get("schema") != expected_schema:
+        errors.append(f"{label}.schema: expected {expected_schema!r}")
+    if payload.get("schema") != expected_schema:
+        errors.append(f"{label}: referenced JSON does not use {expected_schema!r}")
+    expected_id = record.get("artifact_id")
+    if not isinstance(expected_id, str) or payload.get("artifact_id") != expected_id:
+        errors.append(f"{label}: artifact_id does not match the referenced JSON")
+    return payload
+
+
+def _check_commit(
+    value: Any,
+    *,
+    label: str,
+    errors: list[str],
+    git_history: GitHistory | None = None,
+) -> None:
+    _require_hex(value, HEX_40, label=label, errors=errors)
+    if (
+        git_history is not None
+        and isinstance(value, str)
+        and HEX_40.fullmatch(value)
+        and not git_history.commit_exists(value)
+    ):
+        errors.append(f"{label}: commit is not available in Git history: {value}")
+
+
+def _check_provenance(
+    provenance: Any,
+    *,
+    entry_label: str,
+    project_root: Path,
+    artifact_payload: dict[str, Any] | None,
+    errors: list[str],
+    git_history: GitHistory | None,
+) -> None:
+    label = f"{entry_label}.provenance"
+    if not isinstance(provenance, dict):
+        errors.append(f"{label}: expected an object")
+        return
+    status = provenance.get("status")
+    if status not in PROVENANCE_STATUS:
+        errors.append(f"{label}.status: expected one of {sorted(PROVENANCE_STATUS)}")
+    production_commit = provenance.get("production_commit")
+    if status == "exact":
+        _check_commit(
+            production_commit,
+            label=f"{label}.production_commit",
+            errors=errors,
+            git_history=git_history,
+        )
+        if artifact_payload is not None:
+            recorded_commit = (artifact_payload.get("experiment") or {}).get("git_commit")
+            if recorded_commit != production_commit:
+                errors.append(
+                    f"{label}: exact production commit does not match artifact experiment.git_commit"
+                )
+    elif status == "historical_partial" and production_commit is not None:
+        errors.append(f"{label}: historical_partial production_commit must be null")
+
+    evidence_commits = provenance.get("evidence_commits")
+    if not isinstance(evidence_commits, list) or not evidence_commits:
+        errors.append(f"{label}.evidence_commits: expected a non-empty list")
+    else:
+        for index, commit in enumerate(evidence_commits):
+            _check_commit(
+                commit,
+                label=f"{label}.evidence_commits[{index}]",
+                errors=errors,
+                git_history=git_history,
+            )
+
+    if status == "historical_partial":
+        anchor = provenance.get("report_anchor")
+        if not isinstance(anchor, dict) or not isinstance(anchor.get("tag"), str):
+            errors.append(f"{label}.report_anchor: historical entries require tag and commit")
+        else:
+            anchor_commit = anchor.get("commit")
+            _check_commit(
+                anchor_commit,
+                label=f"{label}.report_anchor.commit",
+                errors=errors,
+                git_history=git_history,
+            )
+            if git_history is not None:
+                resolved = git_history.resolve_commit(anchor["tag"])
+                if resolved is None:
+                    errors.append(
+                        f"{label}.report_anchor.tag: tag is not available in Git history: "
+                        f"{anchor['tag']}"
+                    )
+                elif resolved != anchor_commit:
+                    errors.append(
+                        f"{label}.report_anchor: tag {anchor['tag']!r} resolves to "
+                        f"{resolved}, not {anchor_commit}"
+                    )
+
+    manifests = provenance.get("manifests")
+    if not isinstance(manifests, list) or not manifests:
+        errors.append(f"{label}.manifests: expected a non-empty list")
+        return
+    for index, manifest in enumerate(manifests):
+        item_label = f"{label}.manifests[{index}]"
+        if not isinstance(manifest, dict):
+            errors.append(f"{item_label}: expected an object")
+            continue
+        availability = manifest.get("availability")
+        if availability not in MANIFEST_AVAILABILITY:
+            errors.append(
+                f"{item_label}.availability: expected one of {sorted(MANIFEST_AVAILABILITY)}"
+            )
+            continue
+        path = _resolve_path(
+            project_root,
+            manifest.get("path"),
+            label=f"{item_label}.path",
+            errors=errors,
+            must_exist=availability == "tracked",
+        )
+        if availability != "tracked" and isinstance(manifest.get("path"), str):
+            if not manifest["path"].startswith("outputs/"):
+                errors.append(f"{item_label}: untracked run records must live under outputs/")
+        if not isinstance(manifest.get("kind"), str) or not manifest["kind"]:
+            errors.append(f"{item_label}.kind: expected a non-empty string")
+        if path is None:
+            continue
+
+
+def _check_config_snapshots(
+    snapshots: Any,
+    *,
+    entry_label: str,
+    project_root: Path,
+    errors: list[str],
+    git_history: GitHistory | None,
+) -> None:
+    label = f"{entry_label}.config_snapshots"
+    if not isinstance(snapshots, list) or not snapshots:
+        errors.append(f"{label}: expected a non-empty list")
+        return
+    for index, snapshot in enumerate(snapshots):
+        item_label = f"{label}[{index}]"
+        if not isinstance(snapshot, dict):
+            errors.append(f"{item_label}: expected an object")
+            continue
+        runtime_use = snapshot.get("runtime_use")
+        if runtime_use not in CONFIG_RUNTIME_USE:
+            errors.append(f"{item_label}.runtime_use: invalid value")
+        snapshot_path = snapshot.get("path")
+        _resolve_path(
+            project_root,
+            snapshot_path,
+            label=f"{item_label}.path",
+            errors=errors,
+            must_exist=runtime_use == "unknown" and str(snapshot.get("path", "")).startswith("configs/"),
+        )
+        commit = snapshot.get("commit")
+        digest = snapshot.get("sha256_lf")
+        _check_commit(
+            commit,
+            label=f"{item_label}.commit",
+            errors=errors,
+            git_history=git_history,
+        )
+        _require_hex(digest, HEX_64, label=f"{item_label}.sha256_lf", errors=errors)
+        if (
+            git_history is not None
+            and runtime_use == "unknown"
+            and isinstance(snapshot_path, str)
+            and isinstance(commit, str)
+            and HEX_40.fullmatch(commit)
+        ):
+            historical_bytes = git_history.file_bytes(commit, snapshot_path)
+            if historical_bytes is None:
+                errors.append(
+                    f"{item_label}: {snapshot_path} is not available at commit {commit}"
+                )
+            elif isinstance(digest, str) and normalized_bytes_sha256(historical_bytes) != digest:
+                errors.append(f"{item_label}: sha256_lf does not match the Git snapshot")
+
+
+def _check_lockfile_snapshots(
+    snapshots: Any,
+    *,
+    entry_label: str,
+    errors: list[str],
+    git_history: GitHistory | None,
+) -> None:
+    label = f"{entry_label}.lockfile_snapshots"
+    if not isinstance(snapshots, list) or not snapshots:
+        errors.append(f"{label}: expected a non-empty list")
+        return
+    for index, snapshot in enumerate(snapshots):
+        item_label = f"{label}[{index}]"
+        if not isinstance(snapshot, dict):
+            errors.append(f"{item_label}: expected an object")
+            continue
+        status = snapshot.get("status")
+        if status not in LOCKFILE_STATUS:
+            errors.append(f"{item_label}.status: invalid value")
+        if snapshot.get("path") != "requirements-lock.txt":
+            errors.append(f"{item_label}.path: expected 'requirements-lock.txt'")
+        commit = snapshot.get("commit")
+        _check_commit(
+            commit,
+            label=f"{item_label}.commit",
+            errors=errors,
+            git_history=git_history,
+        )
+        digest = snapshot.get("sha256_lf")
+        if status == "not_present":
+            if digest is not None:
+                errors.append(f"{item_label}.sha256_lf: not_present snapshots require null")
+        else:
+            _require_hex(digest, HEX_64, label=f"{item_label}.sha256_lf", errors=errors)
+        if (
+            git_history is not None
+            and isinstance(commit, str)
+            and HEX_40.fullmatch(commit)
+        ):
+            historical_bytes = git_history.file_bytes(commit, "requirements-lock.txt")
+            if status == "not_present" and historical_bytes is not None:
+                errors.append(f"{item_label}: lockfile exists at a not_present snapshot")
+            elif status == "repository_snapshot":
+                if historical_bytes is None:
+                    errors.append(f"{item_label}: lockfile is absent at commit {commit}")
+                elif isinstance(digest, str) and normalized_bytes_sha256(historical_bytes) != digest:
+                    errors.append(f"{item_label}: sha256_lf does not match the Git snapshot")
+
+
+def _check_metric_summary(value: Any, *, label: str, errors: list[str]) -> None:
+    if not isinstance(value, dict) or not value:
+        errors.append(f"{label}: expected a non-empty object")
+        return
+    for name, metric in value.items():
+        if not isinstance(name, str) or not name:
+            errors.append(f"{label}: metric names must be non-empty strings")
+        if isinstance(metric, bool) or not isinstance(metric, (int, float)) or not math.isfinite(metric):
+            errors.append(f"{label}.{name}: metric must be a finite number")
+
+
+def validate_registry(
+    registry_path: Path,
+    *,
+    project_root: Path,
+    git_history: GitHistory | None = None,
+) -> list[str]:
+    """Return every schema, path, and hash inconsistency in a registry."""
+    root = project_root.resolve()
+    errors: list[str] = []
+    registry = _load_json(registry_path, label="registry", errors=errors)
+    if registry is None:
+        return errors
+    if registry.get("schema") != REGISTRY_SCHEMA:
+        errors.append(f"registry.schema: expected {REGISTRY_SCHEMA!r}")
+    if registry.get("hash_convention") != (
+        "sha256_lf normalizes CRLF and CR text newlines to LF before hashing"
+    ):
+        errors.append("registry.hash_convention: unsupported convention")
+
+    lockfile = registry.get("current_lockfile")
+    if not isinstance(lockfile, dict):
+        errors.append("registry.current_lockfile: expected an object")
+    else:
+        lock_path = _resolve_path(
+            root,
+            lockfile.get("path"),
+            label="registry.current_lockfile.path",
+            errors=errors,
+            must_exist=True,
+        )
+        expected_hash = lockfile.get("sha256_lf")
+        _require_hex(expected_hash, HEX_64, label="registry.current_lockfile.sha256_lf", errors=errors)
+        if lock_path is not None and lock_path.is_file() and isinstance(expected_hash, str):
+            actual = normalized_text_sha256(lock_path)
+            if actual != expected_hash:
+                errors.append(
+                    "registry.current_lockfile: requirements-lock.txt changed without "
+                    "updating its registry hash and reproduction note"
+                )
+        last_dependency_commit = lockfile.get("last_dependency_change_commit")
+        _check_commit(
+            last_dependency_commit,
+            label="registry.current_lockfile.last_dependency_change_commit",
+            errors=errors,
+            git_history=git_history,
+        )
+        if (
+            git_history is not None
+            and isinstance(last_dependency_commit, str)
+            and HEX_40.fullmatch(last_dependency_commit)
+            and isinstance(expected_hash, str)
+        ):
+            historical_bytes = git_history.file_bytes(
+                last_dependency_commit, "requirements-lock.txt"
+            )
+            if historical_bytes is None:
+                errors.append(
+                    "registry.current_lockfile: lockfile is absent at the last dependency "
+                    "change commit"
+                )
+            elif normalized_bytes_sha256(historical_bytes) != expected_hash:
+                errors.append(
+                    "registry.current_lockfile: hash differs from the last dependency "
+                    "change commit"
+                )
+        _resolve_path(
+            root,
+            lockfile.get("reproduction_note"),
+            label="registry.current_lockfile.reproduction_note",
+            errors=errors,
+            must_exist=True,
+        )
+        validation = lockfile.get("validation")
+        if not isinstance(validation, list) or not validation or not all(
+            isinstance(command, str) and command for command in validation
+        ):
+            errors.append("registry.current_lockfile.validation: expected commands")
+
+    entries = registry.get("entries")
+    if not isinstance(entries, list) or not entries:
+        errors.append("registry.entries: expected a non-empty list")
+        return errors
+    seen: set[str] = set()
+    for index, entry in enumerate(entries):
+        label = f"registry.entries[{index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{label}: expected an object")
+            continue
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str) or ENTRY_ID.fullmatch(entry_id) is None:
+            errors.append(f"{label}.id: expected a lowercase kebab-case id")
+        elif entry_id in seen:
+            errors.append(f"{label}.id: duplicate registry id {entry_id!r}")
+        else:
+            seen.add(entry_id)
+
+        artifact_payload = _check_hashed_json(
+            entry.get("artifact_record"),
+            project_root=root,
+            label=f"{label}.artifact_record",
+            expected_schema=TABLE_ARTIFACT_SCHEMA,
+            errors=errors,
+        )
+        if "external_pointer" in entry:
+            _check_hashed_json(
+                entry.get("external_pointer"),
+                project_root=root,
+                label=f"{label}.external_pointer",
+                expected_schema=POINTER_SCHEMA,
+                errors=errors,
+            )
+        _check_provenance(
+            entry.get("provenance"),
+            entry_label=label,
+            project_root=root,
+            artifact_payload=artifact_payload,
+            errors=errors,
+            git_history=git_history,
+        )
+        _check_config_snapshots(
+            entry.get("config_snapshots"),
+            entry_label=label,
+            project_root=root,
+            errors=errors,
+            git_history=git_history,
+        )
+        _check_lockfile_snapshots(
+            entry.get("lockfile_snapshots"),
+            entry_label=label,
+            errors=errors,
+            git_history=git_history,
+        )
+        _check_metric_summary(
+            entry.get("metric_summary"),
+            label=f"{label}.metric_summary",
+            errors=errors,
+        )
+        notes = entry.get("notes")
+        if not isinstance(notes, list) or not notes or not all(
+            isinstance(note, str) and note for note in notes
+        ):
+            errors.append(f"{label}.notes: expected non-empty note strings")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=Path("artifacts/registry.json"),
+        help="Registry JSON path.",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root used to resolve references.",
+    )
+    parser.add_argument(
+        "--git-executable",
+        default=None,
+        help="Git executable used to verify historical commits and snapshots.",
+    )
+    args = parser.parse_args(argv)
+    git_executable = (
+        args.git_executable or os.environ.get("GIT_EXECUTABLE") or shutil.which("git")
+    )
+    git_history = (
+        GitHistory(args.project_root.resolve(), git_executable) if git_executable else None
+    )
+    errors = validate_registry(
+        args.registry,
+        project_root=args.project_root,
+        git_history=git_history,
+    )
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    if git_history is None:
+        print("Artifact registry checks passed (Git history checks skipped: git not found)")
+    else:
+        print("Artifact registry checks passed, including Git history")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/msmarco_genqa/reporting/latex_tables.py
+++ b/src/msmarco_genqa/reporting/latex_tables.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -50,12 +50,9 @@ class TableArtifact:
 
 
 def file_sha256_16(path: Path) -> str:
-    """Return the first 16 hex chars of a file sha256 digest."""
-    digest = hashlib.sha256()
-    with open(path, "rb") as handle:
-        for chunk in iter(lambda: handle.read(1 << 20), b""):
-            digest.update(chunk)
-    return digest.hexdigest()[:16]
+    """Return an LF-normalized, 16-character SHA-256 for a text artifact."""
+    data = path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return hashlib.sha256(data).hexdigest()[:16]
 
 
 def load_artifact(path: Path) -> TableArtifact:
@@ -191,6 +188,7 @@ def source_sidecar(table_id: str, artifact: TableArtifact) -> dict[str, Any]:
     return {
         "schema": SOURCE_SCHEMA,
         "table_id": table_id,
+        "hash_convention": "sha256_lf",
         "sources": [
             {
                 "path": artifact.relative_path,
@@ -252,6 +250,10 @@ def validate_sidecar_current(sidecar_path: Path) -> None:
     if payload.get("schema") != SOURCE_SCHEMA:
         raise SchemaValidationError(
             f"{sidecar_path}: schema must be {SOURCE_SCHEMA!r}, got {payload.get('schema')!r}"
+        )
+    if payload.get("hash_convention") != "sha256_lf":
+        raise SchemaValidationError(
+            f"{sidecar_path}: hash_convention must be 'sha256_lf'"
         )
     for source in payload.get("sources", []):
         source_path = Path(source["path"])

--- a/tests/test_check_artifact_registry.py
+++ b/tests/test_check_artifact_registry.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CHECK_PATH = PROJECT_ROOT / "scripts" / "check_artifact_registry.py"
+REGISTRY_PATH = PROJECT_ROOT / "artifacts" / "registry.json"
+_spec = importlib.util.spec_from_file_location("check_artifact_registry", CHECK_PATH)
+check_artifact_registry = importlib.util.module_from_spec(_spec)
+sys.modules["check_artifact_registry"] = check_artifact_registry
+_spec.loader.exec_module(check_artifact_registry)  # type: ignore[union-attr]
+
+
+def _registry() -> dict:
+    return json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+def _validate_copy(tmp_path: Path, registry: dict) -> list[str]:
+    path = tmp_path / "registry.json"
+    path.write_text(json.dumps(registry), encoding="utf-8")
+    return check_artifact_registry.validate_registry(path, project_root=PROJECT_ROOT)
+
+
+def test_current_registry_is_consistent() -> None:
+    assert check_artifact_registry.validate_registry(
+        REGISTRY_PATH, project_root=PROJECT_ROOT
+    ) == []
+
+
+def test_rejects_artifact_hash_drift(tmp_path: Path) -> None:
+    registry = _registry()
+    registry["entries"][0]["artifact_record"]["sha256_lf"] = "0" * 64
+
+    errors = _validate_copy(tmp_path, registry)
+
+    assert any("sha256_lf mismatch" in error for error in errors)
+
+
+def test_rejects_duplicate_registry_id(tmp_path: Path) -> None:
+    registry = _registry()
+    registry["entries"][1]["id"] = registry["entries"][0]["id"]
+
+    errors = _validate_copy(tmp_path, registry)
+
+    assert any("duplicate registry id" in error for error in errors)
+
+
+def test_historical_production_commit_must_remain_unknown(tmp_path: Path) -> None:
+    registry = _registry()
+    registry["entries"][0]["provenance"]["production_commit"] = "0" * 40
+
+    errors = _validate_copy(tmp_path, registry)
+
+    assert any(
+        "historical_partial production_commit must be null" in error for error in errors
+    )
+
+
+def test_exact_commit_must_match_artifact_record(tmp_path: Path) -> None:
+    registry = _registry()
+    exact_entry = deepcopy(registry["entries"][-1])
+    exact_entry["provenance"]["production_commit"] = "0" * 40
+    registry["entries"][-1] = exact_entry
+
+    errors = _validate_copy(tmp_path, registry)
+
+    assert any("does not match artifact experiment.git_commit" in error for error in errors)
+
+
+def test_tracked_manifest_path_must_exist(tmp_path: Path) -> None:
+    registry = _registry()
+    manifest = registry["entries"][0]["provenance"]["manifests"][0]
+    manifest["availability"] = "tracked"
+    manifest["path"] = "outputs/definitely-missing/manifest.json"
+
+    errors = _validate_copy(tmp_path, registry)
+
+    assert any("referenced file does not exist" in error for error in errors)
+
+
+def test_rejects_current_lockfile_hash_drift(tmp_path: Path) -> None:
+    registry = _registry()
+    registry["current_lockfile"]["sha256_lf"] = "0" * 64
+
+    errors = _validate_copy(tmp_path, registry)
+
+    assert any("requirements-lock.txt changed" in error for error in errors)

--- a/tests/test_latex_tables.py
+++ b/tests/test_latex_tables.py
@@ -13,6 +13,7 @@ from msmarco_genqa.reporting.latex_tables import (
     SchemaValidationError,
     StaleSourceError,
     export_tables,
+    file_sha256_16,
     load_artifact,
     validate_compatible,
     validate_sidecar_current,
@@ -74,9 +75,19 @@ def test_export_tables_writes_fragment_and_repo_relative_sources(
 
     sidecar = written[0].with_suffix(".sources.json")
     payload = json.loads(sidecar.read_text())
+    assert payload["hash_convention"] == "sha256_lf"
     source_path = payload["sources"][0]["path"]
     assert source_path == "reports/generated/artifacts/a.json"
     assert str(tmp_path) not in source_path
+
+
+def test_source_hash_normalizes_text_newlines(tmp_path: Path):
+    lf_path = tmp_path / "lf.json"
+    crlf_path = tmp_path / "crlf.json"
+    lf_path.write_bytes(b'{\n  "value": 1\n}\n')
+    crlf_path.write_bytes(b'{\r\n  "value": 1\r\n}\r\n')
+
+    assert file_sha256_16(lf_path) == file_sha256_16(crlf_path)
 
 
 def test_load_artifact_missing_path_raises(tmp_path: Path):


### PR DESCRIPTION
## Summary

- add a checked registry linking the four headline experiment surfaces to report artifacts, commits, configuration snapshots, lockfile state, manifests, and external release evidence
- validate paths, schemas, LF-normalized hashes, Git commits, report tags, and historical config/lockfile snapshots in CI
- add the previously unindexed full-corpus BM25 table artifact and keep report source hashes stable across Windows and Linux checkouts
- document the artifact evidence levels and the lockfile change/reproduction policy

## Provenance boundary

The TREC-DL record has exact production provenance. The earlier BM25, dense/rerank, and generation records remain `historical_partial`: the retained report evidence is traceable, but the original production commit and/or runtime environment cannot be established from the repository. The registry records that gap instead of treating an unresolvable legacy backfill SHA as exact evidence.

## Validation

- `pytest -q`: 559 passed, 5 skipped, 1 deselected
- `ruff check src tests experiments scripts`
- canonical registry check, including Git history/tag/config/lockfile verification
- artifact-boundary, headline metric, fixture metric, notebook, and pipeline dry-run checks
- pinned lockfile resolver dry run
- report-table regeneration with zero diff

Closes #18