### PR TITLE
benchmark: add BEIR NFCorpus and SciFact adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ ACL-style findings write-up is
 |---|---|---|
 | Validated result | On MS MARCO `dev/small`, reranked dense top-3 improves T5-small surface metrics over BM25 top-3 on 6,980 paired queries. | [`RESULTS.md`](RESULTS.md) reports the paired metrics and confidence intervals. Dense retrieval and reranking use the documented 50k qrels-anchored candidate pool, not a full-corpus dense first stage. |
 | Validated external retrieval benchmark | On TREC-DL 2019 and 2020, cross-encoder reranking improves MRR@10 and graded nDCG@10 over a full-corpus BM25 first stage on all 43 and 54 judged topics. | [`docs/trec_dl_external_validity.md`](docs/trec_dl_external_validity.md) records the run commit, models, candidate depths, runtimes, independent `ir-measures` cross-check, and links to the checked artifact. This is retrieval evidence, not generation evidence. |
+| Implemented, evaluation pending | NFCorpus and SciFact are available as first cross-domain BEIR retrieval benchmarks. | [`docs/cross_domain_benchmarks.md`](docs/cross_domain_benchmarks.md) documents the dataset ids, corpus separation, runner commands, metrics, and output layout. No NFCorpus or SciFact benchmark number is claimed until a full checked run lands. |
 | Implemented, evaluation pending | The T5-base generator-capacity sweep driver and configurable alternative-generator paths exist. | [`scripts/run_generator_capacity_sweep.py`](scripts/run_generator_capacity_sweep.py) and the Phase A protocol are implemented, but no T5-base or FLAN-T5 headline result is claimed until a complete versioned run lands. |
 | Not established | TREC-DL retrieval gains transfer to grounded generation; dense retrieval beats BM25 under a fair full-corpus candidate condition; or the findings generalize beyond the MS MARCO passage collection. | These remain research questions, not conclusions of the committed artifacts. |
 
@@ -53,8 +54,8 @@ ACL-style findings write-up is
 
 | Area | What is included |
 |---|---|
-| Retrieval | BM25, dense SBERT/FAISS, BM25-on-sample comparisons, and full-corpus BM25 runner support for the judged TREC-DL 2019/2020 passage tracks. |
-| Reranking | Cross-encoder reranking with dataset-selectable TREC-DL runners, aggregate lift, first-stage comparison, and query-level promoted/demoted/new-hit/lost-hit diagnostics. |
+| Retrieval | BM25, dense SBERT/FAISS, BM25-on-sample comparisons, full-corpus BM25 runner support for the judged TREC-DL 2019/2020 passage tracks, and BEIR NFCorpus/SciFact adapters. |
+| Reranking | Cross-encoder reranking with dataset-selectable TREC-DL and BEIR runners, aggregate lift, first-stage comparison, and query-level promoted/demoted/new-hit/lost-hit diagnostics. |
 | Generation | Paired BM25-vs-reranked generation runs using the same generator, prompt format, query set, and top-k depth. |
 | Evaluation | Paired-bootstrap confidence intervals, BERTScore proxy checks, grounding audit, RAG triad reporting, query-form slicing, and regression taxonomy. |
 | Reproducibility | Config-driven runners, manifests, output hashes, metadata, CI, report artifacts, and optional experiment tracking. |
@@ -81,6 +82,7 @@ The repository includes runnable code plus written analysis artifacts:
 - [`docs/lockfile_reproduction.md`](docs/lockfile_reproduction.md) — dependency snapshot update and reproduction policy.
 - [`docs/rag_observatory_exports.md`](docs/rag_observatory_exports.md) — trace and sweep exports for external RAG observability analysis.
 - [`docs/trec_dl_external_validity.md`](docs/trec_dl_external_validity.md) — TREC-DL dataset contract, runner commands, metric boundaries, and benchmark follow-ups.
+- [`docs/cross_domain_benchmarks.md`](docs/cross_domain_benchmarks.md) — NFCorpus and SciFact benchmark contract, commands, output isolation, and result boundary.
 - [`notebooks/rag_eval_demo.ipynb`](notebooks/rag_eval_demo.ipynb) — lightweight evaluation workflow demo.
 
 ## Engineering surface
@@ -122,6 +124,11 @@ auditing the experiments:
   [#153](https://github.com/GioiaZheng/msmarco-genqa/issues/153) and the
   benchmark in [#154](https://github.com/GioiaZheng/msmarco-genqa/issues/154);
   it is not itself a new empirical result.
+- **Cross-domain benchmark adapters.** NFCorpus and SciFact run through the same
+  BM25 and cross-encoder entry points, but each dataset uses its own BEIR corpus,
+  BM25 index, qrels, and output directory. This is the execution surface for
+  [#165](https://github.com/GioiaZheng/msmarco-genqa/issues/165); it does not
+  claim cross-domain results until complete checked artifacts are committed.
 - **RAG triad reporting.** `mgq-rag-triad` joins prediction files with optional
   qrels and writes per-query context relevance, groundedness, and answer
   relevance diagnostics. See
@@ -591,6 +598,27 @@ the original graded labels for nDCG@10 and relevance threshold 2 for MRR@10,
 Recall@100, and Recall@1000. Reportable runs still pass through the independent
 cross-check below. See
 [`docs/trec_dl_external_validity.md`](docs/trec_dl_external_validity.md).
+
+### NFCorpus / SciFact cross-domain retrieval
+
+NFCorpus and SciFact are the first BEIR targets for checking whether the
+retrieval and reranking stack generalizes beyond MS MARCO-derived passage
+benchmarks:
+
+```bash
+mgq-retrieve --dataset beir/nfcorpus/test --resume
+mgq-rerank --dataset beir/nfcorpus/test --resume
+
+mgq-retrieve --dataset beir/scifact/test --resume
+mgq-rerank --dataset beir/scifact/test --resume
+```
+
+Unlike TREC-DL, these datasets do not reuse the MS MARCO passage corpus. Their
+default outputs are isolated under `outputs/beir_nfcorpus_test/` and
+`outputs/beir_scifact_test/`, and their BM25 indexes are isolated under
+`data/processed/bm25_index_beir_nfcorpus_test/` and
+`data/processed/bm25_index_beir_scifact_test/`. See
+[`docs/cross_domain_benchmarks.md`](docs/cross_domain_benchmarks.md).
 
 ### Independent TREC metric cross-check
 

--- a/docs/cross_domain_benchmarks.md
+++ b/docs/cross_domain_benchmarks.md
@@ -1,0 +1,103 @@
+# NFCorpus / SciFact Cross-Domain Benchmarks
+
+## Purpose
+
+MS MARCO `dev/small` and TREC-DL 2019/2020 are useful retrieval evidence, but
+they are still tied to the MS MARCO passage collection. NFCorpus and SciFact are
+the first external-domain checks used here to test whether the retrieval and
+reranking stack remains useful outside that collection.
+
+The goal of this step is deliberately narrow:
+
+- run the same BM25 first stage and cross-encoder reranker on two BEIR test
+  collections;
+- keep each dataset's own corpus, qrels, indexes, and outputs separate;
+- report retrieval metrics before doing deeper error analysis; and
+- avoid claiming cross-domain generalization until complete checked artifacts
+  are committed.
+
+## Dataset Contract
+
+| Dataset id | Domain | Corpus | Qrels | Positive threshold |
+|---|---|---|---|---:|
+| `beir/nfcorpus/test` | Medical information retrieval | NFCorpus BEIR corpus | BEIR test qrels | `rel >= 1` |
+| `beir/scifact/test` | Scientific claim retrieval | SciFact BEIR corpus | BEIR test qrels | `rel >= 1` |
+
+Both datasets are loaded through `ir_datasets`. Unlike TREC-DL, they do not
+reuse the MS MARCO passage corpus or the shared MS MARCO BM25 index. This keeps
+the cross-domain benchmark from accidentally measuring retrieval against the
+wrong document collection.
+
+## Runner Commands
+
+```bash
+mgq-retrieve --dataset beir/nfcorpus/test --resume --require-clean-tree
+mgq-rerank --dataset beir/nfcorpus/test --resume --require-clean-tree
+
+mgq-retrieve --dataset beir/scifact/test --resume --require-clean-tree
+mgq-rerank --dataset beir/scifact/test --resume --require-clean-tree
+```
+
+Default outputs are isolated by dataset:
+
+- `outputs/beir_nfcorpus_test/bm25`
+- `outputs/beir_nfcorpus_test/cross_encoder_rerank`
+- `outputs/beir_scifact_test/bm25`
+- `outputs/beir_scifact_test/cross_encoder_rerank`
+
+Default BM25 indexes are also isolated:
+
+- `data/processed/bm25_index_beir_nfcorpus_test`
+- `data/processed/bm25_index_beir_scifact_test`
+
+## Metrics
+
+Runner `metrics.json` files use:
+
+- MRR@10;
+- nDCG@10 with the original graded labels;
+- Recall@100 and Recall@1000; and
+- coverage diagnostics for queries present in the run and qrels.
+
+For thresholded metrics such as MRR and recall, BEIR qrels are binarized with
+`rel >= 1`. nDCG retains the original relevance labels.
+
+## Independent Cross-Check
+
+Materialize the qrels and validate each run with the same TREC-compatible
+evaluator used by the MS MARCO and TREC-DL runners:
+
+```bash
+ir_datasets export beir/nfcorpus/test qrels --format trec \
+  > data/processed/beir-nfcorpus-test.qrels
+ir_datasets export beir/scifact/test qrels --format trec \
+  > data/processed/beir-scifact-test.qrels
+
+mgq-trec-eval --backend ir-measures --qrels-format trec --rel-threshold 1 \
+  --qrels data/processed/beir-nfcorpus-test.qrels \
+  --run outputs/beir_nfcorpus_test/bm25/run.tsv \
+  --output-dir outputs/beir_nfcorpus_test/bm25/trec_eval
+
+mgq-trec-eval --backend ir-measures --qrels-format trec --rel-threshold 1 \
+  --qrels data/processed/beir-scifact-test.qrels \
+  --run outputs/beir_scifact_test/bm25/run.tsv \
+  --output-dir outputs/beir_scifact_test/bm25/trec_eval
+```
+
+Repeat the same command for each dataset's
+`cross_encoder_rerank/run.tsv`. Keep NFCorpus and SciFact separate in reports;
+do not average them into one headline without reporting both dataset values.
+
+## Current Status
+
+The code path and offline tests are implemented. No NFCorpus or SciFact
+benchmark score is claimed yet. A reportable result should include:
+
+- the run commit;
+- the resolved config and manifest;
+- BM25 and reranked `metrics.json`;
+- the TREC-compatible cross-check output; and
+- notes on any query or document coverage gaps.
+
+Only after those artifacts exist should the project move to deeper error
+analysis on failures.

--- a/experiments/run_reranker.py
+++ b/experiments/run_reranker.py
@@ -69,9 +69,10 @@ from msmarco_genqa.data.benchmark import (
     default_retrieval_output_dir,
     default_reranker_output_dir,
     get_benchmark_spec,
+    load_benchmark_corpus,
     load_benchmark_queries,
+    lookup_document_text,
 )
-from msmarco_genqa.data.msmarco import get_docs_store, load_msmarco_passage
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
 from msmarco_genqa.evaluation.trec import evaluate_trec_retrieval, trec_metric_contract
 from msmarco_genqa.reranking.cross_encoder import CrossEncoderReranker
@@ -217,10 +218,10 @@ def resolve_input_run(
 ) -> Path:
     if args.input_run is not None:
         return args.input_run if args.input_run.is_absolute() else project_root / args.input_run
-    if spec.is_trec_dl:
-        path = default_retrieval_output_dir(spec, cfg["eval_retrieval"]["output_dir"])
-        return project_root / path / "run.tsv"
-    return project_root / "outputs/dense_retrieval/run.tsv"
+    if spec.dataset_id == MSMARCO_DEV_SMALL:
+        return project_root / "outputs/dense_retrieval/run.tsv"
+    path = default_retrieval_output_dir(spec, cfg["eval_retrieval"]["output_dir"])
+    return project_root / path / "run.tsv"
 
 
 def resolve_input_stage_dir(
@@ -247,7 +248,7 @@ def resolve_output_dir(
 
 
 def first_stage_label(spec: BenchmarkSpec, input_run_path: Path) -> str:
-    if spec.is_trec_dl or "bm25" in str(input_run_path).lower():
+    if spec.dataset_id != MSMARCO_DEV_SMALL or "bm25" in str(input_run_path).lower():
         return "bm25"
     if "dense" in str(input_run_path).lower():
         return "dense"
@@ -285,7 +286,7 @@ def validate_trec_input_run(
     upstream_metadata: dict[str, object],
 ) -> None:
     """Fail before model loading when a TREC run has the wrong topic scope."""
-    if not spec.is_trec_dl:
+    if spec.dataset_id == MSMARCO_DEV_SMALL:
         return
 
     upstream_dataset = upstream_metadata.get("dataset_id")
@@ -331,7 +332,7 @@ def _resolve_passages(doc_ids: list[str], docs_store) -> dict[str, str]:
     out: dict[str, str] = {}
     for d in doc_ids:
         try:
-            out[d] = docs_store.get(d).text
+            out[d] = lookup_document_text(docs_store, d)
         except KeyError:
             out[d] = ""
             n_missing += 1
@@ -421,12 +422,15 @@ def main() -> None:
     # ---------------------------------------------------------------- #
     # 2. Queries + qrels
     # ---------------------------------------------------------------- #
-    corpus_data = load_msmarco_passage(cache_dir=cache_dir, load_corpus=False)
-    docs_store = corpus_data.docs_store or get_docs_store(cache_dir=cache_dir)
+    corpus_data = load_benchmark_corpus(
+        benchmark_spec,
+        cache_dir=cache_dir,
+        load_corpus=False,
+    )
+    docs_store = corpus_data.docs_store
     benchmark = load_benchmark_queries(
         args.dataset,
         cache_dir=cache_dir,
-        msmarco_data=corpus_data,
     )
     upstream_benchmark = load_upstream_benchmark_metadata(input_stage_dir)
     validate_trec_input_run(
@@ -437,7 +441,7 @@ def main() -> None:
     )
     sample_qrels = (
         benchmark.qrels
-        if benchmark_spec.is_trec_dl
+        if benchmark_spec.dataset_id != MSMARCO_DEV_SMALL
         else _load_sample_qrels(input_stage_dir, benchmark.qrels)
     )
 
@@ -605,8 +609,8 @@ def main() -> None:
     # ---------------------------------------------------------------- #
     input_runs_eval = {q: [d for d, _ in runs_topk[q]] for q in eval_qids}
 
-    if benchmark_spec.is_trec_dl:
-        rel_threshold = benchmark_spec.rel_threshold or 2
+    if benchmark_spec.has_graded_qrels:
+        rel_threshold = benchmark_spec.rel_threshold or 1
         input_metrics = evaluate_trec_retrieval(
             input_runs_eval,
             benchmark.graded_qrels,
@@ -678,7 +682,7 @@ def main() -> None:
     benchmark_metadata = benchmark.metadata()
     benchmark_metadata.update(
         {
-            "corpus_id": "msmarco-passage",
+            "corpus_id": benchmark_spec.corpus_id,
             "corpus_scope": upstream_benchmark.get("corpus_scope", "unknown"),
             "input_run_topic_count": len(runs_topk),
             "reranked_topic_count": len(final_runs),
@@ -730,10 +734,10 @@ def main() -> None:
         "peak_memory_mib": peak_mem_mb,
         "environment": (env_dict := capture_environment()),
     }
-    if benchmark_spec.is_trec_dl:
+    if benchmark_spec.has_graded_qrels:
         payload["evaluation"] = {
             **trec_metric_contract(
-                rel_threshold=benchmark_spec.rel_threshold or 2,
+                rel_threshold=benchmark_spec.rel_threshold or 1,
             ),
             "qrels_source": benchmark_spec.dataset_id,
             "internal_backend": "msmarco_genqa.evaluation.trec",
@@ -786,6 +790,7 @@ def main() -> None:
             else str(input_run_path),
             "resumed": bool(args.resume) and len(done_qids) > 0,
             "dataset": benchmark_spec.dataset_id,
+            "corpus_id": benchmark_spec.corpus_id,
             "track_year": benchmark_spec.track_year,
             "judged_topic_count": benchmark.judged_topic_count,
             "judged_topic_coverage": benchmark_metadata["judged_topic_coverage"],

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -37,11 +37,13 @@ from msmarco_genqa.data.benchmark import (
     MSMARCO_DEV_SMALL,
     SUPPORTED_DATASETS,
     BenchmarkSpec,
+    default_retrieval_index_dir,
     default_retrieval_output_dir,
     get_benchmark_spec,
+    load_benchmark_corpus,
     load_benchmark_queries,
+    lookup_document_text,
 )
-from msmarco_genqa.data.msmarco import load_msmarco_passage
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
 from msmarco_genqa.evaluation.trec import evaluate_trec_retrieval, trec_metric_contract
 from msmarco_genqa.retrieval.bm25 import BM25Retriever
@@ -187,7 +189,15 @@ def main() -> None:
     seed_coverage = set_global_seed(seed)
 
     output_dir = resolve_output_dir(args, cfg, benchmark_spec)
-    index_dir = PROJECT_ROOT / cfg["retrieval"]["index_dir"]
+    index_dir_config = default_retrieval_index_dir(
+        benchmark_spec,
+        cfg["retrieval"]["index_dir"],
+    )
+    index_dir = (
+        index_dir_config
+        if index_dir_config.is_absolute()
+        else PROJECT_ROOT / index_dir_config
+    )
     cache_dir = PROJECT_ROOT / cfg["data"].get("cache_dir", "data/raw")
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -203,7 +213,8 @@ def main() -> None:
 
     # ---- 1. Data ----
     have_index = (index_dir / "config.json").exists() and not args.rebuild_index
-    corpus_data = load_msmarco_passage(
+    corpus_data = load_benchmark_corpus(
+        benchmark_spec,
         cache_dir=cache_dir,
         load_corpus=not have_index,
         limit=corpus_limit,
@@ -211,7 +222,6 @@ def main() -> None:
     benchmark = load_benchmark_queries(
         args.dataset,
         cache_dir=cache_dir,
-        msmarco_data=corpus_data,
     )
     query_text_by_qid, query_transform_summary, query_transform_outputs = (
         materialize_query_transform(
@@ -377,11 +387,11 @@ def main() -> None:
     logger.info("Reading %s for evaluation...", run_path)
     runs, scores_by_qid = _read_runs_from_tsv(run_path)
 
-    if benchmark_spec.is_trec_dl:
+    if benchmark_spec.has_graded_qrels:
         metrics = evaluate_trec_retrieval(
             runs=runs,
             qrels=benchmark.graded_qrels,
-            rel_threshold=benchmark_spec.rel_threshold or 2,
+            rel_threshold=benchmark_spec.rel_threshold or 1,
             ks_mrr=tuple(ks_mrr),
             ks_recall=tuple(ks_recall),
             ks_ndcg=tuple(ks_ndcg),
@@ -405,13 +415,15 @@ def main() -> None:
         def get_text(doc_id: str) -> str:
             return id_to_text.get(doc_id, "")
     else:
-        from msmarco_genqa.data.msmarco import get_docs_store
-
-        store = get_docs_store(cache_dir=cache_dir)
+        store = corpus_data.docs_store or load_benchmark_corpus(
+            benchmark_spec,
+            cache_dir=cache_dir,
+            load_corpus=False,
+        ).docs_store
 
         def get_text(doc_id: str) -> str:
             try:
-                return store.get(doc_id).text
+                return lookup_document_text(store, doc_id)
             except KeyError:
                 return ""
 
@@ -464,7 +476,7 @@ def main() -> None:
     judged_qids = set(benchmark.graded_qrels)
     benchmark_metadata.update(
         {
-            "corpus_id": "msmarco-passage",
+            "corpus_id": benchmark_spec.corpus_id,
             "corpus_scope": "first-N-truncated" if corpus_limit is not None else "full",
             "run_topic_count": len(set(runs) & set(benchmark.queries)),
             "judged_topic_coverage": (
@@ -490,10 +502,10 @@ def main() -> None:
         "query_transform": query_transform_summary,
         "resumed": args.resume and bool(set(qids) - set(pending_qids)),
     }
-    if benchmark_spec.is_trec_dl:
+    if benchmark_spec.has_graded_qrels:
         payload["evaluation"] = {
             **trec_metric_contract(
-                rel_threshold=benchmark_spec.rel_threshold or 2,
+                rel_threshold=benchmark_spec.rel_threshold or 1,
             ),
             "qrels_source": benchmark_spec.dataset_id,
             "internal_backend": "msmarco_genqa.evaluation.trec",
@@ -526,6 +538,7 @@ def main() -> None:
             "n_eval_queries": len(qids),
             "n_metric_queries": n_examples,
             "dataset": benchmark_spec.dataset_id,
+            "corpus_id": benchmark_spec.corpus_id,
             "track_year": benchmark_spec.track_year,
             "judged_topic_count": benchmark.judged_topic_count,
             "run_topic_count": len(set(runs) & set(benchmark.queries)),

--- a/src/msmarco_genqa/data/benchmark.py
+++ b/src/msmarco_genqa/data/benchmark.py
@@ -1,16 +1,26 @@
-"""Dataset selection shared by the full-corpus retrieval runners."""
+"""Dataset and corpus selection shared by the full-corpus runners."""
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from msmarco_genqa.data.msmarco import MSMarcoPassage, load_msmarco_passage
-from msmarco_genqa.data.trec_dl import DEFAULT_REL_THRESHOLD, TREC_DL_DATASETS, load_trec_dl
+from msmarco_genqa.data.trec_dl import (
+    DEFAULT_REL_THRESHOLD,
+    TREC_DL_DATASETS,
+    binarize_qrels,
+    load_trec_dl,
+)
 
 
 MSMARCO_DEV_SMALL = "msmarco-passage/dev/small"
-SUPPORTED_DATASETS = (MSMARCO_DEV_SMALL, *TREC_DL_DATASETS.values())
+BEIR_NFCORPUS_TEST = "beir/nfcorpus/test"
+BEIR_SCIFACT_TEST = "beir/scifact/test"
+BEIR_DATASETS = (BEIR_NFCORPUS_TEST, BEIR_SCIFACT_TEST)
+SUPPORTED_DATASETS = (MSMARCO_DEV_SMALL, *TREC_DL_DATASETS.values(), *BEIR_DATASETS)
 
 
 @dataclass(frozen=True)
@@ -19,12 +29,38 @@ class BenchmarkSpec:
 
     dataset_id: str
     output_slug: str
+    corpus_id: str = "msmarco-passage"
+    benchmark_family: str = "msmarco"
+    topic_scope: str = "dev/small"
     track_year: int | None = None
     rel_threshold: int | None = None
+    domain: str | None = None
 
     @property
     def is_trec_dl(self) -> bool:
         return self.track_year is not None
+
+    @property
+    def is_beir(self) -> bool:
+        return self.benchmark_family == "beir"
+
+    @property
+    def has_graded_qrels(self) -> bool:
+        return self.is_trec_dl or self.is_beir
+
+    @property
+    def uses_msmarco_corpus(self) -> bool:
+        return self.corpus_id == "msmarco-passage"
+
+
+@dataclass
+class BenchmarkCorpus:
+    """Corpus documents normalized across supported benchmark families."""
+
+    spec: BenchmarkSpec
+    corpus_doc_ids: list[str]
+    corpus_texts: list[str]
+    docs_store: Any | None = None
 
 
 @dataclass
@@ -47,12 +83,15 @@ class BenchmarkQueries:
     def metadata(self) -> dict[str, object]:
         return {
             "dataset_id": self.spec.dataset_id,
+            "corpus_id": self.spec.corpus_id,
+            "benchmark_family": self.spec.benchmark_family,
+            "domain": self.spec.domain,
             "track_year": self.spec.track_year,
-            "topic_scope": "judged" if self.spec.is_trec_dl else "dev/small",
+            "topic_scope": self.spec.topic_scope,
             "query_count": len(self.queries),
             "judged_topic_count": self.judged_topic_count,
             "positive_topic_count": self.positive_topic_count,
-            "qrels_type": "graded" if self.spec.is_trec_dl else "binary",
+            "qrels_type": "graded" if self.spec.has_graded_qrels else "binary",
             "relevance_threshold": self.spec.rel_threshold,
         }
 
@@ -60,16 +99,124 @@ class BenchmarkQueries:
 def get_benchmark_spec(dataset_id: str) -> BenchmarkSpec:
     if dataset_id == MSMARCO_DEV_SMALL:
         return BenchmarkSpec(dataset_id=dataset_id, output_slug="msmarco_dev_small")
+
     for year, candidate in TREC_DL_DATASETS.items():
         if dataset_id == candidate:
             return BenchmarkSpec(
                 dataset_id=dataset_id,
                 output_slug=f"trec_dl_{year}",
+                benchmark_family="trec-dl",
+                topic_scope="judged",
                 track_year=year,
                 rel_threshold=DEFAULT_REL_THRESHOLD,
             )
+
+    if dataset_id == BEIR_NFCORPUS_TEST:
+        return BenchmarkSpec(
+            dataset_id=dataset_id,
+            output_slug="beir_nfcorpus_test",
+            corpus_id=dataset_id,
+            benchmark_family="beir",
+            topic_scope="test",
+            rel_threshold=1,
+            domain="medical",
+        )
+
+    if dataset_id == BEIR_SCIFACT_TEST:
+        return BenchmarkSpec(
+            dataset_id=dataset_id,
+            output_slug="beir_scifact_test",
+            corpus_id=dataset_id,
+            benchmark_family="beir",
+            topic_scope="test",
+            rel_threshold=1,
+            domain="scientific",
+        )
+
     raise ValueError(
         f"unsupported dataset {dataset_id!r}; expected one of {SUPPORTED_DATASETS}"
+    )
+
+
+def _set_irds_home(cache_dir: Path | str | None) -> None:
+    if cache_dir is not None:
+        os.environ["IR_DATASETS_HOME"] = str(Path(cache_dir).expanduser().resolve())
+
+
+def _record_text(record: object, *, fields: tuple[str, ...]) -> str:
+    values: list[str] = []
+    for field in fields:
+        value = getattr(record, field, None)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            values.append(text)
+    return "\n".join(values)
+
+
+def query_text(record: object) -> str:
+    """Return the canonical query text for common ir_datasets query records."""
+    return _record_text(record, fields=("text", "title", "all", "desc"))
+
+
+def document_text(record: object) -> str:
+    """Return searchable text for common ir_datasets document records."""
+    return _record_text(record, fields=("title", "text", "abstract", "body"))
+
+
+def lookup_document_text(docs_store: Any, doc_id: str) -> str:
+    """Look up and normalize one document from an ir_datasets docs_store."""
+    return document_text(docs_store.get(doc_id))
+
+
+def load_benchmark_corpus(
+    spec: BenchmarkSpec,
+    *,
+    cache_dir: Path | str | None = None,
+    load_corpus: bool = True,
+    limit: int | None = None,
+) -> BenchmarkCorpus:
+    """Load the corpus attached to a benchmark.
+
+    TREC-DL shares the MS MARCO passage corpus. BEIR datasets use their own
+    inherited corpora, so using the MS MARCO index for them would be invalid.
+    """
+    if spec.uses_msmarco_corpus:
+        data = load_msmarco_passage(
+            cache_dir=cache_dir,
+            load_corpus=load_corpus,
+            limit=limit,
+        )
+        return BenchmarkCorpus(
+            spec=spec,
+            corpus_doc_ids=data.corpus_doc_ids,
+            corpus_texts=data.corpus_texts,
+            docs_store=data.docs_store,
+        )
+
+    _set_irds_home(cache_dir)
+    import ir_datasets
+
+    dataset = ir_datasets.load(spec.corpus_id)
+    doc_ids: list[str] = []
+    texts: list[str] = []
+    docs_store = None
+
+    if load_corpus:
+        for index, doc in enumerate(dataset.docs_iter()):
+            if limit is not None and index >= limit:
+                break
+            doc_ids.append(doc.doc_id)
+            texts.append(document_text(doc))
+    else:
+        docs_store = dataset.docs_store()
+
+    return BenchmarkCorpus(
+        spec=spec,
+        corpus_doc_ids=doc_ids,
+        corpus_texts=texts,
+        docs_store=docs_store,
     )
 
 
@@ -81,7 +228,7 @@ def load_benchmark_queries(
 ) -> BenchmarkQueries:
     """Load query text and qrels without loading the passage corpus eagerly."""
     spec = get_benchmark_spec(dataset_id)
-    if not spec.is_trec_dl:
+    if spec.dataset_id == MSMARCO_DEV_SMALL:
         data = msmarco_data or load_msmarco_passage(
             cache_dir=cache_dir,
             load_corpus=False,
@@ -92,21 +239,40 @@ def load_benchmark_queries(
         }
         return BenchmarkQueries(spec, data.queries, data.qrels, graded_qrels)
 
-    data = load_trec_dl(
-        spec.track_year,
-        cache_dir=cache_dir,
-        rel_threshold=spec.rel_threshold or DEFAULT_REL_THRESHOLD,
-    )
-    return BenchmarkQueries(spec, data.queries, data.qrels, data.graded_qrels)
+    if spec.is_trec_dl:
+        data = load_trec_dl(
+            spec.track_year,
+            cache_dir=cache_dir,
+            rel_threshold=spec.rel_threshold or DEFAULT_REL_THRESHOLD,
+        )
+        return BenchmarkQueries(spec, data.queries, data.qrels, data.graded_qrels)
+
+    _set_irds_home(cache_dir)
+    import ir_datasets
+
+    dataset = ir_datasets.load(spec.dataset_id)
+    queries = {q.query_id: query_text(q) for q in dataset.queries_iter()}
+    graded_qrels: dict[str, dict[str, int]] = {}
+    for qrel in dataset.qrels_iter():
+        if qrel.query_id in queries:
+            graded_qrels.setdefault(qrel.query_id, {})[qrel.doc_id] = int(qrel.relevance)
+    qrels = binarize_qrels(graded_qrels, rel_threshold=spec.rel_threshold or 1)
+    return BenchmarkQueries(spec, queries, qrels, graded_qrels)
 
 
 def default_retrieval_output_dir(spec: BenchmarkSpec, configured: str) -> Path:
-    if not spec.is_trec_dl:
+    if spec.dataset_id == MSMARCO_DEV_SMALL:
         return Path(configured)
     return Path("outputs") / spec.output_slug / "bm25"
 
 
 def default_reranker_output_dir(spec: BenchmarkSpec, configured: str) -> Path:
-    if not spec.is_trec_dl:
+    if spec.dataset_id == MSMARCO_DEV_SMALL:
         return Path(configured)
     return Path("outputs") / spec.output_slug / "cross_encoder_rerank"
+
+
+def default_retrieval_index_dir(spec: BenchmarkSpec, configured: str) -> Path:
+    if spec.uses_msmarco_corpus:
+        return Path(configured)
+    return Path("data") / "processed" / f"bm25_index_{spec.output_slug}"

--- a/tests/test_benchmark_dataset_selection.py
+++ b/tests/test_benchmark_dataset_selection.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -21,10 +23,15 @@ from experiments.run_retrieval import (
 )
 from msmarco_genqa.data import benchmark as benchmark_module
 from msmarco_genqa.data.benchmark import (
+    BEIR_NFCORPUS_TEST,
+    BEIR_SCIFACT_TEST,
     MSMARCO_DEV_SMALL,
     SUPPORTED_DATASETS,
+    default_retrieval_index_dir,
     get_benchmark_spec,
+    load_benchmark_corpus,
     load_benchmark_queries,
+    lookup_document_text,
 )
 from msmarco_genqa.data.trec_dl import TREC_DL_DATASETS, load_trec_dl_from_files
 
@@ -38,6 +45,64 @@ def cfg() -> dict:
         "eval_retrieval": {"output_dir": "outputs/bm25_baseline"},
         "reranker": {"output_dir": "outputs/cross_encoder_rerank"},
     }
+
+
+class FakeDocsStore:
+    def __init__(self, docs: dict[str, object]):
+        self.docs = docs
+
+    def get(self, doc_id: str) -> object:
+        return self.docs[doc_id]
+
+
+class FakeIrDataset:
+    def __init__(self) -> None:
+        self.docs = {
+            "D1": SimpleNamespace(
+                doc_id="D1",
+                title="Trial result",
+                text="A scientific abstract about treatment response.",
+                url="https://example.test/d1",
+            ),
+            "D2": SimpleNamespace(
+                doc_id="D2",
+                title="Background",
+                text="A non-relevant background document.",
+                url="https://example.test/d2",
+            ),
+        }
+        self.queries = [
+            SimpleNamespace(
+                query_id="q1",
+                text="does treatment improve response",
+                url="https://example.test/q1",
+            ),
+            SimpleNamespace(query_id="q2", text="unjudged claim"),
+        ]
+        self.qrels = [
+            SimpleNamespace(query_id="q1", doc_id="D1", relevance=1, iteration="0"),
+            SimpleNamespace(query_id="q1", doc_id="D2", relevance=0, iteration="0"),
+        ]
+
+    def docs_iter(self):
+        return iter(self.docs.values())
+
+    def queries_iter(self):
+        return iter(self.queries)
+
+    def qrels_iter(self):
+        return iter(self.qrels)
+
+    def docs_store(self):
+        return FakeDocsStore(self.docs)
+
+
+@pytest.fixture
+def fake_irds(monkeypatch):
+    dataset = FakeIrDataset()
+    fake_module = SimpleNamespace(load=lambda dataset_id: dataset)
+    monkeypatch.setitem(sys.modules, "ir_datasets", fake_module)
+    return dataset
 
 
 @pytest.mark.parametrize("year", [2019, 2020])
@@ -71,9 +136,77 @@ def test_supported_datasets_keep_dev_small_as_default():
         MSMARCO_DEV_SMALL,
         TREC_DL_DATASETS[2019],
         TREC_DL_DATASETS[2020],
+        BEIR_NFCORPUS_TEST,
+        BEIR_SCIFACT_TEST,
     )
     assert parse_retrieval_args([]).dataset == MSMARCO_DEV_SMALL
     assert parse_reranker_args([]).dataset == MSMARCO_DEV_SMALL
+
+
+@pytest.mark.parametrize(
+    ("dataset_id", "slug", "domain"),
+    [
+        (BEIR_NFCORPUS_TEST, "beir_nfcorpus_test", "medical"),
+        (BEIR_SCIFACT_TEST, "beir_scifact_test", "scientific"),
+    ],
+)
+def test_beir_default_paths_and_indexes_are_isolated(
+    dataset_id,
+    slug,
+    domain,
+    cfg,
+    tmp_path,
+):
+    spec = get_benchmark_spec(dataset_id)
+    retrieval_args = parse_retrieval_args(["--dataset", dataset_id])
+    reranker_args = parse_reranker_args(["--dataset", dataset_id])
+
+    retrieval_dir = resolve_retrieval_output_dir(
+        retrieval_args,
+        cfg,
+        spec,
+        project_root=tmp_path,
+    )
+    reranker_dir = resolve_reranker_output_dir(
+        reranker_args,
+        cfg,
+        spec,
+        project_root=tmp_path,
+    )
+
+    assert spec.corpus_id == dataset_id
+    assert spec.domain == domain
+    assert spec.has_graded_qrels
+    assert retrieval_dir == tmp_path / "outputs" / slug / "bm25"
+    assert reranker_dir == tmp_path / "outputs" / slug / "cross_encoder_rerank"
+    assert default_retrieval_index_dir(spec, "data/processed/bm25_index_msmarco") == (
+        Path("data") / "processed" / f"bm25_index_{slug}"
+    )
+    assert resolve_input_run(reranker_args, cfg, spec, project_root=tmp_path) == (
+        retrieval_dir / "run.tsv"
+    )
+    assert first_stage_label(spec, retrieval_dir / "run.tsv") == "bm25"
+
+
+def test_beir_query_and_corpus_loaders_use_dataset_corpus(fake_irds):
+    selected = load_benchmark_queries(BEIR_SCIFACT_TEST)
+    spec = get_benchmark_spec(BEIR_SCIFACT_TEST)
+    corpus = load_benchmark_corpus(spec, load_corpus=True)
+    lazy_corpus = load_benchmark_corpus(spec, load_corpus=False)
+
+    assert selected.queries == {
+        "q1": "does treatment improve response",
+        "q2": "unjudged claim",
+    }
+    assert selected.qrels == {"q1": {"D1"}}
+    assert selected.graded_qrels == {"q1": {"D1": 1, "D2": 0}}
+    assert selected.metadata()["corpus_id"] == BEIR_SCIFACT_TEST
+    assert selected.metadata()["benchmark_family"] == "beir"
+    assert corpus.corpus_doc_ids == ["D1", "D2"]
+    assert corpus.corpus_texts[0] == (
+        "Trial result\nA scientific abstract about treatment response."
+    )
+    assert lookup_document_text(lazy_corpus.docs_store, "D1") == corpus.corpus_texts[0]
 
 
 @pytest.mark.parametrize("year", [2019, 2020])


### PR DESCRIPTION
## Why
NFCorpus and SciFact provide first cross-domain retrieval checks beyond MS MARCO-derived passage benchmarks. This PR adds the execution surface for issue #165 without reporting new benchmark results.

## What changed
- Adds BEIR dataset specs for NFCorpus and SciFact.
- Loads dataset-specific corpora, qrels, and document text instead of reusing the MS MARCO passage corpus.
- Routes BM25 indexes and stage outputs into dataset-isolated directories.
- Extends retrieval and reranker evaluation metadata with corpus provenance.
- Documents the benchmark contract, commands, metric boundaries, and result boundary.
- Adds offline tests for dataset selection, path isolation, qrels binarization, and document lookup.

## Validation
- C:\Users\gioia.zheng\anaconda3\python.exe -m pytest -q tests\test_benchmark_dataset_selection.py tests\test_trec_dl.py tests\test_trec_cross_check.py --basetemp C:\Users\gioia.zheng\Documents\Codex\2026-06-05\github-readme-commit-message-pr-issue\.tmp-pytest-msmarco
- C:\Users\gioia.zheng\anaconda3\Scripts\ruff.exe check --no-cache src\msmarco_genqa\data\benchmark.py experiments\run_retrieval.py experiments\run_reranker.py tests\test_benchmark_dataset_selection.py
- git diff --cached --check
- scanned changed public files for source-control conflict markers, mojibake, and disallowed generated-content traces

## Risk / follow-up
- This does not run or claim full NFCorpus or SciFact benchmark scores.
- Next step is to run BM25 and reranked artifacts, cross-check metrics, and only then decide whether deeper error analysis is useful.

Refs #165.