### PR TITLE
fix(eval): respect reranker candidate depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,9 @@ Unlike TREC-DL, these datasets do not reuse the MS MARCO passage corpus. Their
 default outputs are isolated under `outputs/beir_nfcorpus_test/` and
 `outputs/beir_scifact_test/`, and their BM25 indexes are isolated under
 `data/processed/bm25_index_beir_nfcorpus_test/` and
-`data/processed/bm25_index_beir_scifact_test/`. See
+`data/processed/bm25_index_beir_scifact_test/`. The BM25 runs report
+Recall@1000; top-100 cross-encoder runs omit it because their candidate depth
+cannot support a comparable Recall@1000 measurement. See
 [`docs/cross_domain_benchmarks.md`](docs/cross_domain_benchmarks.md).
 
 ### Independent TREC metric cross-check

--- a/docs/cross_domain_benchmarks.md
+++ b/docs/cross_domain_benchmarks.md
@@ -52,12 +52,19 @@ Default BM25 indexes are also isolated:
 
 ## Metrics
 
-Runner `metrics.json` files use:
+The BM25 retrieval `metrics.json` files use:
 
 - MRR@10;
 - nDCG@10 with the original graded labels;
 - Recall@100 and Recall@1000; and
 - coverage diagnostics for queries present in the run and qrels.
+
+The cross-encoder only reranks the fixed BM25 top-100 candidate set. Its
+`metrics.json` therefore reports MRR@10, nDCG@10, and Recall@100, but omits
+Recall@1000. A top-100 reranked run cannot establish Recall@1000: evaluating
+that cutoff would only repeat Recall@100 and could be mistaken for a recall
+drop relative to the full BM25 top-1000 run. Recall@100 is expected to remain
+unchanged because reranking changes order, not candidate membership.
 
 For thresholded metrics such as MRR and recall, BEIR qrels are binarized with
 `rel >= 1`. nDCG retains the original relevance labels.
@@ -87,6 +94,9 @@ mgq-trec-eval --backend ir-measures --qrels-format trec --rel-threshold 1 \
 Repeat the same command for each dataset's
 `cross_encoder_rerank/run.tsv`. Keep NFCorpus and SciFact separate in reports;
 do not average them into one headline without reporting both dataset values.
+The standalone evaluator still computes Recall@1000 for any supplied run. For
+a top-100 reranked file, that value is candidate-set Recall@100 under a larger
+cutoff and must not be presented as a comparable Recall@1000 result.
 
 ## Current Status
 
@@ -97,7 +107,9 @@ benchmark score is claimed yet. A reportable result should include:
 - the resolved config and manifest;
 - BM25 and reranked `metrics.json`;
 - the TREC-compatible cross-check output; and
-- notes on any query or document coverage gaps.
+- notes on any query or document coverage gaps;
+- the reranker candidate depth and omitted metric cutoffs; and
+- runtime plus hardware/device information for both stages.
 
 Only after those artifacts exist should the project move to deeper error
 analysis on failures.

--- a/experiments/run_reranker.py
+++ b/experiments/run_reranker.py
@@ -364,6 +364,20 @@ def _load_sample_qrels(input_stage_dir: Path, all_qrels: dict[str, set[str]]) ->
     return {q: r for q, r in sample_qrels.items() if r}
 
 
+def metric_cutoffs_within_depth(
+    cutoffs: list[int] | tuple[int, ...],
+    *,
+    run_depth: int,
+) -> tuple[int, ...]:
+    """Keep only cutoffs that a candidate-limited run can actually support."""
+    if run_depth <= 0:
+        raise ValueError("run_depth must be a positive integer")
+    normalized = tuple(int(k) for k in cutoffs)
+    if any(k <= 0 for k in normalized):
+        raise ValueError("metric cutoffs must be positive integers")
+    return tuple(k for k in normalized if k <= run_depth)
+
+
 def main() -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -388,6 +402,16 @@ def main() -> None:
         or rerank_cfg.get("chunk_size", 200)
     )
     n_examples_to_save = int(rerank_cfg.get("n_examples", 20))
+    eval_cfg = cfg.get("eval_retrieval", {})
+    configured_ks_mrr = tuple(eval_cfg.get("ks_mrr", (10,)))
+    configured_ks_ndcg = tuple(eval_cfg.get("ks_ndcg", (10,)))
+    configured_ks_recall = tuple(eval_cfg.get("ks_recall", (100, 1000)))
+    ks_mrr = metric_cutoffs_within_depth(configured_ks_mrr, run_depth=rerank_top_k)
+    ks_ndcg = metric_cutoffs_within_depth(configured_ks_ndcg, run_depth=rerank_top_k)
+    ks_recall = metric_cutoffs_within_depth(
+        configured_ks_recall,
+        run_depth=rerank_top_k,
+    )
     cache_dir = PROJECT_ROOT / cfg["data"].get("cache_dir", "data/raw")
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -615,15 +639,33 @@ def main() -> None:
             input_runs_eval,
             benchmark.graded_qrels,
             rel_threshold=rel_threshold,
+            ks_mrr=ks_mrr,
+            ks_ndcg=ks_ndcg,
+            ks_recall=ks_recall,
         )
         rerank_metrics = evaluate_trec_retrieval(
             rerank_runs_eval,
             benchmark.graded_qrels,
             rel_threshold=rel_threshold,
+            ks_mrr=ks_mrr,
+            ks_ndcg=ks_ndcg,
+            ks_recall=ks_recall,
         )
     else:
-        input_metrics = evaluate_retrieval(input_runs_eval, sample_qrels)
-        rerank_metrics = evaluate_retrieval(rerank_runs_eval, sample_qrels)
+        input_metrics = evaluate_retrieval(
+            input_runs_eval,
+            sample_qrels,
+            ks_mrr=ks_mrr,
+            ks_ndcg=ks_ndcg,
+            ks_recall=ks_recall,
+        )
+        rerank_metrics = evaluate_retrieval(
+            rerank_runs_eval,
+            sample_qrels,
+            ks_mrr=ks_mrr,
+            ks_ndcg=ks_ndcg,
+            ks_recall=ks_recall,
+        )
     logger.info("%s (input) metrics: %s", input_label, input_metrics)
     logger.info("%s + CE rerank metrics: %s", input_label, rerank_metrics)
 
@@ -711,6 +753,19 @@ def main() -> None:
             "batch_size": batch_size,
             "max_length": max_length,
         },
+        "metric_scope": {
+            "run_depth": rerank_top_k,
+            "reported_cutoffs": {
+                "mrr": list(ks_mrr),
+                "ndcg": list(ks_ndcg),
+                "recall": list(ks_recall),
+            },
+            "omitted_cutoffs_above_run_depth": {
+                "mrr": [k for k in configured_ks_mrr if k > rerank_top_k],
+                "ndcg": [k for k in configured_ks_ndcg if k > rerank_top_k],
+                "recall": [k for k in configured_ks_recall if k > rerank_top_k],
+            },
+        },
         "metrics": {
             input_label: input_metrics,
             "rerank": rerank_metrics,
@@ -738,6 +793,10 @@ def main() -> None:
         payload["evaluation"] = {
             **trec_metric_contract(
                 rel_threshold=benchmark_spec.rel_threshold or 1,
+                ks_mrr=ks_mrr,
+                ks_ndcg=ks_ndcg,
+                ks_recall=ks_recall,
+                run_depth=rerank_top_k,
             ),
             "qrels_source": benchmark_spec.dataset_id,
             "internal_backend": "msmarco_genqa.evaluation.trec",

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -506,6 +506,10 @@ def main() -> None:
         payload["evaluation"] = {
             **trec_metric_contract(
                 rel_threshold=benchmark_spec.rel_threshold or 1,
+                ks_mrr=tuple(ks_mrr),
+                ks_ndcg=tuple(ks_ndcg),
+                ks_recall=tuple(ks_recall),
+                run_depth=top_k,
             ),
             "qrels_source": benchmark_spec.dataset_id,
             "internal_backend": "msmarco_genqa.evaluation.trec",

--- a/src/msmarco_genqa/evaluation/trec.py
+++ b/src/msmarco_genqa/evaluation/trec.py
@@ -198,23 +198,43 @@ def graded_ndcg_at_k(
     return dcg / idcg if idcg > 0 else 0.0
 
 
-def trec_metric_contract(*, rel_threshold: int) -> dict[str, Any]:
-    """Describe the graded and thresholded metric semantics saved with a run."""
+def trec_metric_contract(
+    *,
+    rel_threshold: int,
+    ks_mrr: tuple[int, ...] = (10,),
+    ks_ndcg: tuple[int, ...] = (10,),
+    ks_recall: tuple[int, ...] = (100, 1000),
+    run_depth: int | None = None,
+) -> dict[str, Any]:
+    """Describe the exact metric cutoffs and run depth saved with a run."""
     _validate_rel_threshold(rel_threshold)
-    return {
+    cutoffs = (*ks_mrr, *ks_ndcg, *ks_recall)
+    if any(k <= 0 for k in cutoffs):
+        raise ValueError("metric cutoffs must be positive integers")
+    if run_depth is not None and run_depth <= 0:
+        raise ValueError("run_depth must be a positive integer")
+
+    contract = {
         "topic_scope": "all_qrels_topics",
         "graded_metrics": {
-            "ndcg@10": {
+            f"ndcg@{k}": {
                 "gain": NDCG_GAIN_CONVENTION,
                 "discount": NDCG_DISCOUNT,
             }
+            for k in ks_ndcg
         },
         "binary_metrics": {
-            "names": ["mrr@10", "recall@100", "recall@1000"],
+            "names": [
+                *(f"mrr@{k}" for k in ks_mrr),
+                *(f"recall@{k}" for k in ks_recall),
+            ],
             "relevance_threshold": rel_threshold,
             "threshold_rule": f"relevance >= {rel_threshold}",
         },
     }
+    if run_depth is not None:
+        contract["run_depth"] = run_depth
+    return contract
 
 
 def evaluate_trec_retrieval(

--- a/tests/test_benchmark_dataset_selection.py
+++ b/tests/test_benchmark_dataset_selection.py
@@ -11,6 +11,7 @@ import pytest
 from experiments.run_reranker import (
     first_stage_label,
     load_upstream_benchmark_metadata,
+    metric_cutoffs_within_depth,
     parse_args as parse_reranker_args,
     resolve_input_run,
     resolve_output_dir as resolve_reranker_output_dir,
@@ -289,3 +290,13 @@ def test_upstream_corpus_scope_is_read_from_metrics(tmp_path):
         "dataset_id": "track",
         "corpus_scope": "first-N-truncated",
     }
+
+
+def test_reranker_metric_cutoffs_stop_at_candidate_depth():
+    assert metric_cutoffs_within_depth((100, 1000), run_depth=100) == (100,)
+    assert metric_cutoffs_within_depth((10,), run_depth=100) == (10,)
+
+
+def test_reranker_metric_cutoffs_reject_invalid_depth():
+    with pytest.raises(ValueError, match="run_depth"):
+        metric_cutoffs_within_depth((100,), run_depth=0)

--- a/tests/test_trec_cross_check.py
+++ b/tests/test_trec_cross_check.py
@@ -14,6 +14,7 @@ from msmarco_genqa.evaluation.trec import (
     compare_metric_sets,
     read_qrels,
     run_trec_cross_check,
+    trec_metric_contract,
 )
 
 
@@ -165,6 +166,21 @@ def test_graded_qrels_use_trec_ndcg_and_thresholded_binary_metrics(tmp_path):
         "q1\tQ0\td3\t2\t0.5\tmsmarco-genqa",
         "q1\tQ0\td1\t3\t0.333333333333\tmsmarco-genqa",
     ]
+
+
+def test_metric_contract_records_only_reported_cutoffs_and_run_depth():
+    contract = trec_metric_contract(
+        rel_threshold=1,
+        ks_mrr=(10,),
+        ks_ndcg=(10,),
+        ks_recall=(100,),
+        run_depth=100,
+    )
+
+    assert contract["run_depth"] == 100
+    assert contract["binary_metrics"]["names"] == ["mrr@10", "recall@100"]
+    assert "ndcg@10" in contract["graded_metrics"]
+    assert "recall@1000" not in contract["binary_metrics"]["names"]
 
 
 def test_metric_mismatch_fails_gate():


### PR DESCRIPTION
## Summary

- filter evaluation cutoffs to the actual reranker candidate depth;
- omit Recall@1000 from the default top-100 cross-encoder metrics;
- record the run depth, reported cutoffs, and omitted cutoffs in `metrics.json`;
- keep the graded metric contract aligned with the metrics that were actually computed; and
- document the BM25 top-1000 versus reranked top-100 reporting boundary.

## Why

A post-merge review of #166 found that the reranker evaluated only the fixed BM25 top-100 candidate set but still emitted a field named `recall@1000`. That value necessarily repeated Recall@100 and could be misread as a recall drop when compared with the full BM25 top-1000 run.

This change makes the artifact explicit: the default reranker reports MRR@10, nDCG@10, and Recall@100. Recall@1000 remains available for the full BM25 run and is `n/a (reranked top-100)` in result tables.

The scoring model, candidate set, and existing reportable benchmark values are unchanged.

## Validation

- 29 targeted tests passed;
- full fast suite: 565 passed, 5 skipped, 1 deselected by the repository's default markers;
- `ruff check .` passed;
- `git diff --check` passed; and
- the published Git tree matches the locally reviewed tree `216c9d786871c3480eecae944022b8c7ba0a6eab`.

## Benchmark boundary

This PR does not add or claim NFCorpus or SciFact results. #165 remains open until both complete BM25 and cross-encoder runs, manifests, independent metric cross-checks, and hardware/runtime notes are available. The stopped partial SciFact rerank is not evidence and will not be reported.

Follow-up to #166. Contributes to #165.