### PR TITLE
fix(repro): distinguish benchmark data fingerprints

### DIFF
--- a/experiments/run_reranker.py
+++ b/experiments/run_reranker.py
@@ -824,6 +824,10 @@ def main() -> None:
     resolved_config_hash = compute_resolved_config_hash(cfg)
     data_fingerprint = compute_data_fingerprint(
         cache_dir=cache_dir,
+        data_sources={
+            "dataset_id": benchmark_spec.dataset_id,
+            "corpus_id": benchmark_spec.corpus_id,
+        },
         extra_files={"input_run": input_run_path},
     )
     env_fingerprint = compute_env_fingerprint(env_dict)

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -523,6 +523,10 @@ def main() -> None:
     data_fingerprint = compute_data_fingerprint(
         cache_dir=cache_dir,
         corpus_limit=corpus_limit,
+        data_sources={
+            "dataset_id": benchmark_spec.dataset_id,
+            "corpus_id": benchmark_spec.corpus_id,
+        },
     )
     env_fingerprint = compute_env_fingerprint(env_dict)
 

--- a/src/msmarco_genqa/util/manifest.py
+++ b/src/msmarco_genqa/util/manifest.py
@@ -251,6 +251,7 @@ def compute_data_fingerprint(
     *,
     cache_dir: Path,
     corpus_limit: int | None = None,
+    data_sources: dict[str, str] | None = None,
     extra_files: dict[str, Path] | None = None,
 ) -> str:
     """Lean sha256 hex digest identifying the data inputs of a run.
@@ -259,6 +260,9 @@ def compute_data_fingerprint(
     - ``cache_dir`` as string. Anchors which ir_datasets cache served
       the corpus/queries/qrels for this run.
     - ``corpus_limit``: scalar, ``None`` for the full corpus.
+    - ``data_sources``: stable logical identifiers for the data loaded from
+      that cache, such as the ir_datasets dataset and corpus ids. A cache can
+      contain multiple datasets, so its path alone is not a data identity.
     - ``extra_files``: optional ``{label: Path}`` mapping for run-specific
       inputs that should be content-hashed — e.g. ``sample_doc_ids.json``
       for dense, ``input run.tsv`` for reranker/generation. Each
@@ -274,6 +278,8 @@ def compute_data_fingerprint(
         "cache_dir": str(cache_dir),
         "corpus_limit": corpus_limit,
     }
+    if data_sources:
+        parts["data_sources"] = dict(sorted(data_sources.items()))
     if extra_files:
         for label, raw_path in sorted(extra_files.items()):
             if raw_path is None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -832,6 +832,38 @@ def test_compute_data_fingerprint_sensitive_to_corpus_limit(tmp_path: Path):
     assert a != b
 
 
+def test_compute_data_fingerprint_sensitive_to_data_sources(tmp_path: Path):
+    """Datasets sharing one ir_datasets cache must not share a fingerprint."""
+    nfcorpus = compute_data_fingerprint(
+        cache_dir=tmp_path / "cache",
+        data_sources={
+            "dataset_id": "beir/nfcorpus/test",
+            "corpus_id": "beir/nfcorpus",
+        },
+    )
+    scifact = compute_data_fingerprint(
+        cache_dir=tmp_path / "cache",
+        data_sources={
+            "dataset_id": "beir/scifact/test",
+            "corpus_id": "beir/scifact",
+        },
+    )
+    assert nfcorpus != scifact
+
+
+def test_compute_data_fingerprint_data_source_order_stable(tmp_path: Path):
+    """Mapping insertion order must not affect the canonical fingerprint."""
+    dataset_first = compute_data_fingerprint(
+        cache_dir=tmp_path / "cache",
+        data_sources={"dataset_id": "dataset", "corpus_id": "corpus"},
+    )
+    corpus_first = compute_data_fingerprint(
+        cache_dir=tmp_path / "cache",
+        data_sources={"corpus_id": "corpus", "dataset_id": "dataset"},
+    )
+    assert dataset_first == corpus_first
+
+
 def test_compute_data_fingerprint_extra_files_change_hash(tmp_path: Path):
     """Changing the content of an extra file changes the fingerprint —
     so sample_doc_ids.json drift or input_run.tsv drift is caught."""


### PR DESCRIPTION
## Summary

- include benchmark dataset and corpus identifiers in run data fingerprints
- wire the identifiers through the full-corpus retrieval and reranking runners
- add regression coverage for cross-dataset separation and mapping-order stability

## Why

While checking the NFCorpus and SciFact result bundles for #165, I found that their BM25 manifests had the same `data_fingerprint`. The fingerprint included the shared cache path and corpus limit, but not the logical dataset loaded from that cache. That made distinct BEIR datasets indistinguishable at the fingerprint level even though the manifest metadata named them correctly.

The change is backward-compatible for callers that do not provide `data_sources`. Existing result values are not changed; this only strengthens provenance for new retrieval and reranking runs.

Related to #165.

## Validation

- `ruff check src/msmarco_genqa/util/manifest.py experiments/run_retrieval.py experiments/run_reranker.py tests/test_manifest.py`
- `pytest tests/test_manifest.py -q`: 84 passed
- related runner and reproduction tests: 37 passed
- full test suite: 567 passed, 5 skipped, 1 deselected

## Review notes

- The canonical hash remains order-stable because `data_sources` is sorted before serialization.
- Existing hashes remain unchanged when `data_sources` is omitted.
- Retrieval and reranking both use the benchmark selector's resolved dataset and corpus ids.
