### PR TITLE
build(deps): refresh security pins and lockfile provenance

### DIFF
--- a/artifacts/registry.json
+++ b/artifacts/registry.json
@@ -4,8 +4,8 @@
   "hash_convention": "sha256_lf normalizes CRLF and CR text newlines to LF before hashing",
   "current_lockfile": {
     "path": "requirements-lock.txt",
-    "sha256_lf": "cc0420bbd69869b353ad2a74e6e62b23370e2ecb5718ae333d8d6302b1497715",
-    "last_dependency_change_commit": "fe7077994b9a4eea643a7a1db51ae431a05b3c8e",
+    "sha256_lf": "663dcc7aad0ac5f89d8cdf5e7366b16bab10d997269a0dbd2d2cc055678c5fb5",
+    "last_dependency_change_commit": "13c6758455937f7bc6e0e0ae7529008da2096aea",
     "reproduction_note": "docs/lockfile_reproduction.md",
     "validation": [
       "python -m pip install --dry-run -r requirements-lock.txt",

--- a/artifacts/registry.json
+++ b/artifacts/registry.json
@@ -4,8 +4,8 @@
   "hash_convention": "sha256_lf normalizes CRLF and CR text newlines to LF before hashing",
   "current_lockfile": {
     "path": "requirements-lock.txt",
-    "sha256_lf": "663dcc7aad0ac5f89d8cdf5e7366b16bab10d997269a0dbd2d2cc055678c5fb5",
-    "last_dependency_change_commit": "13c6758455937f7bc6e0e0ae7529008da2096aea",
+    "sha256_lf": "3b381eb5b4b1024f3424a21e4b74071db6cda49300cad47ffa457e1a54cf7528",
+    "last_dependency_change_commit": "e05230fb79427f98113861df9a6d2fa3e6ff85cd",
     "reproduction_note": "docs/lockfile_reproduction.md",
     "validation": [
       "python -m pip install --dry-run -r requirements-lock.txt",

--- a/docs/lockfile_reproduction.md
+++ b/docs/lockfile_reproduction.md
@@ -30,8 +30,9 @@ needed.
 
 The current snapshot updates `torch` from 2.12.1 to 2.13.0 and `nltk` from
 3.9.4 to 3.10.0. The change removes the direct pins flagged for
-CVE-2025-3000 and CVE-2026-12243 during the repository security audit while
-keeping the rest of the model and evaluation stack fixed.
+CVE-2025-3000 and CVE-2026-12243 during the repository security audit. It also
+adds the previously omitted `bert-score==0.3.13` direct dependency to the
+pinned snapshot; the supported dependency range itself is unchanged.
 
 The two packages have different reproduction implications:
 

--- a/docs/lockfile_reproduction.md
+++ b/docs/lockfile_reproduction.md
@@ -26,6 +26,24 @@ needed.
 | Torch, Transformers, SentenceTransformers, tokenizer, or model revision | Above checks plus `scripts/smoke_model_stack.py`; rerun the affected headline experiment or open a linked follow-up before treating old and new results as comparable. |
 | Security remediation with forced transitive changes | Record the vulnerability and constrained package set, run the affected smoke/evaluation checks, and document any unavoidable reproduction boundary. |
 
+### Security refresh: 2026-07-21
+
+The current snapshot updates `torch` from 2.12.1 to 2.13.0 and `nltk` from
+3.9.4 to 3.10.0. The change removes the direct pins flagged for
+CVE-2025-3000 and CVE-2026-12243 during the repository security audit while
+keeping the rest of the model and evaluation stack fixed.
+
+The two packages have different reproduction implications:
+
+- the Torch update can affect model execution or numerical behavior, so the
+  model-stack smoke test is required before this snapshot is accepted;
+- NLTK is used here through `nltk.translate.bleu_score`, so the fixture metric
+  goldens and bootstrap scorer tests are the relevant regression boundary.
+
+This refresh does not rebaseline any published metric. Historical results stay
+attached to the lockfile snapshots recorded by their artifact-registry entries;
+new experiment manifests record the environment used for new runs.
+
 At minimum, run:
 
 ```bash

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -43,7 +43,7 @@ sentence-transformers==5.6.0
 faiss-cpu==1.14.3
 
 # --- Generation / reranking (transformers stack) ---
-torch==2.12.1
+torch==2.13.0
 transformers==5.12.1
 # Keep tokenizers on the latest stable 0.22.x pin accepted by the
 # transformers stack; 0.23.0 has no stable release.
@@ -55,7 +55,7 @@ safetensors==0.8.0
 evaluate==0.4.6
 rouge_score==0.1.2
 sacrebleu==2.6.0
-nltk==3.9.4
+nltk==3.10.0
 
 # --- Testing / lint ---
 pytest==9.1.1

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -56,6 +56,7 @@ evaluate==0.4.6
 rouge_score==0.1.2
 sacrebleu==2.6.0
 nltk==3.10.0
+bert-score==0.3.13
 
 # --- Testing / lint ---
 pytest==9.1.1


### PR DESCRIPTION
## Summary

- update `torch` from 2.12.1 to 2.13.0 and `nltk` from 3.9.4 to 3.10.0;
- add the previously omitted direct `bert-score==0.3.13` pin to the reproduction snapshot;
- update the canonical lockfile hash and last dependency-change commit in the artifact registry;
- document the security motivation and the boundary between the new environment and published historical results.

## Why

A repository security audit flagged the existing Torch and NLTK pins for CVE-2025-3000 and CVE-2026-12243. The individual Dependabot PRs (#147 and #150) changed only `requirements-lock.txt`, so the artifact-registry consistency check correctly rejected both of them: every lockfile change must update its normalized hash and reproduction note.

This PR integrates the two upgrades under that provenance contract. While validating the resulting environment, `pip check` also exposed that `bert-score` was declared as a runtime dependency but absent from the pinned direct-dependency snapshot, so the existing 0.3.13 compatibility floor is now recorded explicitly.

No published benchmark metric is rebaselined. Historical results remain attached to their recorded lockfile snapshots; new runs will carry the refreshed environment in their manifests.

## Validation

- `python -m pytest -q -p no:cacheprovider --basetemp <workspace-temp>`: 576 passed, 1 skipped, 1 deselected
- `python -m ruff check src tests experiments scripts`
- `python -m pip check`
- `pip-audit -r requirements-lock.txt --no-deps --disable-pip`: no known vulnerabilities
- `python scripts/check_headline_metrics.py`
- `python scripts/check_fixture_headline_metrics.py`
- `python scripts/check_artifact_registry.py`
- `python scripts/export_report_tables.py` followed by a clean generated-table diff
- `python scripts/check_secrets.py`
- `python scripts/smoke_model_stack.py --config configs/baseline.yaml --device cpu --max-new-tokens 4`: pinned T5 generation and MiniLM embedding smoke passed

Supersedes #147 and #150.