### PR TITLE
security(repo): establish the repository security baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 # Avoid duplicate PR workflows while preserving every main-branch run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
           cache: pip
@@ -94,10 +97,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@eec0bff2f6c15bf3f1e8a0152f94d17664a06a06 # v4
+        with:
+          languages: python
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@eec0bff2f6c15bf3f1e8a0152f94d17664a06a06 # v4
+        with:
+          category: "/language:python"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   high-confidence-secrets:
     name: High-confidence secret scan
@@ -12,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run secret scan
         run: python3 scripts/check_secrets.py

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI status](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/ci.yml?query=branch%3Amain)
 [![Secret scan](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/secret-scan.yml/badge.svg?branch=main)](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/secret-scan.yml?query=branch%3Amain)
+[![CodeQL](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/codeql.yml?query=branch%3Amain)
 [![Latest release](https://img.shields.io/github/v/release/GioiaZheng/msmarco-genqa?display_name=tag)](https://github.com/GioiaZheng/msmarco-genqa/releases/latest)
 [![Python](https://img.shields.io/badge/python-%E2%89%A53.10-3776AB?logo=python&logoColor=white)](https://github.com/GioiaZheng/msmarco-genqa/blob/main/pyproject.toml)
 [![License](https://img.shields.io/github/license/GioiaZheng/msmarco-genqa)](https://github.com/GioiaZheng/msmarco-genqa/blob/main/LICENSE)
@@ -158,8 +159,11 @@ auditing the experiments:
   requiring a hosted tracking service.
 - **Model serving.** `mgq-serve` exposes a lightweight FastAPI wrapper around
   the generator (`pip install -e ".[serve]"`), with `/health` and `/generate`
-  endpoints for local demos or integration tests. Validation failures are
-  returned as structured 422 payloads. See
+  endpoints for local demos or integration tests. It binds to `127.0.0.1` by
+  default and rejects non-loopback hosts unless `--allow-remote` is supplied.
+  The opt-in does not add authentication, TLS, or rate limiting, so place the
+  service behind appropriate controls rather than exposing it directly.
+  Validation failures are returned as structured 422 payloads. See
   `examples/demo_payload.json` for a minimal request body:
 
   ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,83 +1,67 @@
-# Security posture
+# Security policy
 
-This is a **single-user research CLI**: every entry point under
-`experiments/` and `scripts/` is invoked by a trusted operator, and
-there is no networked service, no web framework, no exposed port, and
-no multi-tenancy. The threat surface is correspondingly narrow.
+Last reviewed: 2026-07-21.
 
-Last audit: 2026-05-20.
+## Supported versions
 
-## What is in scope
+Security fixes are applied to the current `main` branch and included in the next
+release. Historical research releases remain immutable so their published
+artifacts and environments can still be reproduced; they do not receive
+backports.
 
-1. **Secrets / credential leakage.** API keys, HF tokens, AWS keys, or
-   private-key material in the source tree or git history.
-2. **Untrusted deserialization.** `pickle.load` / `torch.load` /
-   unsafe `yaml.load` against attacker-controllable bytes.
-3. **Subprocess injection.** `shell=True`, `os.system`, or
-   user-controlled strings concatenated into shell commands.
-4. **Path traversal.** User-controlled filesystem paths going into
-   `open()` without bounding.
-5. **SSRF.** Outbound HTTP requests where the URL is derived from
-   user input.
+## Reporting a vulnerability
 
-## What is out of scope (and why)
+Please report suspected vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/GioiaZheng/msmarco-genqa/security/advisories/new).
+Include the affected entry point, reproduction steps, expected impact, and any
+suggested mitigation. Do not open a public issue for an unpatched vulnerability
+or include live credentials, private data, or exploit payloads in a report.
 
-- **CSRF and security response headers.** Not applicable: the repo
-  ships no HTTP server, no web framework, no cookies / sessions, no
-  cross-origin endpoints. No browser ever loads anything this repo
-  produces.
-- **Multi-user authorization.** Single-operator CLI by construction.
+General hardening suggestions that do not disclose a vulnerability may use the
+normal issue tracker.
 
-## Audit results — 2026-05-20
+## Security boundary
 
-| Axis | Result | Notes |
-|---|---|---|
-| Secrets in source | ✅ clean | `grep -rEn 'HF_TOKEN\|OPENAI_API_KEY\|AWS_SECRET\|sk-[A-Za-z0-9]{20,}\|hf_[A-Za-z0-9]{20,}\|BEGIN.*PRIVATE KEY'` over the tracked source paths (`src`, `tests`, `experiments`, `scripts`, `configs`, `README.md`, `pyproject.toml`, `requirements*.txt`) returns nothing. |
-| `.env` / credential files | ✅ none | No `.env`, no `*.pem`, no `*.key`, no `credentials*`, no `secrets*` anywhere outside `.git/`, `outputs/`, `data/`, and the local-scratch directory. |
-| Secrets in git history | ✅ clean | `git log --all -p` over the source paths above returns no plaintext-key matches. |
-| `pickle.load` / `torch.load` | ✅ none in source | Zero direct calls. PyTorch is invoked via `transformers` / `sentence_transformers`, which fetch model weights from the HF Hub (trusted registry) — see *Outbound network surface* below. |
-| `yaml.load` (unsafe) | ✅ none | All five YAML loads in the project use `yaml.safe_load` against `configs/baseline.yaml`. |
-| `subprocess` with `shell=True` | ✅ none | All `subprocess` call sites pass argv lists, not shell strings. Sites: `src/msmarco_genqa/util/manifest.py` (`git rev-parse`, `git status`), `src/msmarco_genqa/util/environment.py` (`git rev-parse`), `tests/test_sampling.py` (test fixtures), `scripts/run_full_generation_and_analysis.py` (driver subprocess). All commands are fixed strings + Path values, not user-string-interpolated. |
-| Path-into-`open()` | ✅ bounded | Every entry point uses `argparse` with `type=Path`; downstream `open()` calls receive these paths unchanged. There is no web-form path input. For a single-user CLI this is the expected pattern. |
-| SSRF | ✅ none | Zero `requests.get` / `urllib.request.urlopen` / `httpx` calls in source. The only outbound traffic is library-internal (see below); URLs are not user-controlled. |
+This repository is a research pipeline operated by a trusted user. Its primary
+entry points are local CLI commands that process operator-selected datasets,
+models, configurations, and filesystem paths. The project does not provide
+multi-user isolation or sandbox arbitrary model and dataset artifacts.
 
-## Outbound network surface (audited explicitly)
+The optional `mgq-serve` FastAPI wrapper is intended for local demos and
+integration tests. It binds to `127.0.0.1` by default and rejects non-loopback
+hosts unless the operator explicitly passes `--allow-remote`. That override does
+not add authentication, TLS, authorization, request quotas, or rate limiting;
+deployments outside a trusted host must supply those controls separately.
 
-The repo makes outbound HTTP calls only through library internals,
-never through hand-written code:
+## External artifacts and network access
 
-1. **HuggingFace Hub** — pulled by `transformers` / `sentence_transformers`
-   / `bert_score` for model weights. Targets are fixed registry URLs
-   (`huggingface.co/<org>/<model>`); model ids are baked into
-   `configs/baseline.yaml` or set as CLI defaults
-   (`distilbert-base-uncased`, `sentence-transformers/all-MiniLM-L6-v2`,
-   `cross-encoder/ms-marco-MiniLM-L-6-v2`, `cross-encoder/nli-deberta-v3-small`,
-   `t5-small`). A `--model` / `--nli-model` flag *can* override the id;
-   in the single-operator threat model this is benign (the operator
-   chooses what to download).
-2. **ir_datasets** — pulled for the MS MARCO Passage corpus + qrels.
-   URLs are fixed inside `ir_datasets`; cache lives under
-   `data/raw/`, gitignored.
+- Hugging Face libraries download model and metric artifacts selected by the
+  configuration or CLI. Use pinned model revisions for controlled experiments.
+- `ir_datasets` and dataset loaders retrieve benchmark corpora and judgments
+  from their configured upstream sources.
+- Release-reproduction commands download repository-owned result bundles and
+  verify the archive and member hashes before consuming them.
 
-Both libraries cache their downloads, so the runtime network surface
-collapses to zero after the first invocation.
+Treat model weights, datasets, run files, JSONL inputs, and archives from
+untrusted sources as untrusted data. Run third-party artifacts in an isolated
+environment when their provenance is uncertain.
 
-## Gitignored sensitive paths
+## Repository controls
 
-Per the project's local operating contract, the following directories
-never enter git regardless of how `git add` is invoked:
+- GitHub secret scanning and push protection cover repository history and
+  incoming pushes.
+- A repository-local high-confidence scanner checks tracked text files in CI.
+- CodeQL analyzes Python changes and the default branch.
+- GitHub Actions are pinned to full commit SHAs and receive read-only repository
+  contents by default.
+- Dependency updates are proposed by Dependabot. The direct-dependency snapshot
+  is audited during security reviews and checked against the artifact registry.
 
-- The local-scratch directory (operator workspace)
-- `outputs/` (experiment artifacts)
-- `data/raw/`, `data/processed/`, `data/cache/` (datasets, indexes,
-  caches)
-- `*.jsonl` transcripts under any local-scratch subdirectory
+## Known limitations
 
-This is enforced both by the project `.gitignore` and by operator
-convention.
-
-## How to report a problem
-
-This repo has no public deployment, no users, and no security contact.
-If you believe you have found a real security issue in the code, open
-a GitHub issue.
+- `requirements-lock.txt` pins direct dependencies but is not a fully resolved,
+  hash-locked transitive environment. Use isolated environments and review
+  resolver output for sensitive deployments.
+- Downloaded models and datasets inherit the trust and availability properties
+  of their upstream registries.
+- The local FastAPI wrapper is not a production-ready public API.

--- a/docs/input_validation.md
+++ b/docs/input_validation.md
@@ -60,5 +60,10 @@ payload:
 }
 ```
 
-This keeps production-facing errors explicit while preserving the research
-pipeline's deterministic batch behavior.
+This keeps service errors explicit while preserving the research pipeline's
+deterministic batch behavior.
+
+`mgq-serve` binds to `127.0.0.1` by default. A non-loopback `--host` is rejected
+unless the operator also passes `--allow-remote`. That flag is an explicit risk
+acknowledgement, not a production-security mode: the service does not implement
+authentication, TLS, or rate limiting.

--- a/scripts/check_secrets.py
+++ b/scripts/check_secrets.py
@@ -51,22 +51,54 @@ SKIP_EXTENSIONS = {
     ".zip",
 }
 
-ALLOWLIST_HINTS = re.compile(
-    r"(dummy|example|fake|placeholder|redacted|sample|test[-_ ]?only|"
-    r"your[-_ ]?(api[-_ ]?)?(key|secret|token)|xxxxx|<[^>]+>)",
-    re.IGNORECASE,
-)
-
 PATTERNS = [
     ("private key block", re.compile(r"-----BEGIN(?: [A-Z]+)? PRIVATE KEY-----")),
-    ("GitHub token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36}\b")),
+    ("GitHub token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,255}\b")),
     ("GitHub fine-grained token", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{80,}\b")),
+    ("Hugging Face token", re.compile(r"\bhf_[A-Za-z0-9]{30,}\b")),
     ("AWS access key", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
     ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b")),
     ("Slack token", re.compile(r"\bxox[baprs]-[0-9A-Za-z-]{20,}\b")),
     ("Stripe live secret key", re.compile(r"\bsk_live_[0-9A-Za-z]{24,}\b")),
-    ("sk-prefixed API key", re.compile(r"\bsk-[A-Za-z0-9]{48,}\b")),
+    (
+        "sk-prefixed API key",
+        re.compile(r"\bsk-(?:(?:proj|svcacct)-)?[A-Za-z0-9_-]{32,}\b"),
+    ),
 ]
+
+
+def is_placeholder(candidate: str) -> bool:
+    """Return whether the matched credential-shaped value is visibly inert.
+
+    Only an all-``x`` or all-zero payload is accepted. The decision is scoped
+    to the match itself, so prose such as ``sample`` elsewhere on the line
+    cannot suppress a real credential.
+    """
+
+    value = candidate.casefold()
+    prefixes = (
+        "github_pat_",
+        "sk-svcacct-",
+        "sk-proj-",
+        "sk_live_",
+        "ghp_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+        "hf_",
+        "xoxb-",
+        "xoxa-",
+        "xoxp-",
+        "xoxr-",
+        "xoxs-",
+        "akia",
+        "asia",
+        "aiza",
+        "sk-",
+    )
+    payload = next((value[len(prefix) :] for prefix in prefixes if value.startswith(prefix)), "")
+    return bool(payload and re.fullmatch(r"[x0_-]{8,}", payload))
 
 
 def tracked_files() -> list[Path]:
@@ -97,10 +129,8 @@ def scan_file(path: Path) -> list[tuple[int, str]]:
 
     findings: list[tuple[int, str]] = []
     for line_no, line in enumerate(data.decode("utf-8", errors="replace").splitlines(), 1):
-        if ALLOWLIST_HINTS.search(line):
-            continue
         for label, pattern in PATTERNS:
-            if pattern.search(line):
+            if any(not is_placeholder(match.group(0)) for match in pattern.finditer(line)):
                 findings.append((line_no, label))
     return findings
 

--- a/src/msmarco_genqa/service/app.py
+++ b/src/msmarco_genqa/service/app.py
@@ -8,6 +8,7 @@ FastAPI. Install the `serve` extra and run `mgq-serve` to expose `/health` and
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -93,6 +94,30 @@ def build_generator_from_env() -> RAGGenerator:
     )
 
 
+def is_loopback_host(host: str) -> bool:
+    """Return whether *host* is an explicit local-only bind target."""
+
+    normalized = host.strip()
+    if normalized.casefold().rstrip(".") == "localhost":
+        return True
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_bind_host(host: str, *, allow_remote: bool) -> None:
+    """Reject accidental network exposure unless the operator opts in."""
+
+    if not allow_remote and not is_loopback_host(host):
+        raise ValueError(
+            "refusing to bind to a non-loopback host without --allow-remote; "
+            "the demo service has no authentication, TLS, or rate limiting"
+        )
+
+
 def create_app(generator: object | None = None):
     try:
         from fastapi import FastAPI
@@ -136,7 +161,19 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Serve the RAG generator over FastAPI.")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help=(
+            "allow a non-loopback bind; the demo service has no authentication, "
+            "TLS, or rate limiting"
+        ),
+    )
     args = parser.parse_args()
+    try:
+        validate_bind_host(args.host, allow_remote=args.allow_remote)
+    except ValueError as exc:
+        parser.error(str(exc))
     try:
         import uvicorn
     except ImportError as exc:

--- a/tests/test_check_secrets.py
+++ b/tests/test_check_secrets.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from scripts.check_secrets import scan_file
+
+
+def _scan(tmp_path, text: str):
+    path = tmp_path / "candidate.txt"
+    path.write_text(text, encoding="utf-8")
+    return scan_file(path)
+
+
+def test_line_level_hint_does_not_hide_a_credential(tmp_path):
+    token = "hf_" + "A1b2" * 9
+    assert _scan(tmp_path, f"sample output accidentally included {token}\n") == [
+        (1, "Hugging Face token")
+    ]
+
+
+def test_credential_shaped_placeholder_is_allowed(tmp_path):
+    placeholder = "hf_" + "x" * 36
+    assert _scan(tmp_path, f"HF_TOKEN={placeholder}\n") == []
+
+
+def test_modern_openai_token_shape_is_detected(tmp_path):
+    token = "sk-" + "proj-" + "A1b2" * 10
+    assert _scan(tmp_path, f"OPENAI_API_KEY={token}\n") == [(1, "sk-prefixed API key")]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,7 +4,13 @@ import json
 
 import pytest
 
-from msmarco_genqa.service.app import GenerationService, create_app, load_passages_jsonl
+from msmarco_genqa.service.app import (
+    GenerationService,
+    create_app,
+    is_loopback_host,
+    load_passages_jsonl,
+    validate_bind_host,
+)
 from msmarco_genqa.util.input_validation import InputValidationError
 
 
@@ -90,3 +96,17 @@ def test_generate_endpoint_returns_structured_validation_error():
         "message": "must not be empty",
         "field": "query",
     }
+
+
+@pytest.mark.parametrize("host", ["localhost", "localhost.", "127.0.0.1", "127.4.3.2", "::1"])
+def test_loopback_hosts_are_recognized(host):
+    assert is_loopback_host(host)
+    validate_bind_host(host, allow_remote=False)
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.168.1.20", "service.internal"])
+def test_remote_bind_requires_explicit_opt_in(host):
+    assert not is_loopback_host(host)
+    with pytest.raises(ValueError, match="--allow-remote"):
+        validate_bind_host(host, allow_remote=False)
+    validate_bind_host(host, allow_remote=True)


### PR DESCRIPTION
## Summary

- pin every third-party GitHub Action to a verified full commit SHA and give workflows read-only repository contents by default;
- add a weekly and pull-request CodeQL analysis for Python;
- harden the repository secret scanner so a word such as `sample` elsewhere on a line cannot suppress a real credential, and cover Hugging Face plus current `sk-proj` token shapes;
- keep `mgq-serve` local by default and require an explicit `--allow-remote` acknowledgement for non-loopback binds;
- replace the stale security posture with an accurate reporting policy, service boundary, external-artifact model, and known limitations;
- add a CodeQL status badge alongside the existing CI and secret-scan badges.

## Why

The previous security document predated the FastAPI wrapper and still stated that the repository had no HTTP service. The service was safe by default because it bound to `127.0.0.1`, but an operator could expose it with `--host 0.0.0.0` without acknowledging that it has no authentication, TLS, or rate limiting.

The audit also found mutable Action tags, no CodeQL workflow, and a broad line-level allowlist in the custom secret scanner. For example, a valid token on a line containing the word `sample` would have been skipped. This change fixes those concrete boundaries without changing the retrieval, reranking, generation, evaluation, or published-result paths.

The Action SHAs were resolved directly from the official repositories before being recorded:

- `actions/checkout@v7`: `3d3c42e5aac5ba805825da76410c181273ba90b1`
- `actions/setup-python@v6`: `ece7cb06caefa5fff74198d8649806c4678c61a1`
- `github/codeql-action@v4`: `eec0bff2f6c15bf3f1e8a0152f94d17664a06a06`

## Impact and boundaries

The CLI and benchmark results are unchanged. Existing local serving commands continue to work with the default host, `localhost`, IPv4 loopback, and IPv6 loopback. A non-loopback host now requires `--allow-remote`; the flag is a risk acknowledgement and does not claim to make the demo service production-ready.

`requirements-lock.txt` remains a direct-dependency snapshot rather than a transitive hash-locked environment. That limitation is documented rather than obscured.

## Validation

- `python -m pytest -q -p no:cacheprovider --basetemp <workspace-temp>`: 588 passed, 1 skipped, 1 deselected
- `python -m ruff check src tests experiments scripts`
- `python scripts/check_secrets.py`
- `python scripts/check_headline_metrics.py`
- `python scripts/check_fixture_headline_metrics.py`
- `python scripts/check_artifact_registry.py --git-executable <git>`: including Git history checks
- `python scripts/export_report_tables.py` followed by a clean generated-table diff
- `mgq-serve --host 0.0.0.0`: rejected before model loading with exit code 2
- all workflow YAML parsed successfully

## Review focus

Please check the remote-bind guard, the match-scoped placeholder logic in the secret scanner, the explicit workflow permissions, and the first real CodeQL run on this PR.