### PR TITLE
docs(repro): add cross-platform evidence commands

### DIFF
--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -118,6 +118,13 @@ The fast external-evidence target is:
 make reproduce-trec-eval
 ```
 
+On Windows or other environments without `make`, run the equivalent Python
+entry point directly:
+
+```bash
+python -m msmarco_genqa.cli.trec_release reproduce
+```
+
 It downloads the pinned GitHub Release asset, verifies the ZIP size and
 SHA-256 digest, validates every member against the bundle manifest, and
 recomputes the BM25 and BM25-plus-cross-encoder metrics for TREC-DL 2019 and
@@ -143,6 +150,12 @@ The corresponding cross-domain evidence target is:
 
 ```bash
 make reproduce-beir-eval
+```
+
+The equivalent direct Python command is:
+
+```bash
+python -m msmarco_genqa.cli.beir_release reproduce
 ```
 
 It downloads the immutable NFCorpus/SciFact release asset, checks the pinned


### PR DESCRIPTION
## Summary

- document the direct Python entry point for reproducing the published TREC-DL evidence
- document the corresponding direct Python entry point for the NFCorpus/SciFact evidence
- keep the existing Make targets as the primary shorthand

## Why

The reproduction guide previously showed only `make` targets. Windows does not provide `make` by default, even though the underlying release-verification commands are already cross-platform. Listing the equivalent Python entry points removes that avoidable setup friction without changing the evaluation code, published artifacts, or reported results.

## Validation

- `git diff --check`
- `python scripts/check_secrets.py`
- tested both documented Python entry points from a clean clone
  - TREC-DL: all four published rows reproduced with maximum absolute delta `0.0`
  - NFCorpus/SciFact: all four published rows reproduced with maximum absolute delta `0.0`