### PR TITLE
Analyze NFCorpus first-stage coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts check-registry export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline reproduce-trec-eval build-trec-release reproduce-beir-eval build-beir-release
+.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts check-registry export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline reproduce-trec-eval build-trec-release reproduce-beir-eval build-beir-release analyze-nfcorpus-first-stage
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -34,6 +34,7 @@ help:
 	@echo "  make build-trec-release   -- build the maintainer release ZIP from canonical runs"
 	@echo "  make reproduce-beir-eval  -- fetch + verify published BEIR runs and metrics"
 	@echo "  make build-beir-release   -- build the maintainer BEIR release ZIP"
+	@echo "  make analyze-nfcorpus-first-stage -- reproduce inputs + diagnose BM25 coverage"
 
 # ----------------------------------------------------------------------------- #
 # Install
@@ -159,9 +160,15 @@ build-trec-release:
 # identifiers and scores; public NFCorpus/SciFact qrels are recovered through
 # ir_datasets before the four result rows are recomputed.
 reproduce-beir-eval:
-	$(PYTHON) -m msmarco_genqa.cli.beir_release reproduce
+	$(PYTHON) -m msmarco_genqa.cli.beir_release reproduce --cache-dir outputs/reproductions/beir_irds_cache
 
 # Maintainer-only packaging target. The generated ZIP stays under ignored
 # outputs/ and is published only after its exact size and SHA-256 are pinned.
 build-beir-release:
 	$(PYTHON) -m msmarco_genqa.cli.beir_release build --output outputs/releases/beir-cross-domain-baselines-v1.zip
+
+# Query-level diagnosis over the immutable NFCorpus BM25 run. The dependency
+# materializes and verifies the public release, qrels, and source archive; this
+# target does not rebuild the index, rerun retrieval, or invoke the reranker.
+analyze-nfcorpus-first-stage: reproduce-beir-eval
+	$(PYTHON) scripts/analyze_nfcorpus_first_stage.py

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The repository includes runnable code plus written analysis artifacts:
 - [`docs/failure_taxonomy.md`](docs/failure_taxonomy.md) — regression and grounding error taxonomy.
 - [`docs/retrieval_quality_reporting.md`](docs/retrieval_quality_reporting.md) — run-level retrieval metrics and matched-qid comparison reports.
 - [`docs/retrieval_lift_analysis.md`](docs/retrieval_lift_analysis.md) — query-level reranker lift analysis protocol.
+- [`docs/nfcorpus_first_stage_error_analysis.md`](docs/nfcorpus_first_stage_error_analysis.md) — fixed-output NFCorpus candidate-set coverage diagnosis.
 - [`docs/context_packing.md`](docs/context_packing.md) — prompt compression, provenance, and packed-vs-plain generation comparison.
 - [`docs/rag_triad_evaluation.md`](docs/rag_triad_evaluation.md) — context relevance, groundedness, and answer relevance report protocol.
 - [`docs/input_validation.md`](docs/input_validation.md) — run-file, JSONL, prompt, and serving input validation contract.
@@ -641,7 +642,10 @@ Here `n/a` means the reranked run has depth 100; reporting it as Recall@1000
 would be misleading. The fixed candidate set also explains the unchanged
 Recall@100. The cross-encoder improves early ranking on both collections, while
 the low NFCorpus Recall@100 identifies the first-stage retriever as the larger
-remaining bottleneck there.
+remaining bottleneck there. The fixed-output follow-up finds that 72/323
+NFCorpus queries have no relevant document in the BM25 top-100 candidate set;
+see
+[`docs/nfcorpus_first_stage_error_analysis.md`](docs/nfcorpus_first_stage_error_analysis.md).
 
 The four ranked runs are published as a checksummed, text-only
 [GitHub Release bundle](https://github.com/GioiaZheng/msmarco-genqa/releases/tag/v2.2-beir-cross-domain-baselines).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -126,6 +126,26 @@ These results show that the ranking benefit transfers to two non-MS-MARCO
 retrieval collections. They do not establish broad cross-domain RAG
 generalization or downstream generation quality.
 
+### NFCorpus first-stage coverage diagnostic
+
+Query-level analysis of the fixed NFCorpus BM25 run separates candidate-set
+absence from partial coverage:
+
+| Diagnostic | Queries | Share |
+|---|---:|---:|
+| At least one relevant document in BM25 top 100 | 251 | 77.7% |
+| No relevant document in BM25 top 100 | 72 | 22.3% |
+| First relevant hit only at ranks 101-1000 | 24 | 7.4% |
+| No relevant hit at depth 1000 | 48 | 14.9% |
+| Complete relevant-document coverage at 100 | 19 | 5.9% |
+
+Extending the same BM25 output from depth 100 to 1000 increases macro Recall
+from 0.2378 to 0.4572 and finds 3,616 additional positive qrels across 200
+queries. It still leaves 6,753 of 12,334 positive qrels unretrieved. The
+definitions, exact reconciliation, limitations, and reproduction command are
+in
+[`docs/nfcorpus_first_stage_error_analysis.md`](docs/nfcorpus_first_stage_error_analysis.md).
+
 ## Query-Type Slice
 
 Token-F1 lift by query type:

--- a/configs/nfcorpus_first_stage_contract.json
+++ b/configs/nfcorpus_first_stage_contract.json
@@ -1,0 +1,62 @@
+{
+  "schema": "msmarco-genqa.retrieval-data-metric-contract.v1",
+  "dataset_id": "beir/nfcorpus/test",
+  "analysis_base_commit": "19a9b071044fd1d436fbbe7f39c6cdcaf78ab16c",
+  "experiment_commit": "e276d80fb4da",
+  "release": {
+    "pointer_path": "artifacts/beir_cross_domain_v1.json",
+    "repository": "GioiaZheng/msmarco-genqa",
+    "tag": "v2.2-beir-cross-domain-baselines",
+    "asset": "beir-cross-domain-baselines-v1.zip"
+  },
+  "inputs": {
+    "release_asset": {
+      "path": "outputs/releases/beir-cross-domain-baselines-v1.zip",
+      "bytes": 6006875,
+      "sha256": "15e8e4ded1fe8d889e24a31f7794988ce0bbb6750c5f9b10e1d7dd4b38a5f633"
+    },
+    "source_archive": {
+      "path": "outputs/reproductions/beir_irds_cache/beir/nfcorpus/source.zip",
+      "bytes": 2448432,
+      "sha256": "efe5be03f8c5b86a5870102d0599d227c8c6e2484328e68c6522560385671b0b",
+      "query_member": "nfcorpus/queries.jsonl",
+      "corpus_member": "nfcorpus/corpus.jsonl"
+    },
+    "qrels": {
+      "path": "outputs/reproductions/beir_local_qrels/nfcorpus.qrels",
+      "bytes": 279549,
+      "sha256": "885574a3151a88679251b41919fa75e9db445b0f154728e2574e7039d3606b68"
+    },
+    "bm25_run": {
+      "path": "outputs/beir_nfcorpus_test/bm25/run.tsv",
+      "bytes": 13422823,
+      "sha256": "4ad5eaa880db0d1fa4f1c9e34370d71e861ec2a0e4b88b3738918de1e273f30a",
+      "query_count": 323,
+      "row_count": 323000,
+      "depth": 1000
+    },
+    "ce_run": {
+      "path": "outputs/beir_nfcorpus_test/cross_encoder_rerank/run.tsv",
+      "bytes": 1774037,
+      "sha256": "0ba549fa223b9af485a77f86dee580e66468867e8da32229936c2979e3e68158",
+      "query_count": 323,
+      "row_count": 32300,
+      "depth": 100
+    }
+  },
+  "expected_counts": {
+    "source_queries": 3237,
+    "corpus_documents": 3633,
+    "test_queries": 323,
+    "qrels_judgments": 12334
+  },
+  "qrels_format": "three-column",
+  "binary_relevance_threshold": 1,
+  "expected_bm25_metrics": {
+    "mrr@10": 0.5186041083099907,
+    "ndcg@10": 0.30640715529625967,
+    "recall@100": 0.23775575921008424,
+    "recall@1000": 0.4572325663968621
+  },
+  "metric_tolerance": 1e-12
+}

--- a/configs/nfcorpus_first_stage_contract.json
+++ b/configs/nfcorpus_first_stage_contract.json
@@ -11,7 +11,7 @@
   },
   "inputs": {
     "release_asset": {
-      "path": "outputs/releases/beir-cross-domain-baselines-v1.zip",
+      "path": "outputs/reproductions/beir_cross_domain_v1/beir-cross-domain-baselines-v1.zip",
       "bytes": 6006875,
       "sha256": "15e8e4ded1fe8d889e24a31f7794988ce0bbb6750c5f9b10e1d7dd4b38a5f633"
     },
@@ -23,12 +23,12 @@
       "corpus_member": "nfcorpus/corpus.jsonl"
     },
     "qrels": {
-      "path": "outputs/reproductions/beir_local_qrels/nfcorpus.qrels",
-      "bytes": 279549,
-      "sha256": "885574a3151a88679251b41919fa75e9db445b0f154728e2574e7039d3606b68"
+      "path": "outputs/reproductions/beir_irds_cache/beir/nfcorpus/test.qrels",
+      "bytes": 279572,
+      "sha256": "f8fba6ef3d4dd9c3a242a8ba4ae38276fc3622fce7dcbae764766d564542fd2a"
     },
     "bm25_run": {
-      "path": "outputs/beir_nfcorpus_test/bm25/run.tsv",
+      "path": "outputs/reproductions/beir_cross_domain_v1/bundle/runs/beir_nfcorpus_bm25.tsv",
       "bytes": 13422823,
       "sha256": "4ad5eaa880db0d1fa4f1c9e34370d71e861ec2a0e4b88b3738918de1e273f30a",
       "query_count": 323,
@@ -36,7 +36,7 @@
       "depth": 1000
     },
     "ce_run": {
-      "path": "outputs/beir_nfcorpus_test/cross_encoder_rerank/run.tsv",
+      "path": "outputs/reproductions/beir_cross_domain_v1/bundle/runs/beir_nfcorpus_bm25_ce.tsv",
       "bytes": 1774037,
       "sha256": "0ba549fa223b9af485a77f86dee580e66468867e8da32229936c2979e3e68158",
       "query_count": 323,
@@ -57,6 +57,27 @@
     "ndcg@10": 0.30640715529625967,
     "recall@100": 0.23775575921008424,
     "recall@1000": 0.4572325663968621
+  },
+  "expected_first_stage_diagnostics": {
+    "n_queries": 323,
+    "n_positive_qrels": 12334,
+    "first_hit_bucket_counts": {
+      "top_10": 218,
+      "ranks_11_100": 33,
+      "ranks_101_1000": 24,
+      "miss_top_1000": 48
+    },
+    "coverage_at_100_bucket_counts": {
+      "none": 72,
+      "partial_lt_25pct": 145,
+      "partial_25_to_lt_50pct": 51,
+      "partial_50_to_lt_100pct": 36,
+      "complete": 19
+    },
+    "positive_qrels_in_top_100": 1965,
+    "positive_qrels_in_top_1000": 5581,
+    "queries_gaining_relevant_documents_101_1000": 200,
+    "positive_qrels_missing_at_1000": 6753
   },
   "metric_tolerance": 1e-12
 }

--- a/docs/cross_domain_benchmarks.md
+++ b/docs/cross_domain_benchmarks.md
@@ -183,5 +183,8 @@ generalizes across domains, because neither dataset was run through generation
 or grounded-answer evaluation. They also do not establish state of the art or
 replace a broader benchmark suite.
 
-The next evidence-driven step is first-stage retrieval analysis on NFCorpus,
-where Recall@100 leaves most relevant documents outside the reranker's reach.
+The follow-up first-stage analysis is now recorded in
+[`nfcorpus_first_stage_error_analysis.md`](nfcorpus_first_stage_error_analysis.md).
+It uses the published fixed BM25 output and finds that 72/323 queries have no
+relevant document in the top-100 candidate set; 24 of those first obtain a
+relevant hit at ranks 101-1000, while 48 remain misses at depth 1000.

--- a/docs/nfcorpus_first_stage_error_analysis.md
+++ b/docs/nfcorpus_first_stage_error_analysis.md
@@ -1,0 +1,155 @@
+# NFCorpus First-Stage Coverage: Query-Level Diagnostic
+
+## Technical summary
+
+The fixed NFCorpus BM25 top-100 candidate set contains at least one
+qrels-relevant document for **251 of 323 queries (77.7%)**. The remaining
+**72 queries (22.3%)** give the cross-encoder no relevant candidate to rank.
+Under the current qrels, this is a hard candidate-set limit: reranker changes
+cannot recover a judged relevant document for those queries without changing
+first-stage membership.
+
+The limitation is broader than the 72 complete misses. Among all queries,
+**232 (71.8%)** have only partial relevant-document coverage at depth 100, and
+only **19 (5.9%)** have complete coverage. Extending the same BM25 run from
+depth 100 to 1000 raises macro Recall from **0.2378 to 0.4572**, finding 3,616
+additional positive qrels across 200 queries. Even at depth 1000, 48 queries
+have no relevant hit and 6,753 of 12,334 positive qrels remain unretrieved.
+
+These are descriptive results for one frozen BM25 run. They establish where
+the current candidate-set ceiling occurs; they do not yet identify the
+semantic cause of each miss or evaluate a replacement retriever.
+
+## The failure is both query-level absence and incomplete coverage
+
+The first relevant hit separates queries by whether a fixed top-100 reranker
+can reach any relevant document:
+
+| First relevant BM25 hit | Queries | Share | Interpretation |
+|---|---:|---:|---|
+| Rank 1-10 | 218 | 67.5% | A relevant document is already inside the headline rank window. |
+| Rank 11-100 | 33 | 10.2% | A relevant document is reachable by the fixed top-100 reranker. |
+| Rank 101-1000 | 24 | 7.4% | BM25 finds a relevant document, but outside the reranker candidate set. |
+| No hit in top 1000 | 48 | 14.9% | Deeper BM25 retrieval still does not find a relevant document. |
+
+The relevant-document coverage view shows why a binary “any hit” diagnostic is
+not sufficient for NFCorpus, where one query may have many positive qrels:
+
+| Recall@100 bucket | Queries | Share |
+|---|---:|---:|
+| 0 | 72 | 22.3% |
+| Greater than 0 and below 0.25 | 145 | 44.9% |
+| 0.25 to below 0.50 | 51 | 15.8% |
+| 0.50 to below 1 | 36 | 11.1% |
+| 1 | 19 | 5.9% |
+
+The two partitions reconcile exactly to all 323 queries. In particular, the
+24 first hits at ranks 101-1000 plus the 48 top-1000 misses equal the 72
+queries with Recall@100 equal to zero.
+
+## Going deeper helps, but does not remove the bottleneck
+
+| Diagnostic | Depth 100 | Depth 1000 | Change |
+|---|---:|---:|---:|
+| Macro Recall | 0.2378 | 0.4572 | +0.2195 |
+| Micro positive-qrel coverage | 0.1593 | 0.4525 | +0.2932 |
+| Positive qrels retrieved | 1,965 | 5,581 | +3,616 |
+
+Macro Recall gives every query equal weight and remains the benchmark
+headline definition. Micro coverage weights queries by their number of
+positive qrels and is reported only as a diagnostic decomposition. The
+difference between the two is expected because NFCorpus has between 1 and 475
+positive qrels per query (median 16, mean 38.19).
+
+Ranks 101-1000 add at least one relevant document for 200 queries. This shows
+that a deeper candidate pool contains useful evidence for many queries, but
+it is not itself an end-to-end result: reranking 1,000 candidates would change
+runtime and would require a separate controlled experiment.
+
+## Scope and metric definitions
+
+- Dataset: `beir/nfcorpus/test`.
+- Population: all 323 test queries with positive qrels.
+- Relevance rule: `rel >= 1`.
+- First-stage run: the immutable BM25 depth-1000 output published in
+  `v2.2-beir-cross-domain-baselines`.
+- Reranker reachability cutoff: BM25 top 100.
+- First-hit buckets: ranks 1-10, 11-100, 101-1000, or no hit at depth 1000.
+- Coverage buckets: Recall@100 equal to 0; partial intervals
+  `(0, 0.25)`, `[0.25, 0.50)`, `[0.50, 1)`; or complete coverage at 1.
+
+The underlying data and metric contract fixes the input byte sizes and
+SHA-256 digests, requires exact qid/docid correspondence, and rejects missing
+queries, duplicate documents, rank gaps, and non-finite scores:
+[`configs/nfcorpus_first_stage_contract.json`](../configs/nfcorpus_first_stage_contract.json).
+
+## Methodology and reproduction
+
+The analysis reads the already-published BM25 run, public NFCorpus query
+records, and qrels. It does not rebuild an index, rerun BM25, invoke the
+cross-encoder, or modify any model.
+
+From a configured clone:
+
+```bash
+make analyze-nfcorpus-first-stage
+```
+
+The target first downloads and verifies the public BEIR release into
+`outputs/reproductions/beir_cross_domain_v1`, recovers the original NFCorpus
+files into the repository-local `outputs/reproductions/beir_irds_cache`, and
+recomputes the released metrics. It then writes:
+
+- `outputs/analysis/nfcorpus_first_stage/summary.json`;
+- `outputs/analysis/nfcorpus_first_stage/per_query.jsonl`;
+- `outputs/analysis/nfcorpus_first_stage/examples.jsonl`;
+- `outputs/analysis/nfcorpus_first_stage/report.md`.
+
+The query-level file records the positive-qrel count, first relevant rank,
+hit counts and recall at 10/100/1000, relevant hits inside and outside the
+top-100 candidate set, and relevant document IDs still missing after depth
+1000. Diagnostic examples are selected deterministically by SHA-256 within
+each bucket rather than chosen manually.
+
+Tables are used instead of charts because both diagnostic dimensions are
+small, mutually exclusive partitions and exact reconciliation is the primary
+audit requirement.
+
+## Limitations and robustness checks
+
+- The reported Recall@100 and Recall@1000 values independently reconcile to
+  the frozen headline metrics with tolerance `1e-12`.
+- Macro and micro results are labeled separately and are not compared as if
+  they used the same denominator.
+- The analysis uses qrels as the available relevance ground truth. Unjudged
+  documents are not treated as newly relevant, and qrels incompleteness may
+  affect qualitative interpretation.
+- A first hit outside rank 100 shows candidate-depth exclusion, not the reason
+  BM25 ranked it late.
+- A top-1000 miss does not by itself prove vocabulary mismatch, domain shift,
+  or a need for dense retrieval.
+- No generation claim follows from this retrieval-only analysis.
+
+## Recommended next step
+
+Keep the architecture unchanged while reviewing two pre-declared cohorts:
+
+1. The 24 queries whose first relevant hit appears at ranks 101-1000. These
+   isolate ranking-depth failures where BM25 can retrieve relevant evidence.
+2. The 48 queries with no relevant hit at depth 1000. These isolate the harder
+   first-stage failures for lexical-overlap and terminology analysis.
+
+For each cohort, compare query terms with the judged relevant documents and
+record a small failure taxonomy before selecting a new retrieval baseline.
+That evidence can determine whether the next controlled test should vary
+candidate depth, query processing, or first-stage retrieval method.
+
+## Further questions
+
+- Are top-100 misses concentrated in queries with many positive qrels, short
+  keyword queries, or specialized medical terminology?
+- Within the 24 depth-only failures, how many relevant documents enter early
+  enough that a larger reranking pool would be computationally credible?
+- Do relevance grades or qrels density change the apparent failure mix?
+- Would a separately versioned dense or hybrid first stage improve coverage
+  without erasing the current BM25 control?

--- a/scripts/analyze_nfcorpus_first_stage.py
+++ b/scripts/analyze_nfcorpus_first_stage.py
@@ -1,0 +1,219 @@
+"""Analyze NFCorpus first-stage coverage from frozen published BM25 outputs."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from msmarco_genqa.evaluation.first_stage_coverage import (
+    FirstStageCoverageError,
+    analyze_first_stage_coverage,
+    assert_first_stage_diagnostic_fingerprint,
+    deterministic_bucket_samples,
+    render_first_stage_coverage_markdown,
+)
+from msmarco_genqa.evaluation.retrieval_contract import (
+    RetrievalContractError,
+    verify_retrieval_contract,
+)
+from msmarco_genqa.evaluation.trec import QrelsFormatError, read_qrels
+from msmarco_genqa.reranking.io import RunTsvFormatError, read_run_tsv
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONTRACT = PROJECT_ROOT / "configs" / "nfcorpus_first_stage_contract.json"
+DEFAULT_OUTPUT_DIR = (
+    PROJECT_ROOT / "outputs" / "analysis" / "nfcorpus_first_stage"
+)
+SAMPLE_SEED = "nfcorpus-first-stage-errors-v1"
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise FirstStageCoverageError(f"{path}: expected a JSON object")
+    return value
+
+
+def _load_query_texts(archive_path: Path, member: str) -> dict[str, str]:
+    queries: dict[str, str] = {}
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            with archive.open(member) as raw:
+                text = io.TextIOWrapper(raw, encoding="utf-8", errors="strict")
+                for line_number, raw_line in enumerate(text, start=1):
+                    value = json.loads(raw_line)
+                    qid = value.get("_id") if isinstance(value, dict) else None
+                    query = value.get("text") if isinstance(value, dict) else None
+                    if not isinstance(qid, str) or not qid:
+                        raise FirstStageCoverageError(
+                            f"{member}:{line_number}: invalid query _id"
+                        )
+                    if not isinstance(query, str) or not query.strip():
+                        raise FirstStageCoverageError(
+                            f"{member}:{line_number}: missing query text"
+                        )
+                    if qid in queries:
+                        raise FirstStageCoverageError(
+                            f"{member}:{line_number}: duplicate query id {qid!r}"
+                        )
+                    queries[qid] = query
+    except (OSError, UnicodeDecodeError, zipfile.BadZipFile, KeyError) as exc:
+        raise FirstStageCoverageError(
+            f"cannot read query member {member!r}: {exc}"
+        ) from exc
+    return queries
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--samples-per-bucket", type=int, default=3)
+    args = parser.parse_args(argv)
+
+    contract_path = _resolve(args.contract).resolve()
+    output_dir = _resolve(args.output_dir).resolve()
+    try:
+        contract_report = verify_retrieval_contract(
+            contract_path,
+            project_root=PROJECT_ROOT,
+        )
+        contract = _load_json_object(contract_path)
+        source_record = contract["inputs"]["source_archive"]
+        query_member = str(source_record["query_member"])
+        source_archive = (
+            PROJECT_ROOT / contract_report["inputs"]["source_archive"]["path"]
+        )
+        qrels_path = PROJECT_ROOT / contract_report["inputs"]["qrels"]["path"]
+        bm25_path = PROJECT_ROOT / contract_report["inputs"]["bm25_run"]["path"]
+        queries = _load_query_texts(source_archive, query_member)
+        qrels = read_qrels(
+            qrels_path,
+            qrels_format=str(contract["qrels_format"]),
+        )
+        bm25_run = read_run_tsv(bm25_path)
+        report = analyze_first_stage_coverage(
+            bm25_run,
+            qrels,
+            queries,
+            rel_threshold=int(contract["binary_relevance_threshold"]),
+        )
+        expected = contract_report["expected_bm25_metrics"]
+        tolerance = float(contract_report["metric_tolerance"])
+        for metric in ("recall@100", "recall@1000"):
+            delta = abs(
+                float(report["macro_recall"][metric]) - float(expected[metric])
+            )
+            if delta > tolerance:
+                raise FirstStageCoverageError(
+                    f"{metric}: analysis drift {delta:.3g} exceeds {tolerance:g}"
+                )
+        assert_first_stage_diagnostic_fingerprint(
+            report,
+            contract.get("expected_first_stage_diagnostics"),
+        )
+        samples = deterministic_bucket_samples(
+            report["per_query"],
+            per_bucket=args.samples_per_bucket,
+            seed=SAMPLE_SEED,
+        )
+    except (
+        FirstStageCoverageError,
+        RetrievalContractError,
+        QrelsFormatError,
+        RunTsvFormatError,
+        OSError,
+        KeyError,
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        print(f"First-stage analysis failed: {exc}", file=sys.stderr)
+        return 1
+
+    per_query = list(report.pop("per_query"))
+    report["dataset_id"] = contract_report["dataset_id"]
+    report["provenance"] = {
+        "analysis_base_commit": contract_report["analysis_base_commit"],
+        "experiment_commit": contract_report["experiment_commit"],
+        "contract": contract_report["contract"],
+        "release": contract_report["release"],
+        "inputs": contract_report["inputs"],
+    }
+    report["sampling"] = {
+        "method": "smallest SHA-256(seed, dimension, bucket, qid)",
+        "seed": SAMPLE_SEED,
+        "per_bucket": args.samples_per_bucket,
+        "n_rows": len(samples),
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(output_dir / "summary.json", report)
+    _write_jsonl(output_dir / "per_query.jsonl", per_query)
+    _write_jsonl(output_dir / "examples.jsonl", samples)
+    markdown = render_first_stage_coverage_markdown(
+        report,
+        dataset_id=str(contract_report["dataset_id"]),
+        contract_path=str(contract_report["contract"]),
+        release_tag=str(contract_report["release"]["tag"]),
+        samples=samples,
+    )
+    (output_dir / "report.md").write_text(
+        markdown,
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    candidate = report["candidate_set_diagnostic"]
+    depth = report["depth_100_to_1000_diagnostic"]
+    print(
+        "NFCorpus first-stage coverage: "
+        f"{candidate['queries_with_no_relevant_in_top_100']}/"
+        f"{report['scope']['n_queries']} queries have no relevant BM25 top-100 "
+        "candidate"
+    )
+    print(
+        "Macro recall: "
+        f"@100={report['macro_recall']['recall@100']:.10f}, "
+        f"@1000={report['macro_recall']['recall@1000']:.10f}, "
+        f"gain={depth['macro_recall_gain']:+.10f}"
+    )
+    print(f"Wrote {_display_path(output_dir)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_nfcorpus_first_stage_contract.py
+++ b/scripts/check_nfcorpus_first_stage_contract.py
@@ -1,0 +1,75 @@
+"""Verify the frozen NFCorpus first-stage data and metric contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from msmarco_genqa.evaluation.retrieval_contract import (
+    RetrievalContractError,
+    verify_retrieval_contract,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONTRACT = PROJECT_ROOT / "configs" / "nfcorpus_first_stage_contract.json"
+DEFAULT_OUTPUT = (
+    PROJECT_ROOT
+    / "outputs"
+    / "analysis"
+    / "nfcorpus_first_stage"
+    / "data_metric_contract.json"
+)
+
+
+def _resolve(path: Path) -> Path:
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args(argv)
+
+    try:
+        report = verify_retrieval_contract(
+            _resolve(args.contract),
+            project_root=PROJECT_ROOT,
+        )
+    except RetrievalContractError as exc:
+        print(f"Contract verification failed: {exc}", file=sys.stderr)
+        return 1
+
+    output = _resolve(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    metrics = report["bm25_metrics"]
+    print(
+        "NFCorpus contract verified: "
+        f"{report['scope']['test_queries']} queries, "
+        f"BM25 {report['scope']['bm25']['row_count']} rows/depth "
+        f"{report['scope']['bm25']['depth']}, "
+        f"CE {report['scope']['ce']['row_count']} rows/depth "
+        f"{report['scope']['ce']['depth']}"
+    )
+    print(
+        "BM25 metrics: "
+        f"MRR@10={metrics['mrr@10']:.10f}, "
+        f"nDCG@10={metrics['ndcg@10']:.10f}, "
+        f"Recall@100={metrics['recall@100']:.10f}, "
+        f"Recall@1000={metrics['recall@1000']:.10f}"
+    )
+    print(f"Maximum absolute metric delta: {report['max_abs_delta']:.3g}")
+    print(f"Wrote {output.relative_to(PROJECT_ROOT).as_posix()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/msmarco_genqa/evaluation/first_stage_coverage.py
+++ b/src/msmarco_genqa/evaluation/first_stage_coverage.py
@@ -1,0 +1,582 @@
+"""Query-level first-stage coverage diagnostics for fixed retrieval runs."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections import Counter
+from statistics import mean, median
+from typing import Any, Mapping, Sequence
+
+
+FIRST_HIT_BUCKETS = (
+    "top_10",
+    "ranks_11_100",
+    "ranks_101_1000",
+    "miss_top_1000",
+)
+COVERAGE_AT_100_BUCKETS = (
+    "none",
+    "partial_lt_25pct",
+    "partial_25_to_lt_50pct",
+    "partial_50_to_lt_100pct",
+    "complete",
+)
+DEFAULT_CUTOFFS = (10, 100, 1000)
+REPORT_SCHEMA = "msmarco-genqa.first-stage-coverage-report.v1"
+
+
+class FirstStageCoverageError(ValueError):
+    """Raised when first-stage diagnostic inputs are inconsistent."""
+
+
+def first_hit_bucket(first_relevant_rank: int | None) -> str:
+    """Map a first relevant rank onto fixed reranker-reachability buckets."""
+    if first_relevant_rank is None:
+        return "miss_top_1000"
+    if (
+        isinstance(first_relevant_rank, bool)
+        or not isinstance(first_relevant_rank, int)
+        or first_relevant_rank < 1
+    ):
+        raise FirstStageCoverageError("first relevant rank must be positive or None")
+    if first_relevant_rank <= 10:
+        return "top_10"
+    if first_relevant_rank <= 100:
+        return "ranks_11_100"
+    if first_relevant_rank <= 1000:
+        return "ranks_101_1000"
+    raise FirstStageCoverageError(
+        "first relevant rank exceeds the fixed BM25 depth of 1000"
+    )
+
+
+def relevant_coverage_at_100_bucket(value: float) -> str:
+    """Bucket a query's Recall@100 without conflating partial and full coverage."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise FirstStageCoverageError("coverage must be a number in [0, 1]")
+    coverage = float(value)
+    if not math.isfinite(coverage) or not 0.0 <= coverage <= 1.0:
+        raise FirstStageCoverageError("coverage must be a finite number in [0, 1]")
+    if coverage == 0.0:
+        return "none"
+    if coverage < 0.25:
+        return "partial_lt_25pct"
+    if coverage < 0.50:
+        return "partial_25_to_lt_50pct"
+    if coverage < 1.0:
+        return "partial_50_to_lt_100pct"
+    return "complete"
+
+
+def _positive_doc_ids(
+    judgments: Mapping[str, int],
+    *,
+    rel_threshold: int,
+) -> set[str]:
+    if (
+        isinstance(rel_threshold, bool)
+        or not isinstance(rel_threshold, int)
+        or rel_threshold < 1
+    ):
+        raise FirstStageCoverageError("rel_threshold must be an integer >= 1")
+    return {
+        doc_id
+        for doc_id, relevance in judgments.items()
+        if relevance >= rel_threshold
+    }
+
+
+def analyze_first_stage_query(
+    qid: str,
+    run_rows: Sequence[tuple[str, float]],
+    judgments: Mapping[str, int],
+    *,
+    query_text: str,
+    rel_threshold: int = 1,
+    cutoffs: tuple[int, int, int] = DEFAULT_CUTOFFS,
+) -> dict[str, Any]:
+    """Build an auditable coverage record for one query."""
+    if cutoffs != DEFAULT_CUTOFFS:
+        raise FirstStageCoverageError(
+            "NFCorpus first-stage analysis requires cutoffs (10, 100, 1000)"
+        )
+    relevant = _positive_doc_ids(judgments, rel_threshold=rel_threshold)
+    if not relevant:
+        raise FirstStageCoverageError(f"{qid}: no judgments with rel >= {rel_threshold}")
+    if len(run_rows) > cutoffs[-1]:
+        raise FirstStageCoverageError(
+            f"{qid}: run depth {len(run_rows)} exceeds fixed depth {cutoffs[-1]}"
+        )
+
+    ranked_hits = [
+        {
+            "doc_id": doc_id,
+            "rank": rank,
+            "score": float(score),
+        }
+        for rank, (doc_id, score) in enumerate(run_rows, start=1)
+        if doc_id in relevant
+    ]
+    first_rank = int(ranked_hits[0]["rank"]) if ranked_hits else None
+    hit_doc_ids = {str(hit["doc_id"]) for hit in ranked_hits}
+    hit_counts = {
+        cutoff: sum(1 for hit in ranked_hits if int(hit["rank"]) <= cutoff)
+        for cutoff in cutoffs
+    }
+    recalls = {
+        cutoff: hit_counts[cutoff] / len(relevant)
+        for cutoff in cutoffs
+    }
+    missing_after_1000 = sorted(relevant - hit_doc_ids)
+
+    return {
+        "qid": qid,
+        "query": query_text,
+        "n_relevant": len(relevant),
+        "first_relevant_rank": first_rank,
+        "first_hit_bucket": first_hit_bucket(first_rank),
+        "coverage_at_100_bucket": relevant_coverage_at_100_bucket(recalls[100]),
+        "hit_count@10": hit_counts[10],
+        "hit_count@100": hit_counts[100],
+        "hit_count@1000": hit_counts[1000],
+        "recall@10": recalls[10],
+        "recall@100": recalls[100],
+        "recall@1000": recalls[1000],
+        "additional_hit_count_101_1000": hit_counts[1000] - hit_counts[100],
+        "missing_count@100": len(relevant) - hit_counts[100],
+        "missing_count@1000": len(missing_after_1000),
+        "relevant_hits_top_100": [
+            hit for hit in ranked_hits if int(hit["rank"]) <= 100
+        ],
+        "relevant_hits_101_1000": [
+            hit for hit in ranked_hits if int(hit["rank"]) > 100
+        ],
+        "missing_relevant_doc_ids_after_1000": missing_after_1000,
+    }
+
+
+def _bucket_summary(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    key: str,
+    order: Sequence[str],
+) -> list[dict[str, int | float | str]]:
+    counts = Counter(str(row[key]) for row in rows)
+    total = len(rows)
+    unknown = sorted(set(counts) - set(order))
+    if unknown:
+        raise FirstStageCoverageError(
+            f"{key}: unexpected buckets: {', '.join(unknown)}"
+        )
+    return [
+        {
+            "bucket": bucket,
+            "n_queries": counts.get(bucket, 0),
+            "share": counts.get(bucket, 0) / total if total else 0.0,
+        }
+        for bucket in order
+    ]
+
+
+def analyze_first_stage_coverage(
+    run: Mapping[str, Sequence[tuple[str, float]]],
+    qrels: Mapping[str, Mapping[str, int]],
+    queries: Mapping[str, str],
+    *,
+    rel_threshold: int = 1,
+) -> dict[str, Any]:
+    """Analyze every qrels query and exactly reconcile the coverage decomposition."""
+    qids = set(qrels)
+    missing_run_qids = sorted(qids - set(run))
+    extra_run_qids = sorted(set(run) - qids)
+    missing_query_texts = sorted(qids - set(queries))
+    if missing_run_qids or extra_run_qids:
+        raise FirstStageCoverageError(
+            "run/qrels qid mismatch: "
+            f"missing={missing_run_qids[:5]}, extra={extra_run_qids[:5]}"
+        )
+    if missing_query_texts:
+        raise FirstStageCoverageError(
+            "query texts missing for qids: " + ", ".join(missing_query_texts[:5])
+        )
+
+    rows = [
+        analyze_first_stage_query(
+            qid,
+            run[qid],
+            qrels[qid],
+            query_text=queries[qid],
+            rel_threshold=rel_threshold,
+        )
+        for qid in sorted(qids)
+    ]
+    if not rows:
+        raise FirstStageCoverageError("analysis requires at least one query")
+
+    total_relevant = sum(int(row["n_relevant"]) for row in rows)
+    macro_recall = {
+        cutoff: mean(float(row[f"recall@{cutoff}"]) for row in rows)
+        for cutoff in DEFAULT_CUTOFFS
+    }
+    total_hits = {
+        cutoff: sum(int(row[f"hit_count@{cutoff}"]) for row in rows)
+        for cutoff in DEFAULT_CUTOFFS
+    }
+    micro_recall = {
+        cutoff: total_hits[cutoff] / total_relevant
+        for cutoff in DEFAULT_CUTOFFS
+    }
+    first_hit_summary = _bucket_summary(
+        rows,
+        key="first_hit_bucket",
+        order=FIRST_HIT_BUCKETS,
+    )
+    coverage_summary = _bucket_summary(
+        rows,
+        key="coverage_at_100_bucket",
+        order=COVERAGE_AT_100_BUCKETS,
+    )
+    first_hit_counts = {
+        str(row["bucket"]): int(row["n_queries"]) for row in first_hit_summary
+    }
+    coverage_counts = {
+        str(row["bucket"]): int(row["n_queries"]) for row in coverage_summary
+    }
+    n_queries = len(rows)
+    if sum(first_hit_counts.values()) != n_queries:
+        raise FirstStageCoverageError("first-hit buckets do not reconcile")
+    if sum(coverage_counts.values()) != n_queries:
+        raise FirstStageCoverageError("coverage@100 buckets do not reconcile")
+
+    n_relevant_values = [int(row["n_relevant"]) for row in rows]
+    qids_gaining_after_100 = sum(
+        int(row["additional_hit_count_101_1000"]) > 0 for row in rows
+    )
+    report = {
+        "schema": REPORT_SCHEMA,
+        "settings": {
+            "relevance_rule": f"relevance >= {rel_threshold}",
+            "rel_threshold": rel_threshold,
+            "cutoffs": list(DEFAULT_CUTOFFS),
+            "reranker_candidate_depth": 100,
+            "headline_aggregation": "macro average over qrels queries",
+        },
+        "scope": {
+            "n_queries": n_queries,
+            "n_positive_qrels": total_relevant,
+            "run_depth": max(len(run[qid]) for qid in qids),
+            "relevant_per_query": {
+                "minimum": min(n_relevant_values),
+                "median": float(median(n_relevant_values)),
+                "mean": mean(n_relevant_values),
+                "maximum": max(n_relevant_values),
+            },
+        },
+        "macro_recall": {
+            f"recall@{cutoff}": macro_recall[cutoff]
+            for cutoff in DEFAULT_CUTOFFS
+        },
+        "micro_qrels_coverage": {
+            f"recall@{cutoff}": micro_recall[cutoff]
+            for cutoff in DEFAULT_CUTOFFS
+        },
+        "first_hit_buckets": first_hit_summary,
+        "coverage_at_100_buckets": coverage_summary,
+        "candidate_set_diagnostic": {
+            "queries_with_any_relevant_in_top_100": (
+                n_queries - coverage_counts["none"]
+            ),
+            "queries_with_no_relevant_in_top_100": coverage_counts["none"],
+            "queries_with_complete_relevant_coverage_at_100": coverage_counts[
+                "complete"
+            ],
+            "queries_with_partial_relevant_coverage_at_100": (
+                n_queries - coverage_counts["none"] - coverage_counts["complete"]
+            ),
+            "positive_qrels_in_top_100": total_hits[100],
+            "positive_qrels_outside_top_100": total_relevant - total_hits[100],
+        },
+        "depth_100_to_1000_diagnostic": {
+            "macro_recall_gain": macro_recall[1000] - macro_recall[100],
+            "micro_qrels_coverage_gain": micro_recall[1000] - micro_recall[100],
+            "additional_positive_qrels_found": total_hits[1000] - total_hits[100],
+            "queries_gaining_relevant_documents": qids_gaining_after_100,
+            "queries_with_first_hit_only_at_ranks_101_1000": first_hit_counts[
+                "ranks_101_1000"
+            ],
+            "queries_still_missing_at_depth_1000": first_hit_counts[
+                "miss_top_1000"
+            ],
+            "positive_qrels_still_missing_at_depth_1000": (
+                total_relevant - total_hits[1000]
+            ),
+        },
+        "reconciliation": {
+            "first_hit_bucket_queries": sum(first_hit_counts.values()),
+            "coverage_at_100_bucket_queries": sum(coverage_counts.values()),
+            "positive_qrels": total_relevant,
+            "positive_qrels_top_100_plus_outside": (
+                total_hits[100] + total_relevant - total_hits[100]
+            ),
+        },
+        "per_query": rows,
+    }
+    return report
+
+
+def deterministic_bucket_samples(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    dimensions: Sequence[str] = (
+        "first_hit_bucket",
+        "coverage_at_100_bucket",
+    ),
+    per_bucket: int = 3,
+    seed: str = "nfcorpus-first-stage-errors-v1",
+) -> list[dict[str, Any]]:
+    """Select stable, non-cherry-picked examples within every observed bucket."""
+    if per_bucket < 1:
+        raise FirstStageCoverageError("per_bucket must be at least 1")
+    samples: list[dict[str, Any]] = []
+    for dimension in dimensions:
+        buckets = sorted({str(row[dimension]) for row in rows})
+        for bucket in buckets:
+            candidates: list[tuple[str, Mapping[str, Any]]] = []
+            for row in rows:
+                if str(row[dimension]) != bucket:
+                    continue
+                qid = str(row["qid"])
+                digest = hashlib.sha256(
+                    f"{seed}\0{dimension}\0{bucket}\0{qid}".encode()
+                ).hexdigest()
+                candidates.append((digest, row))
+            for selection_rank, (digest, row) in enumerate(
+                sorted(candidates, key=lambda item: (item[0], str(item[1]["qid"])))[:per_bucket],
+                start=1,
+            ):
+                samples.append(
+                    {
+                        "sample_dimension": dimension,
+                        "sample_bucket": bucket,
+                        "selection_rank": selection_rank,
+                        "selection_sha256": digest,
+                        **dict(row),
+                    }
+                )
+    return samples
+
+
+def first_stage_diagnostic_fingerprint(
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the exact aggregate counts pinned after the first verified run."""
+    first_hit_counts = {
+        str(row["bucket"]): int(row["n_queries"])
+        for row in report["first_hit_buckets"]
+    }
+    coverage_counts = {
+        str(row["bucket"]): int(row["n_queries"])
+        for row in report["coverage_at_100_buckets"]
+    }
+    candidate = report["candidate_set_diagnostic"]
+    depth = report["depth_100_to_1000_diagnostic"]
+    positive_top_100 = int(candidate["positive_qrels_in_top_100"])
+    additional = int(depth["additional_positive_qrels_found"])
+    return {
+        "n_queries": int(report["scope"]["n_queries"]),
+        "n_positive_qrels": int(report["scope"]["n_positive_qrels"]),
+        "first_hit_bucket_counts": first_hit_counts,
+        "coverage_at_100_bucket_counts": coverage_counts,
+        "positive_qrels_in_top_100": positive_top_100,
+        "positive_qrels_in_top_1000": positive_top_100 + additional,
+        "queries_gaining_relevant_documents_101_1000": int(
+            depth["queries_gaining_relevant_documents"]
+        ),
+        "positive_qrels_missing_at_1000": int(
+            depth["positive_qrels_still_missing_at_depth_1000"]
+        ),
+    }
+
+
+def assert_first_stage_diagnostic_fingerprint(
+    report: Mapping[str, Any],
+    expected: Any,
+) -> None:
+    """Reject aggregate diagnostic drift against an explicit JSON contract."""
+    if not isinstance(expected, dict):
+        raise FirstStageCoverageError(
+            "expected_first_stage_diagnostics must be an object"
+        )
+    observed = first_stage_diagnostic_fingerprint(report)
+    if observed != expected:
+        differing = sorted(
+            key
+            for key in observed.keys() | expected.keys()
+            if observed.get(key) != expected.get(key)
+        )
+        raise FirstStageCoverageError(
+            "first-stage diagnostic drift in: " + ", ".join(differing)
+        )
+
+
+def render_first_stage_coverage_markdown(
+    report: Mapping[str, Any],
+    *,
+    dataset_id: str,
+    contract_path: str,
+    release_tag: str,
+    samples: Sequence[Mapping[str, Any]],
+) -> str:
+    """Render an answer-first diagnostic report from verified query-level evidence."""
+    scope = report["scope"]
+    candidate = report["candidate_set_diagnostic"]
+    depth = report["depth_100_to_1000_diagnostic"]
+    settings = report["settings"]
+    lines = [
+        "# NFCorpus First-Stage Coverage Analysis",
+        "",
+        "## Result",
+        "",
+        (
+            f"BM25 retrieves at least one relevant document inside the fixed top-100 "
+            f"candidate set for **{candidate['queries_with_any_relevant_in_top_100']}/"
+            f"{scope['n_queries']}** queries; "
+            f"**{candidate['queries_with_no_relevant_in_top_100']}/"
+            f"{scope['n_queries']}** queries give the reranker no relevant candidate."
+        ),
+        (
+            f"Extending the same BM25 run from depth 100 to 1000 raises macro Recall "
+            f"from **{report['macro_recall']['recall@100']:.4f}** to "
+            f"**{report['macro_recall']['recall@1000']:.4f}**, but "
+            f"**{depth['positive_qrels_still_missing_at_depth_1000']}** positive qrels "
+            "remain unretrieved."
+        ),
+        "",
+        "This diagnoses the fixed first-stage candidate set; it does not evaluate a "
+        "new retriever or justify an architectural change.",
+        "",
+        "## Frozen Scope",
+        "",
+        f"- Dataset: `{dataset_id}`",
+        f"- Data/metric contract: `{contract_path}`",
+        f"- Published evidence release: `{release_tag}`",
+        f"- Relevance rule: `{settings['relevance_rule']}`",
+        f"- Queries: **{scope['n_queries']}**",
+        f"- Positive qrels: **{scope['n_positive_qrels']}**",
+        f"- BM25 depth: **{scope['run_depth']}**",
+        "",
+        "## Bucket Definitions",
+        "",
+        "| first-hit bucket | definition | reranker interpretation |",
+        "|---|---|---|",
+        "| `top_10` | first relevant document at rank 1-10 | already visible at the headline rank cutoff |",
+        "| `ranks_11_100` | first relevant document at rank 11-100 | reachable by the fixed top-100 reranker |",
+        "| `ranks_101_1000` | first relevant document at rank 101-1000 | excluded from the reranker candidate set |",
+        "| `miss_top_1000` | no relevant document in BM25 top 1000 | not recovered by deeper BM25 retrieval |",
+        "",
+        "| coverage@100 bucket | definition |",
+        "|---|---|",
+        "| `none` | Recall@100 = 0 |",
+        "| `partial_lt_25pct` | 0 < Recall@100 < 0.25 |",
+        "| `partial_25_to_lt_50pct` | 0.25 <= Recall@100 < 0.50 |",
+        "| `partial_50_to_lt_100pct` | 0.50 <= Recall@100 < 1 |",
+        "| `complete` | Recall@100 = 1 |",
+        "",
+        "## Aggregate Coverage",
+        "",
+        "| aggregation | Recall@10 | Recall@100 | Recall@1000 |",
+        "|---|---:|---:|---:|",
+        (
+            f"| Macro (headline definition) | "
+            f"{report['macro_recall']['recall@10']:.4f} | "
+            f"{report['macro_recall']['recall@100']:.4f} | "
+            f"{report['macro_recall']['recall@1000']:.4f} |"
+        ),
+        (
+            f"| Micro qrels coverage (diagnostic only) | "
+            f"{report['micro_qrels_coverage']['recall@10']:.4f} | "
+            f"{report['micro_qrels_coverage']['recall@100']:.4f} | "
+            f"{report['micro_qrels_coverage']['recall@1000']:.4f} |"
+        ),
+        "",
+        "Macro recall gives every query equal weight and remains the reported metric. "
+        "Micro coverage weights queries by their number of positive qrels and is shown "
+        "only to explain where relevant-document mass is lost.",
+        "",
+        "## First Relevant Hit",
+        "",
+        "| bucket | queries | share |",
+        "|---|---:|---:|",
+    ]
+    for row in report["first_hit_buckets"]:
+        lines.append(
+            f"| `{row['bucket']}` | {row['n_queries']} | {row['share']:.1%} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Relevant-Document Coverage at 100",
+            "",
+            "| bucket | queries | share |",
+            "|---|---:|---:|",
+        ]
+    )
+    for row in report["coverage_at_100_buckets"]:
+        lines.append(
+            f"| `{row['bucket']}` | {row['n_queries']} | {row['share']:.1%} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Depth 100 to 1000",
+            "",
+            "| diagnostic | value |",
+            "|---|---:|",
+            f"| Macro Recall gain | {depth['macro_recall_gain']:+.4f} |",
+            f"| Additional positive qrels found | {depth['additional_positive_qrels_found']} |",
+            f"| Queries gaining at least one relevant document | {depth['queries_gaining_relevant_documents']} |",
+            f"| Queries whose first hit is only at rank 101-1000 | {depth['queries_with_first_hit_only_at_ranks_101_1000']} |",
+            f"| Queries still missing at depth 1000 | {depth['queries_still_missing_at_depth_1000']} |",
+            f"| Positive qrels still missing at depth 1000 | {depth['positive_qrels_still_missing_at_depth_1000']} |",
+            "",
+            "## Deterministic Examples",
+            "",
+            "Examples are selected by SHA-256 over the fixed seed, dimension, bucket, "
+            "and qid. They are not manually chosen.",
+            "",
+            "| dimension | bucket | qid | query | first rank | Recall@100 | Recall@1000 |",
+            "|---|---|---|---|---:|---:|---:|",
+        ]
+    )
+    for row in samples:
+        query = (
+            str(row["query"])
+            .replace("|", "\\|")
+            .replace("\r", " ")
+            .replace("\n", " ")
+        )
+        if len(query) > 100:
+            query = query[:97] + "..."
+        first_rank = row["first_relevant_rank"]
+        lines.append(
+            f"| `{row['sample_dimension']}` | `{row['sample_bucket']}` | "
+            f"`{row['qid']}` | {query} | "
+            f"{first_rank if first_rank is not None else '-'} | "
+            f"{float(row['recall@100']):.3f} | "
+            f"{float(row['recall@1000']):.3f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation Boundary",
+            "",
+            "The analysis uses one frozen BM25 output and public graded qrels. It shows "
+            "candidate-set reachability and missing relevant-document coverage, not why "
+            "BM25 missed a document semantically. A later qualitative review may inspect "
+            "lexical mismatch, terminology, query specificity, and document length, but "
+            "those explanations are not asserted here.",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/src/msmarco_genqa/evaluation/retrieval_contract.py
+++ b/src/msmarco_genqa/evaluation/retrieval_contract.py
@@ -1,0 +1,462 @@
+"""Strict data and metric contracts for fixed-output retrieval analysis."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import math
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from msmarco_genqa.evaluation.trec import (
+    QrelsFormatError,
+    evaluate_internal_trec_scope,
+    read_qrels,
+    trec_metric_contract,
+)
+from msmarco_genqa.reranking.io import RunTsvFormatError, read_run_tsv
+
+
+CONTRACT_SCHEMA = "msmarco-genqa.retrieval-data-metric-contract.v1"
+REPORT_SCHEMA = "msmarco-genqa.retrieval-data-metric-contract-report.v1"
+
+
+class RetrievalContractError(RuntimeError):
+    """Raised when a frozen retrieval-analysis input violates its contract."""
+
+
+def sha256_file(path: Path | str) -> str:
+    """Return a lowercase SHA-256 digest without loading the whole file."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _load_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RetrievalContractError(f"{label}: cannot read JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RetrievalContractError(f"{label}: expected a JSON object")
+    return value
+
+
+def _resolve_repo_path(root: Path, value: Any, *, label: str) -> Path:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise RetrievalContractError(
+            f"{label}: expected a repository-relative POSIX path"
+        )
+    pure = PurePosixPath(value)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        raise RetrievalContractError(f"{label}: unsafe repository path {value!r}")
+    path = root.joinpath(*pure.parts).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise RetrievalContractError(f"{label}: path escapes project root") from exc
+    return path
+
+
+def _require_int(value: Any, *, label: str, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise RetrievalContractError(
+            f"{label}: expected an integer greater than or equal to {minimum}"
+        )
+    return value
+
+
+def _require_unit_float(value: Any, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RetrievalContractError(f"{label}: expected a number in [0, 1]")
+    converted = float(value)
+    if not math.isfinite(converted) or not 0.0 <= converted <= 1.0:
+        raise RetrievalContractError(f"{label}: expected a finite number in [0, 1]")
+    return converted
+
+
+def _verify_file_record(
+    root: Path,
+    record: Any,
+    *,
+    label: str,
+) -> tuple[Path, dict[str, Any]]:
+    if not isinstance(record, dict):
+        raise RetrievalContractError(f"{label}: expected a file record")
+    path = _resolve_repo_path(root, record.get("path"), label=f"{label}.path")
+    if not path.is_file():
+        raise RetrievalContractError(f"{label}: missing input {record.get('path')}")
+    expected_bytes = _require_int(record.get("bytes"), label=f"{label}.bytes")
+    expected_sha = record.get("sha256")
+    if (
+        not isinstance(expected_sha, str)
+        or len(expected_sha) != 64
+        or expected_sha.lower() != expected_sha
+    ):
+        raise RetrievalContractError(f"{label}.sha256: expected a lowercase SHA-256")
+    actual_bytes = path.stat().st_size
+    if actual_bytes != expected_bytes:
+        raise RetrievalContractError(
+            f"{label}: byte-size drift; expected {expected_bytes}, got {actual_bytes}"
+        )
+    actual_sha = sha256_file(path)
+    if actual_sha != expected_sha:
+        raise RetrievalContractError(
+            f"{label}: SHA-256 drift; expected {expected_sha}, got {actual_sha}"
+        )
+    return path, {
+        "path": path.relative_to(root).as_posix(),
+        "bytes": actual_bytes,
+        "sha256": actual_sha,
+    }
+
+
+def _load_jsonl_ids_from_zip(
+    archive_path: Path,
+    *,
+    member: Any,
+    label: str,
+) -> set[str]:
+    if not isinstance(member, str) or not member:
+        raise RetrievalContractError(f"{label}: archive member is missing")
+    ids: set[str] = set()
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            with archive.open(member) as raw:
+                text = io.TextIOWrapper(raw, encoding="utf-8", errors="strict")
+                for line_number, raw_line in enumerate(text, start=1):
+                    line = raw_line.strip()
+                    if not line:
+                        raise RetrievalContractError(
+                            f"{label}:{line_number}: empty JSONL row"
+                        )
+                    try:
+                        value = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise RetrievalContractError(
+                            f"{label}:{line_number}: invalid JSON: {exc}"
+                        ) from exc
+                    item_id = value.get("_id") if isinstance(value, dict) else None
+                    if (
+                        not isinstance(item_id, str)
+                        or not item_id
+                        or "\ufffd" in item_id
+                    ):
+                        raise RetrievalContractError(
+                            f"{label}:{line_number}: invalid _id"
+                        )
+                    if item_id in ids:
+                        raise RetrievalContractError(
+                            f"{label}:{line_number}: duplicate _id {item_id!r}"
+                        )
+                    ids.add(item_id)
+    except KeyError as exc:
+        raise RetrievalContractError(
+            f"{label}: source archive is missing {member!r}"
+        ) from exc
+    except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
+        raise RetrievalContractError(f"{label}: cannot read source archive: {exc}") from exc
+    return ids
+
+
+def _validate_run_shape(
+    run: dict[str, list[tuple[str, float]]],
+    record: dict[str, Any],
+    *,
+    label: str,
+) -> dict[str, int]:
+    expected_queries = _require_int(
+        record.get("query_count"), label=f"{label}.query_count", minimum=1
+    )
+    expected_rows = _require_int(
+        record.get("row_count"), label=f"{label}.row_count", minimum=1
+    )
+    expected_depth = _require_int(
+        record.get("depth"), label=f"{label}.depth", minimum=1
+    )
+    query_count = len(run)
+    row_count = sum(len(rows) for rows in run.values())
+    wrong_depth = sorted(qid for qid, rows in run.items() if len(rows) != expected_depth)
+    if query_count != expected_queries:
+        raise RetrievalContractError(
+            f"{label}: expected {expected_queries} queries, got {query_count}"
+        )
+    if row_count != expected_rows:
+        raise RetrievalContractError(
+            f"{label}: expected {expected_rows} rows, got {row_count}"
+        )
+    if wrong_depth:
+        preview = ", ".join(wrong_depth[:5])
+        raise RetrievalContractError(
+            f"{label}: {len(wrong_depth)} queries do not have depth "
+            f"{expected_depth}; first: {preview}"
+        )
+    return {
+        "query_count": query_count,
+        "row_count": row_count,
+        "depth": expected_depth,
+    }
+
+
+def _assert_same_ids(
+    actual: set[str],
+    expected: set[str],
+    *,
+    label: str,
+) -> None:
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing or extra:
+        raise RetrievalContractError(
+            f"{label}: identifier mismatch; missing={missing[:5]}, extra={extra[:5]}"
+        )
+
+
+def _assert_subset(actual: set[str], expected: set[str], *, label: str) -> None:
+    unknown = sorted(actual - expected)
+    if unknown:
+        raise RetrievalContractError(
+            f"{label}: {len(unknown)} identifiers are absent from the source; "
+            f"first: {', '.join(unknown[:5])}"
+        )
+
+
+def verify_retrieval_contract(
+    contract_path: Path | str,
+    *,
+    project_root: Path | str,
+) -> dict[str, Any]:
+    """Verify frozen NFCorpus inputs and independently recompute BM25 metrics."""
+    root = Path(project_root).resolve()
+    contract_source = Path(contract_path).resolve()
+    contract = _load_json_object(contract_source, label="contract")
+    if contract.get("schema") != CONTRACT_SCHEMA:
+        raise RetrievalContractError(
+            f"contract: expected schema {CONTRACT_SCHEMA!r}"
+        )
+
+    inputs = contract.get("inputs")
+    if not isinstance(inputs, dict):
+        raise RetrievalContractError("contract.inputs: expected an object")
+    verified_inputs: dict[str, dict[str, Any]] = {}
+    resolved: dict[str, Path] = {}
+    for key in ("release_asset", "source_archive", "qrels", "bm25_run", "ce_run"):
+        resolved[key], verified_inputs[key] = _verify_file_record(
+            root,
+            inputs.get(key),
+            label=f"inputs.{key}",
+        )
+
+    release = contract.get("release")
+    if not isinstance(release, dict):
+        raise RetrievalContractError("contract.release: expected an object")
+    pointer_path = _resolve_repo_path(
+        root, release.get("pointer_path"), label="release.pointer_path"
+    )
+    pointer = _load_json_object(pointer_path, label="release pointer")
+    pointer_release = pointer.get("release")
+    pointer_download = pointer.get("download")
+    if not isinstance(pointer_release, dict) or not isinstance(pointer_download, dict):
+        raise RetrievalContractError("release pointer is missing release/download")
+    for key in ("repository", "tag", "asset"):
+        if pointer_release.get(key) != release.get(key):
+            raise RetrievalContractError(
+                f"release pointer {key} drift: expected {release.get(key)!r}, "
+                f"got {pointer_release.get(key)!r}"
+            )
+    release_asset = verified_inputs["release_asset"]
+    if (
+        pointer_download.get("bytes") != release_asset["bytes"]
+        or pointer_download.get("sha256") != release_asset["sha256"]
+    ):
+        raise RetrievalContractError(
+            "release asset bytes/SHA-256 do not match the tracked pointer"
+        )
+
+    source_record = inputs["source_archive"]
+    query_ids = _load_jsonl_ids_from_zip(
+        resolved["source_archive"],
+        member=source_record.get("query_member"),
+        label="source queries",
+    )
+    corpus_ids = _load_jsonl_ids_from_zip(
+        resolved["source_archive"],
+        member=source_record.get("corpus_member"),
+        label="source corpus",
+    )
+    try:
+        qrels = read_qrels(
+            resolved["qrels"],
+            qrels_format=str(contract.get("qrels_format", "auto")),
+        )
+        bm25_run = read_run_tsv(resolved["bm25_run"])
+        ce_run = read_run_tsv(resolved["ce_run"])
+    except (QrelsFormatError, RunTsvFormatError) as exc:
+        raise RetrievalContractError(str(exc)) from exc
+
+    expected_counts = contract.get("expected_counts")
+    if not isinstance(expected_counts, dict):
+        raise RetrievalContractError("contract.expected_counts: expected an object")
+    observed_counts = {
+        "source_queries": len(query_ids),
+        "corpus_documents": len(corpus_ids),
+        "test_queries": len(qrels),
+        "qrels_judgments": sum(len(rows) for rows in qrels.values()),
+    }
+    for key, observed in observed_counts.items():
+        expected = _require_int(
+            expected_counts.get(key), label=f"expected_counts.{key}", minimum=1
+        )
+        if observed != expected:
+            raise RetrievalContractError(
+                f"{key}: expected {expected}, got {observed}"
+            )
+
+    test_qids = set(qrels)
+    _assert_subset(test_qids, query_ids, label="qrels query ids")
+    _assert_same_ids(set(bm25_run), test_qids, label="BM25 query ids")
+    _assert_same_ids(set(ce_run), test_qids, label="CE query ids")
+
+    qrels_doc_ids = {
+        doc_id for judgments in qrels.values() for doc_id in judgments
+    }
+    bm25_doc_ids = {
+        doc_id for rows in bm25_run.values() for doc_id, _score in rows
+    }
+    ce_doc_ids = {
+        doc_id for rows in ce_run.values() for doc_id, _score in rows
+    }
+    _assert_subset(qrels_doc_ids, corpus_ids, label="qrels document ids")
+    _assert_subset(bm25_doc_ids, corpus_ids, label="BM25 document ids")
+    _assert_subset(ce_doc_ids, corpus_ids, label="CE document ids")
+
+    bm25_shape = _validate_run_shape(
+        bm25_run, inputs["bm25_run"], label="BM25 run"
+    )
+    ce_shape = _validate_run_shape(ce_run, inputs["ce_run"], label="CE run")
+    candidate_mismatches = [
+        qid
+        for qid in sorted(test_qids)
+        if {doc_id for doc_id, _score in bm25_run[qid][: ce_shape["depth"]]}
+        != {doc_id for doc_id, _score in ce_run[qid]}
+    ]
+    if candidate_mismatches:
+        raise RetrievalContractError(
+            "CE candidate set differs from BM25 top-100 for "
+            f"{len(candidate_mismatches)} queries; first: "
+            f"{', '.join(candidate_mismatches[:5])}"
+        )
+
+    rel_threshold = _require_int(
+        contract.get("binary_relevance_threshold"),
+        label="binary_relevance_threshold",
+        minimum=1,
+    )
+    relevance_levels = sorted(
+        {
+            relevance
+            for judgments in qrels.values()
+            for relevance in judgments.values()
+        }
+    )
+    if any(relevance < 0 for relevance in relevance_levels):
+        raise RetrievalContractError("qrels relevance levels must be non-negative")
+    no_positive = sorted(
+        qid
+        for qid, judgments in qrels.items()
+        if not any(relevance >= rel_threshold for relevance in judgments.values())
+    )
+    if no_positive:
+        raise RetrievalContractError(
+            f"{len(no_positive)} qrels topics have no relevance >= "
+            f"{rel_threshold}; first: {', '.join(no_positive[:5])}"
+        )
+
+    metrics = evaluate_internal_trec_scope(
+        bm25_run,
+        qrels,
+        rel_threshold=rel_threshold,
+    )
+    expected_metrics = contract.get("expected_bm25_metrics")
+    if not isinstance(expected_metrics, dict) or not expected_metrics:
+        raise RetrievalContractError("expected_bm25_metrics: expected an object")
+    tolerance_value = contract.get("metric_tolerance", 0.0)
+    if isinstance(tolerance_value, bool) or not isinstance(
+        tolerance_value, (int, float)
+    ):
+        raise RetrievalContractError("metric_tolerance must be a number")
+    tolerance = float(tolerance_value)
+    if not math.isfinite(tolerance) or tolerance < 0:
+        raise RetrievalContractError("metric_tolerance must be finite and non-negative")
+    deltas: dict[str, float] = {}
+    normalized_expected_metrics: dict[str, float] = {}
+    for name, expected in expected_metrics.items():
+        if name not in metrics:
+            raise RetrievalContractError(f"recomputed metrics are missing {name}")
+        normalized_expected = _require_unit_float(
+            expected,
+            label=f"expected_bm25_metrics.{name}",
+        )
+        normalized_expected_metrics[name] = normalized_expected
+        delta = abs(float(metrics[name]) - normalized_expected)
+        deltas[name] = delta
+        if delta > tolerance:
+            raise RetrievalContractError(
+                f"{name}: metric drift {delta:.3g} exceeds tolerance {tolerance:g}"
+            )
+
+    try:
+        contract_relative = contract_source.relative_to(root).as_posix()
+        pointer_relative = pointer_path.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise RetrievalContractError(
+            "contract and release pointer must be inside the project root"
+        ) from exc
+
+    return {
+        "schema": REPORT_SCHEMA,
+        "verified": True,
+        "contract": contract_relative,
+        "dataset_id": contract.get("dataset_id"),
+        "analysis_base_commit": contract.get("analysis_base_commit"),
+        "experiment_commit": contract.get("experiment_commit"),
+        "release": {
+            "pointer_path": pointer_relative,
+            "repository": release.get("repository"),
+            "tag": release.get("tag"),
+            "asset": release.get("asset"),
+        },
+        "inputs": verified_inputs,
+        "scope": {
+            **observed_counts,
+            "bm25": bm25_shape,
+            "ce": ce_shape,
+        },
+        "integrity": {
+            "qrels_queries_covered_by_source": True,
+            "run_queries_equal_qrels_queries": True,
+            "qrels_documents_covered_by_corpus": True,
+            "run_documents_covered_by_corpus": True,
+            "bm25_ce_candidate_sets_equal": True,
+            "duplicates_rank_gaps_and_non_finite_scores_absent": True,
+        },
+        "evaluation": trec_metric_contract(
+            rel_threshold=rel_threshold,
+            ks_mrr=(10,),
+            ks_ndcg=(10,),
+            ks_recall=(100, 1000),
+            run_depth=bm25_shape["depth"],
+        ),
+        "qrels_relevance_levels": relevance_levels,
+        "bm25_metrics": {
+            name: float(metrics[name]) for name in expected_metrics
+        },
+        "expected_bm25_metrics": normalized_expected_metrics,
+        "absolute_deltas": deltas,
+        "max_abs_delta": max(deltas.values(), default=0.0),
+        "metric_tolerance": tolerance,
+    }

--- a/src/msmarco_genqa/evaluation/trec.py
+++ b/src/msmarco_genqa/evaluation/trec.py
@@ -116,7 +116,10 @@ def read_qrels(
     qrels: dict[str, dict[str, int]] = {}
     seen: set[tuple[str, str]] = set()
     try:
-        with p.open(encoding="utf-8") as handle:
+        # ``utf-8-sig`` is identical to UTF-8 for ordinary files and removes
+        # a leading BOM when a public qrels export was written by a Windows
+        # tool. Without this, the first qid becomes a distinct hidden value.
+        with p.open(encoding="utf-8-sig") as handle:
             for line_number, raw_line in enumerate(handle, start=1):
                 line = raw_line.strip()
                 if not line:

--- a/src/msmarco_genqa/evaluation/trec.py
+++ b/src/msmarco_genqa/evaluation/trec.py
@@ -124,10 +124,24 @@ def read_qrels(
                 line = raw_line.strip()
                 if not line:
                     raise QrelsFormatError(p, line_number, "empty line")
+                fields = line.split()
+                if line_number == 1 and fields == [
+                    "query-id",
+                    "corpus-id",
+                    "score",
+                ]:
+                    if qrels_format not in {"auto", "three-column"}:
+                        raise QrelsFormatError(
+                            p,
+                            line_number,
+                            "ir_datasets three-column header requires "
+                            "qrels_format='auto' or 'three-column'",
+                        )
+                    continue
                 qid, doc_id, relevance = _parse_qrels_fields(
                     p,
                     line_number,
-                    line.split(),
+                    fields,
                     qrels_format,
                 )
                 if not qid:

--- a/tests/test_first_stage_coverage.py
+++ b/tests/test_first_stage_coverage.py
@@ -1,0 +1,190 @@
+"""Tests for fixed-output first-stage coverage diagnostics."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from msmarco_genqa.evaluation.first_stage_coverage import (
+    FirstStageCoverageError,
+    analyze_first_stage_coverage,
+    assert_first_stage_diagnostic_fingerprint,
+    deterministic_bucket_samples,
+    first_hit_bucket,
+    first_stage_diagnostic_fingerprint,
+    relevant_coverage_at_100_bucket,
+    render_first_stage_coverage_markdown,
+)
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected"),
+    [
+        (1, "top_10"),
+        (10, "top_10"),
+        (11, "ranks_11_100"),
+        (100, "ranks_11_100"),
+        (101, "ranks_101_1000"),
+        (1000, "ranks_101_1000"),
+        (None, "miss_top_1000"),
+    ],
+)
+def test_first_hit_bucket_boundaries(rank, expected):
+    assert first_hit_bucket(rank) == expected
+
+
+@pytest.mark.parametrize("rank", [0, -1, 1.5, True])
+def test_first_hit_bucket_rejects_invalid_ranks(rank):
+    with pytest.raises(FirstStageCoverageError):
+        first_hit_bucket(rank)
+
+
+@pytest.mark.parametrize(
+    ("coverage", "expected"),
+    [
+        (0.0, "none"),
+        (0.01, "partial_lt_25pct"),
+        (0.249999, "partial_lt_25pct"),
+        (0.25, "partial_25_to_lt_50pct"),
+        (0.499999, "partial_25_to_lt_50pct"),
+        (0.5, "partial_50_to_lt_100pct"),
+        (0.999999, "partial_50_to_lt_100pct"),
+        (1.0, "complete"),
+    ],
+)
+def test_relevant_coverage_bucket_boundaries(coverage, expected):
+    assert relevant_coverage_at_100_bucket(coverage) == expected
+
+
+@pytest.mark.parametrize("coverage", [-0.1, 1.1, math.inf, math.nan])
+def test_relevant_coverage_bucket_rejects_invalid_values(coverage):
+    with pytest.raises(FirstStageCoverageError):
+        relevant_coverage_at_100_bucket(coverage)
+
+
+def _synthetic_analysis():
+    qrels = {
+        "q1": {"d1": 1, "d2": 2},
+        "q2": {"d3": 1},
+        "q3": {"d4": 1, "d5": 1},
+        "q4": {"d6": 1},
+    }
+    queries = {qid: f"query {qid}" for qid in qrels}
+    run = {
+        "q1": [
+            ("d1", 5.0),
+            *[(f"x1-{rank}", 4.0 - rank / 1000) for rank in range(2, 101)],
+            ("d2", 1.0),
+        ],
+        "q2": [
+            *[(f"x2-{rank}", 4.0 - rank / 1000) for rank in range(1, 50)],
+            ("d3", 1.0),
+        ],
+        "q3": [
+            *[(f"x3-{rank}", 4.0 - rank / 1000) for rank in range(1, 500)],
+            ("d4", 1.0),
+        ],
+        "q4": [(f"x4-{rank}", 4.0 - rank / 1000) for rank in range(1, 1001)],
+    }
+    return analyze_first_stage_coverage(run, qrels, queries)
+
+
+def test_analysis_reconciles_macro_micro_and_candidate_set_counts():
+    report = _synthetic_analysis()
+
+    assert report["scope"]["n_queries"] == 4
+    assert report["scope"]["n_positive_qrels"] == 6
+    assert report["macro_recall"]["recall@100"] == pytest.approx(0.375)
+    assert report["macro_recall"]["recall@1000"] == pytest.approx(0.625)
+    assert report["micro_qrels_coverage"]["recall@100"] == pytest.approx(2 / 6)
+    assert report["micro_qrels_coverage"]["recall@1000"] == pytest.approx(4 / 6)
+    assert report["candidate_set_diagnostic"] == {
+        "queries_with_any_relevant_in_top_100": 2,
+        "queries_with_no_relevant_in_top_100": 2,
+        "queries_with_complete_relevant_coverage_at_100": 1,
+        "queries_with_partial_relevant_coverage_at_100": 1,
+        "positive_qrels_in_top_100": 2,
+        "positive_qrels_outside_top_100": 4,
+    }
+    assert report["depth_100_to_1000_diagnostic"][
+        "additional_positive_qrels_found"
+    ] == 2
+    assert report["reconciliation"]["first_hit_bucket_queries"] == 4
+    assert report["reconciliation"]["coverage_at_100_bucket_queries"] == 4
+
+
+def test_analysis_assigns_expected_query_buckets():
+    rows = {row["qid"]: row for row in _synthetic_analysis()["per_query"]}
+
+    assert rows["q1"]["first_hit_bucket"] == "top_10"
+    assert rows["q1"]["coverage_at_100_bucket"] == "partial_50_to_lt_100pct"
+    assert rows["q2"]["first_hit_bucket"] == "ranks_11_100"
+    assert rows["q2"]["coverage_at_100_bucket"] == "complete"
+    assert rows["q3"]["first_hit_bucket"] == "ranks_101_1000"
+    assert rows["q3"]["coverage_at_100_bucket"] == "none"
+    assert rows["q4"]["first_hit_bucket"] == "miss_top_1000"
+    assert rows["q4"]["coverage_at_100_bucket"] == "none"
+
+
+def test_analysis_rejects_missing_or_extra_run_queries():
+    qrels = {"q1": {"d1": 1}}
+    queries = {"q1": "query"}
+
+    with pytest.raises(FirstStageCoverageError, match="qid mismatch"):
+        analyze_first_stage_coverage({}, qrels, queries)
+    with pytest.raises(FirstStageCoverageError, match="qid mismatch"):
+        analyze_first_stage_coverage(
+            {"q1": [("d1", 1.0)], "extra": [("d2", 0.0)]},
+            qrels,
+            queries,
+        )
+
+
+def test_deterministic_samples_are_stable_and_cover_observed_buckets():
+    rows = _synthetic_analysis()["per_query"]
+
+    first = deterministic_bucket_samples(rows, per_bucket=1, seed="fixed")
+    second = deterministic_bucket_samples(rows, per_bucket=1, seed="fixed")
+
+    assert first == second
+    assert {
+        (row["sample_dimension"], row["sample_bucket"]) for row in first
+    } == {
+        ("first_hit_bucket", "top_10"),
+        ("first_hit_bucket", "ranks_11_100"),
+        ("first_hit_bucket", "ranks_101_1000"),
+        ("first_hit_bucket", "miss_top_1000"),
+        ("coverage_at_100_bucket", "none"),
+        ("coverage_at_100_bucket", "partial_50_to_lt_100pct"),
+        ("coverage_at_100_bucket", "complete"),
+    }
+
+
+def test_diagnostic_fingerprint_is_exact_and_rejects_drift():
+    report = _synthetic_analysis()
+    expected = first_stage_diagnostic_fingerprint(report)
+
+    assert_first_stage_diagnostic_fingerprint(report, expected)
+    drifted = {**expected, "positive_qrels_in_top_100": 999}
+    with pytest.raises(FirstStageCoverageError, match="diagnostic drift"):
+        assert_first_stage_diagnostic_fingerprint(report, drifted)
+
+
+def test_markdown_states_definitions_and_interpretation_boundary():
+    report = _synthetic_analysis()
+    samples = deterministic_bucket_samples(report["per_query"], per_bucket=1)
+    report = {key: value for key, value in report.items() if key != "per_query"}
+
+    markdown = render_first_stage_coverage_markdown(
+        report,
+        dataset_id="beir/nfcorpus/test",
+        contract_path="configs/contract.json",
+        release_tag="v1",
+        samples=samples,
+    )
+
+    assert "`ranks_101_1000`" in markdown
+    assert "Macro (headline definition)" in markdown
+    assert "Micro qrels coverage (diagnostic only)" in markdown
+    assert "Interpretation Boundary" in markdown

--- a/tests/test_retrieval_contract.py
+++ b/tests/test_retrieval_contract.py
@@ -1,0 +1,229 @@
+"""Tests for frozen retrieval data and metric contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from msmarco_genqa.evaluation.retrieval_contract import (
+    RetrievalContractError,
+    verify_retrieval_contract,
+)
+
+
+def _file_record(path: Path, root: Path) -> dict[str, object]:
+    return {
+        "path": path.relative_to(root).as_posix(),
+        "bytes": path.stat().st_size,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+
+
+def _write_run(
+    path: Path,
+    rows: dict[str, list[tuple[str, float]]],
+    *,
+    system: str,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"{qid}\tQ0\t{doc_id}\t{rank}\t{score}\t{system}"
+        for qid in sorted(rows)
+        for rank, (doc_id, score) in enumerate(rows[qid], start=1)
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def _make_contract(root: Path) -> Path:
+    source = root / "inputs" / "source.zip"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    query_rows = [
+        {"_id": "q1", "text": "one"},
+        {"_id": "q2", "text": "two"},
+        {"_id": "train-only", "text": "extra"},
+    ]
+    corpus_rows = [
+        {"_id": "d1", "text": "one"},
+        {"_id": "d2", "text": "two"},
+        {"_id": "x1", "text": "other"},
+        {"_id": "x2", "text": "other"},
+    ]
+    with zipfile.ZipFile(source, "w") as archive:
+        archive.writestr(
+            "nfcorpus/queries.jsonl",
+            "".join(json.dumps(row) + "\n" for row in query_rows),
+        )
+        archive.writestr(
+            "nfcorpus/corpus.jsonl",
+            "".join(json.dumps(row) + "\n" for row in corpus_rows),
+        )
+
+    qrels = root / "inputs" / "qrels.trec"
+    qrels.write_text("q1 0 d1 1\nq2 0 d2 2\n", encoding="utf-8", newline="\n")
+    bm25 = root / "inputs" / "bm25.tsv"
+    ce = root / "inputs" / "ce.tsv"
+    _write_run(
+        bm25,
+        {"q1": [("d1", 2.0), ("x1", 1.0)], "q2": [("d2", 2.0), ("x2", 1.0)]},
+        system="bm25",
+    )
+    _write_run(
+        ce,
+        {"q1": [("d1", 3.0)], "q2": [("d2", 3.0)]},
+        system="bm25_ce",
+    )
+
+    release_asset = root / "inputs" / "release.zip"
+    release_asset.write_bytes(b"release fixture")
+    pointer = {
+        "release": {
+            "repository": "GioiaZheng/msmarco-genqa",
+            "tag": "fixture",
+            "asset": "release.zip",
+        },
+        "download": {
+            "bytes": release_asset.stat().st_size,
+            "sha256": hashlib.sha256(release_asset.read_bytes()).hexdigest(),
+        },
+    }
+    pointer_path = root / "artifacts" / "pointer.json"
+    pointer_path.parent.mkdir(parents=True, exist_ok=True)
+    pointer_path.write_text(json.dumps(pointer), encoding="utf-8", newline="\n")
+
+    contract = {
+        "schema": "msmarco-genqa.retrieval-data-metric-contract.v1",
+        "dataset_id": "beir/nfcorpus/test",
+        "analysis_base_commit": "a" * 40,
+        "experiment_commit": "b" * 12,
+        "release": {
+            "pointer_path": pointer_path.relative_to(root).as_posix(),
+            **pointer["release"],
+        },
+        "inputs": {
+            "release_asset": _file_record(release_asset, root),
+            "source_archive": {
+                **_file_record(source, root),
+                "query_member": "nfcorpus/queries.jsonl",
+                "corpus_member": "nfcorpus/corpus.jsonl",
+            },
+            "qrels": _file_record(qrels, root),
+            "bm25_run": {
+                **_file_record(bm25, root),
+                "query_count": 2,
+                "row_count": 4,
+                "depth": 2,
+            },
+            "ce_run": {
+                **_file_record(ce, root),
+                "query_count": 2,
+                "row_count": 2,
+                "depth": 1,
+            },
+        },
+        "expected_counts": {
+            "source_queries": 3,
+            "corpus_documents": 4,
+            "test_queries": 2,
+            "qrels_judgments": 2,
+        },
+        "qrels_format": "trec",
+        "binary_relevance_threshold": 1,
+        "expected_bm25_metrics": {
+            "mrr@10": 1.0,
+            "ndcg@10": 1.0,
+            "recall@100": 1.0,
+            "recall@1000": 1.0,
+        },
+        "metric_tolerance": 1e-12,
+    }
+    contract_path = root / "configs" / "contract.json"
+    contract_path.parent.mkdir(parents=True, exist_ok=True)
+    contract_path.write_text(
+        json.dumps(contract, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return contract_path
+
+
+def test_contract_verifies_structure_identifiers_and_metrics(tmp_path: Path) -> None:
+    contract_path = _make_contract(tmp_path)
+
+    report = verify_retrieval_contract(contract_path, project_root=tmp_path)
+
+    assert report["verified"] is True
+    assert report["scope"]["test_queries"] == 2
+    assert report["scope"]["bm25"] == {
+        "query_count": 2,
+        "row_count": 4,
+        "depth": 2,
+    }
+    assert report["scope"]["ce"]["depth"] == 1
+    assert report["max_abs_delta"] == 0.0
+    assert all(report["integrity"].values())
+
+
+def test_contract_rejects_release_or_input_hash_drift(tmp_path: Path) -> None:
+    contract_path = _make_contract(tmp_path)
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    bm25 = tmp_path / contract["inputs"]["bm25_run"]["path"]
+    bm25.write_text(
+        bm25.read_text(encoding="utf-8") + "q3\tQ0\td1\t1\t1.0\tbm25\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    with pytest.raises(RetrievalContractError, match="byte-size drift"):
+        verify_retrieval_contract(contract_path, project_root=tmp_path)
+
+
+def test_contract_rejects_unknown_document_ids(tmp_path: Path) -> None:
+    contract_path = _make_contract(tmp_path)
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    bm25 = tmp_path / contract["inputs"]["bm25_run"]["path"]
+    text = bm25.read_text(encoding="utf-8").replace("x2", "unknown")
+    bm25.write_text(text, encoding="utf-8", newline="\n")
+    contract["inputs"]["bm25_run"].update(_file_record(bm25, tmp_path))
+    contract_path.write_text(json.dumps(contract), encoding="utf-8", newline="\n")
+
+    with pytest.raises(RetrievalContractError, match="absent from the source"):
+        verify_retrieval_contract(contract_path, project_root=tmp_path)
+
+
+def test_contract_rejects_ce_candidate_set_changes(tmp_path: Path) -> None:
+    contract_path = _make_contract(tmp_path)
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    ce = tmp_path / contract["inputs"]["ce_run"]["path"]
+    text = ce.read_text(encoding="utf-8").replace(
+        "q2\tQ0\td2", "q2\tQ0\tx2"
+    )
+    ce.write_text(text, encoding="utf-8", newline="\n")
+    contract["inputs"]["ce_run"].update(_file_record(ce, tmp_path))
+    contract_path.write_text(json.dumps(contract), encoding="utf-8", newline="\n")
+
+    with pytest.raises(RetrievalContractError, match="candidate set differs"):
+        verify_retrieval_contract(contract_path, project_root=tmp_path)
+
+
+def test_contract_rejects_metric_drift(tmp_path: Path) -> None:
+    contract_path = _make_contract(tmp_path)
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    contract["expected_bm25_metrics"]["mrr@10"] = 0.5
+    contract_path.write_text(json.dumps(contract), encoding="utf-8", newline="\n")
+
+    with pytest.raises(RetrievalContractError, match="metric drift"):
+        verify_retrieval_contract(contract_path, project_root=tmp_path)
+
+
+def test_contract_rejects_non_finite_expected_metric(tmp_path: Path) -> None:
+    contract_path = _make_contract(tmp_path)
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    contract["expected_bm25_metrics"]["mrr@10"] = float("nan")
+    contract_path.write_text(json.dumps(contract), encoding="utf-8", newline="\n")
+
+    with pytest.raises(RetrievalContractError, match="finite number"):
+        verify_retrieval_contract(contract_path, project_root=tmp_path)

--- a/tests/test_trec_cross_check.py
+++ b/tests/test_trec_cross_check.py
@@ -132,6 +132,28 @@ def test_qrels_reader_strips_utf8_bom_from_first_qid(tmp_path):
     }
 
 
+@pytest.mark.parametrize("qrels_format", ["auto", "three-column"])
+def test_qrels_reader_accepts_ir_datasets_three_column_header(
+    tmp_path, qrels_format
+):
+    path = tmp_path / "qrels.txt"
+    path.write_text(
+        "query-id\tcorpus-id\tscore\r\nq1\td1\t2\r\n",
+        encoding="utf-8",
+        newline="",
+    )
+
+    assert read_qrels(path, qrels_format=qrels_format) == {"q1": {"d1": 2}}
+
+
+def test_qrels_reader_rejects_header_with_wrong_explicit_format(tmp_path):
+    path = tmp_path / "qrels.txt"
+    path.write_text("query-id\tcorpus-id\tscore\nq1\td1\t2\n")
+
+    with pytest.raises(QrelsFormatError, match="three-column header requires"):
+        read_qrels(path, qrels_format="trec")
+
+
 def test_ambiguous_qrels_requires_explicit_format(tmp_path):
     path = tmp_path / "qrels.txt"
     path.write_text("q1 0 d1 0\n")

--- a/tests/test_trec_cross_check.py
+++ b/tests/test_trec_cross_check.py
@@ -123,6 +123,15 @@ def test_qrels_layouts(tmp_path, content, qrels_format):
     assert read_qrels(path, qrels_format=qrels_format) == {"q1": {"d1": 1}}
 
 
+def test_qrels_reader_strips_utf8_bom_from_first_qid(tmp_path):
+    path = tmp_path / "qrels.txt"
+    path.write_text("q1 d1 1\nq1 d2 1\n", encoding="utf-8-sig")
+
+    assert read_qrels(path, qrels_format="three-column") == {
+        "q1": {"d1": 1, "d2": 1}
+    }
+
+
 def test_ambiguous_qrels_requires_explicit_format(tmp_path):
     path = tmp_path / "qrels.txt"
     path.write_text("q1 0 d1 0\n")


### PR DESCRIPTION
## Summary

- freeze the public NFCorpus release, source archive, qrels, BM25 run, and CE run behind an exact data/metric contract;
- add a query-level first-stage coverage analysis with deterministic bucket sampling and drift detection;
- document the aggregate diagnosis in `RESULTS.md` and a focused technical note;
- add `make analyze-nfcorpus-first-stage` to recover the public inputs and reproduce the analysis without rebuilding an index, rerunning BM25, or invoking the cross-encoder.

## Result

For the fixed NFCorpus BM25 run:

- 251/323 queries have at least one relevant document in the top-100 candidate set;
- 72/323 have no relevant top-100 candidate, so the fixed reranker cannot recover a judged relevant document for those queries;
- 24 queries receive their first relevant hit only at ranks 101–1000, while 48 still have no relevant hit at depth 1000;
- macro Recall rises from 0.2378 at 100 to 0.4572 at 1000, but 6,753 of 12,334 positive qrels remain unretrieved.

These are descriptive findings for one frozen run. They do not introduce a new retriever or make an architectural claim.

## Reproduction

```bash
make analyze-nfcorpus-first-stage
```

The command verifies the public Release archive and every member, recovers the original NFCorpus files through a repository-local `ir_datasets` cache, reproduces the published metrics, checks the exact analysis fingerprint, and writes the query-level outputs under ignored `outputs/analysis/` paths.

## Validation

- public BEIR release reproduction: four rows reproduced with maximum absolute delta 0;
- NFCorpus contract: 323 queries, 323,000 BM25 rows at depth 1000, 32,300 CE rows at depth 100, metric delta 0;
- test suite: 627 passed, 1 skipped, 1 deselected;
- `ruff check src tests experiments scripts`;
- headline and fixture metric checks;
- notebook, artifact-boundary, artifact-registry including Git history, generated-table, and high-confidence secret checks.

Progresses #19.