### PR TITLE
analysis: evaluate NFCorpus video query representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The repository includes runnable code plus written analysis artifacts:
 - [`docs/retrieval_lift_analysis.md`](docs/retrieval_lift_analysis.md) — query-level reranker lift analysis protocol.
 - [`docs/nfcorpus_first_stage_error_analysis.md`](docs/nfcorpus_first_stage_error_analysis.md) — fixed-output NFCorpus candidate-set coverage diagnosis.
 - [`docs/nfcorpus_first_stage_taxonomy_review.md`](docs/nfcorpus_first_stage_taxonomy_review.md) — complete 72-query review of NFCorpus source-context and first-stage failures.
+- [`docs/reports/2026-07-28-nfcorpus-video-query-representation.md`](docs/reports/2026-07-28-nfcorpus-video-query-representation.md) — controlled 102-query test of bounded NFCorpus source context.
 - [`docs/context_packing.md`](docs/context_packing.md) — prompt compression, provenance, and packed-vs-plain generation comparison.
 - [`docs/rag_triad_evaluation.md`](docs/rag_triad_evaluation.md) — context relevance, groundedness, and answer relevance report protocol.
 - [`docs/input_validation.md`](docs/input_validation.md) — run-file, JSONL, prompt, and serving input validation contract.
@@ -653,6 +654,16 @@ retriever capacity rather than an architecture verdict. See
 [`docs/nfcorpus_first_stage_error_analysis.md`](docs/nfcorpus_first_stage_error_analysis.md)
 and the
 [`72-case taxonomy review`](docs/nfcorpus_first_stage_taxonomy_review.md).
+
+The predeclared follow-up changes only the query representation on the official
+102-query NFCorpus test/video subset. Combining the BEIR title with the bounded
+official description raises BM25 Recall@100 from 0.2821 to 0.3700
+(`+0.0880`, paired 95% CI `[+0.0535, +0.1265]`) and reduces no-hit-at-100
+queries from 11 to 4. Description alone has a positive point estimate, but its
+primary interval crosses zero. This is evidence of missing source context on
+the video subset, not an architecture or full-dataset generalization result.
+See the
+[`query-representation report`](docs/reports/2026-07-28-nfcorpus-video-query-representation.md).
 
 The four ranked runs are published as a checksummed, text-only
 [GitHub Release bundle](https://github.com/GioiaZheng/msmarco-genqa/releases/tag/v2.2-beir-cross-domain-baselines).

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -163,6 +163,35 @@ recoverable from the exported page title alone. The case-level evidence,
 taxonomy contract, limitations, and exact reproduction command are in
 [`docs/nfcorpus_first_stage_taxonomy_review.md`](docs/nfcorpus_first_stage_taxonomy_review.md).
 
+### NFCorpus bounded query-representation experiment
+
+The predeclared follow-up holds the 102-query test/video cohort, corpus, qrels,
+BM25 index, retriever parameters, reranker, and architecture fixed while
+changing only the query text:
+
+| Representation | System | MRR@10 | nDCG@10 | Recall@100 | Recall@1000 |
+|---|---|---:|---:|---:|---:|
+| Title | BM25 | 0.4780 | 0.2493 | 0.2821 | 0.4919 |
+| Description | BM25 | 0.5308 | 0.2929 | 0.3272 | 0.6413 |
+| Title + description | BM25 | **0.6036** | **0.3457** | **0.3700** | **0.6723** |
+| Title | BM25 + CE | 0.5220 | 0.2980 | 0.2821 | n/a |
+| Description | BM25 + CE | 0.6357 | 0.3568 | 0.3272 | n/a |
+| Title + description | BM25 + CE | **0.6689** | **0.3853** | **0.3700** | n/a |
+
+For the primary Recall@100 comparison, description alone improves the point
+estimate by `+0.0451`, but its paired 95% interval crosses zero
+(`[-0.0024, +0.0943]`, `p = 0.0610`). Title plus description gives a
+`+0.0880` improvement with interval `[+0.0535, +0.1265]` and
+`p < 0.0002`. It reduces no-hit-at-100 queries from 11 to 4 and no-hit-at-1000
+queries from 8 to 0.
+
+All 306 reranker candidate-set checks pass, and independent `ir-measures`
+evaluation agrees with the project evaluator within `1e-12`. The result
+supports a source-context limitation on this official video subset, not a
+general architecture, cross-dataset, generation, or grounding claim. The
+complete paired results and interpretation boundary are in
+[`docs/reports/2026-07-28-nfcorpus-video-query-representation.md`](docs/reports/2026-07-28-nfcorpus-video-query-representation.md).
+
 ## Query-Type Slice
 
 Token-F1 lift by query type:
@@ -197,7 +226,7 @@ corpus retrieval.
 
 | Status | Boundary |
 |---|---|
-| Validated | The paired T5-small generation comparison on MS MARCO `dev/small`; full-corpus BM25 plus cross-encoder retrieval on TREC-DL 2019/2020; full-corpus BM25 plus fixed top-100 cross-encoder reranking on BEIR NFCorpus and SciFact. |
+| Validated | The paired T5-small generation comparison on MS MARCO `dev/small`; full-corpus BM25 plus cross-encoder retrieval on TREC-DL 2019/2020; full-corpus BM25 plus fixed top-100 cross-encoder reranking on BEIR NFCorpus and SciFact; the bounded query-representation comparison on the official 102-query NFCorpus test/video subset. |
 | Implemented but not yet evaluated | The T5-base generator-capacity sweep and configurable alternative-generator paths. Their existence is not an empirical result. |
 | Not supported by current evidence | Retrieval lift transfers to generation on TREC-DL or BEIR; a fair full-corpus dense-vs-BM25 conclusion; broad cross-domain RAG generalization beyond the two evaluated retrieval collections. |
 

--- a/configs/nfcorpus_video_query_representation.json
+++ b/configs/nfcorpus_video_query_representation.json
@@ -119,12 +119,17 @@
       "positive_score_recall@100": 0.2820649478633883,
       "positive_score_recall@1000": 0.4587958058307442
     },
-    "deterministic_tie_bm25": null,
+    "deterministic_tie_bm25": {
+      "mrr@10": 0.47801898537192655,
+      "ndcg@10": 0.2492523025557319,
+      "recall@100": 0.2820649478633883,
+      "recall@1000": 0.4918916912361657
+    },
     "deterministic_tie_bm25_ce": null
   },
   "acceptance_checks": [
-    "Before freezing the deterministic title baseline, the title condition reproduces the published MRR@10, nDCG@10, and positive-score Recall@100/1000 invariants within 1e-12.",
-    "After freezing, the deterministic title condition reproduces every recorded metric within 1e-12.",
+    "The deterministic title condition reproduces every recorded metric within 1e-12.",
+    "Published fixed-run deltas and positive-score recall are retained as diagnostics, not cross-platform acceptance guards.",
     "All three conditions contain the same 102 qids exactly once.",
     "The corpus, qrels, BM25 parameters, and index fingerprint are identical across conditions.",
     "Each reranked run contains exactly the corresponding BM25 top-100 candidate set per qid.",

--- a/configs/nfcorpus_video_query_representation.json
+++ b/configs/nfcorpus_video_query_representation.json
@@ -73,6 +73,7 @@
     "reranker": "cross-encoder/ms-marco-MiniLM-L-6-v2",
     "rerank_depth": 100,
     "index_policy": "Reuse one corpus index across all query representations",
+    "ranking_tie_break": "Retrieve the full 3,633-document corpus, then sort by score descending and doc_id ascending before top-k truncation.",
     "architecture_changes": false,
     "training": false
   },
@@ -113,10 +114,17 @@
       "mrr@10": 0.517110177404295,
       "ndcg@10": 0.29720633866694945,
       "recall@100": 0.2820649478633883
-    }
+    },
+    "positive_score_bm25": {
+      "positive_score_recall@100": 0.2820649478633883,
+      "positive_score_recall@1000": 0.4587958058307442
+    },
+    "deterministic_tie_bm25": null,
+    "deterministic_tie_bm25_ce": null
   },
   "acceptance_checks": [
-    "The title condition reproduces the frozen 102-query BM25 slice within 1e-12 for every metric.",
+    "Before freezing the deterministic title baseline, the title condition reproduces the published MRR@10, nDCG@10, and positive-score Recall@100/1000 invariants within 1e-12.",
+    "After freezing, the deterministic title condition reproduces every recorded metric within 1e-12.",
     "All three conditions contain the same 102 qids exactly once.",
     "The corpus, qrels, BM25 parameters, and index fingerprint are identical across conditions.",
     "Each reranked run contains exactly the corresponding BM25 top-100 candidate set per qid.",

--- a/configs/nfcorpus_video_query_representation.json
+++ b/configs/nfcorpus_video_query_representation.json
@@ -11,6 +11,7 @@
     },
     "official_nfcorpus_v1": {
       "dataset_id": "nfcorpus/test/video",
+      "path": "outputs/reproductions/beir_irds_cache/downloads/49c061fbadc52ba4d35d0e42e2d742fd",
       "url": "https://www.cl.uni-heidelberg.de/downloads/statnlp/nfcorpus.tar.gz",
       "released": "2016-02-19",
       "bytes": 31039523,

--- a/configs/nfcorpus_video_query_representation.json
+++ b/configs/nfcorpus_video_query_representation.json
@@ -125,7 +125,11 @@
       "recall@100": 0.2820649478633883,
       "recall@1000": 0.4918916912361657
     },
-    "deterministic_tie_bm25_ce": null
+    "deterministic_tie_bm25_ce": {
+      "mrr@10": 0.5220121381886088,
+      "ndcg@10": 0.29800270457307226,
+      "recall@100": 0.2820649478633883
+    }
   },
   "acceptance_checks": [
     "The deterministic title condition reproduces every recorded metric within 1e-12.",

--- a/configs/nfcorpus_video_query_representation.json
+++ b/configs/nfcorpus_video_query_representation.json
@@ -1,0 +1,130 @@
+{
+  "schema": "msmarco-genqa.nfcorpus-video-query-representation.v1",
+  "issue": "https://github.com/GioiaZheng/msmarco-genqa/issues/19",
+  "baseline_commit": "cb1b02642af96347911745041478d34867a9e112",
+  "research_question": "Does bounded source-page context improve NFCorpus first-stage retrieval without changing the corpus, judgments, retriever, reranker, or architecture?",
+  "inputs": {
+    "beir_source_archive": {
+      "path": "outputs/reproductions/beir_irds_cache/beir/nfcorpus/source.zip",
+      "bytes": 2448432,
+      "sha256": "efe5be03f8c5b86a5870102d0599d227c8c6e2484328e68c6522560385671b0b"
+    },
+    "official_nfcorpus_v1": {
+      "dataset_id": "nfcorpus/test/video",
+      "url": "https://www.cl.uni-heidelberg.de/downloads/statnlp/nfcorpus.tar.gz",
+      "released": "2016-02-19",
+      "bytes": 31039523,
+      "md5": "49c061fbadc52ba4d35d0e42e2d742fd",
+      "sha256": "e2325ace35d02185a22e96bb52e72e62f2caf45a4975757c81a1c4087d8c59e9",
+      "note": "The ir_datasets 0.6.1 metadata points to an obsolete URL. Use the current official download URL and retain the published integrity check."
+    },
+    "beir_qrels": {
+      "member": "nfcorpus/qrels/test.tsv",
+      "relevance_threshold": 1,
+      "n_qrels": 12334
+    },
+    "beir_corpus": {
+      "member": "nfcorpus/corpus.jsonl",
+      "n_documents": 3633
+    }
+  },
+  "cohort": {
+    "name": "official_test_video",
+    "n_queries": 102,
+    "qid_sha256": "55dc5fa5b71077fd35046d45b674d70a0d033dad7eaacb83c56032e60347213f",
+    "qid_sha256_canonicalization": "UTF-8 encoding of lexicographically sorted qids, one qid plus newline per record.",
+    "official_query_records_sha256": "ce1886625fc73d92311ac9b97240489503cb94670a25f67e034c6ffffd89a61f",
+    "official_query_records_sha256_canonicalization": "UTF-8 JSON Lines ordered by qid; each compact sorted-key record contains qid, title, and description, followed by newline.",
+    "membership_rule": "Exact qid intersection with nfcorpus/test/video; no outcome-based query selection.",
+    "required_alignment": {
+      "video_qids_match_beir_url_group": true,
+      "normalized_official_titles_match_beir_text": true,
+      "mapped_qrels_match_beir_exactly": true,
+      "retained_relevant_docids_present_in_beir_corpus": true
+    }
+  },
+  "query_representations": {
+    "title": {
+      "source": "BEIR query text",
+      "construction": "Normalize Unicode and collapse whitespace only.",
+      "role": "Primary baseline"
+    },
+    "description": {
+      "source": "Official NFCorpus video description",
+      "construction": "Normalize Unicode and collapse whitespace only.",
+      "role": "Primary treatment"
+    },
+    "title_plus_description": {
+      "source": "BEIR query text plus official NFCorpus video description",
+      "construction": "Normalize each field, join with one newline, then collapse repeated whitespace within each field.",
+      "role": "Primary treatment"
+    }
+  },
+  "excluded_conditions": {
+    "official_all_fields": "Not a primary treatment: median 192 words, 136 of 323 shared queries exceed 512 words, and the field contains full source-page content connected to qrel construction.",
+    "live_page_scraping": "Not reproducible against the 2015 crawl and may introduce temporal drift.",
+    "qrel_or_document_conditioning": "No qrel, relevant document, ranked document, or metric result may be read while constructing query text.",
+    "manual_query_rewriting": "No case-specific edits are allowed."
+  },
+  "fixed_system": {
+    "retriever": "Existing project BM25 implementation and parameters",
+    "corpus": "BEIR NFCorpus corpus from the pinned source archive",
+    "reranker": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    "rerank_depth": 100,
+    "index_policy": "Reuse one corpus index across all query representations",
+    "architecture_changes": false,
+    "training": false
+  },
+  "evaluation": {
+    "primary_metric": "recall@100",
+    "secondary_metrics": [
+      "mrr@10",
+      "ndcg@10",
+      "recall@1000"
+    ],
+    "paired_query_metrics": [
+      "reciprocal_rank@10",
+      "ndcg@10",
+      "recall@100",
+      "recall@1000"
+    ],
+    "bootstrap_resamples": 10000,
+    "bootstrap_seed": 20260727,
+    "confidence_level": 0.95,
+    "report_no_hit_counts_at": [
+      100,
+      1000
+    ],
+    "reranker_boundary": "Recall@1000 is omitted for top-100 reranked runs."
+  },
+  "frozen_title_baseline": {
+    "n_queries": 102,
+    "bm25": {
+      "mrr@10": 0.47801898537192655,
+      "ndcg@10": 0.2491649126201414,
+      "recall@100": 0.2820649478633883,
+      "recall@1000": 0.532002447896766,
+      "no_relevant_top_100": 11,
+      "first_hit_101_1000": 5,
+      "miss_top_1000": 6
+    },
+    "bm25_ce": {
+      "mrr@10": 0.517110177404295,
+      "ndcg@10": 0.29720633866694945,
+      "recall@100": 0.2820649478633883
+    }
+  },
+  "acceptance_checks": [
+    "The title condition reproduces the frozen 102-query BM25 slice within 1e-12 for every metric.",
+    "All three conditions contain the same 102 qids exactly once.",
+    "The corpus, qrels, BM25 parameters, and index fingerprint are identical across conditions.",
+    "Each reranked run contains exactly the corresponding BM25 top-100 candidate set per qid.",
+    "Query construction succeeds without loading qrels, corpus documents, ranked outputs, or metrics.",
+    "All scores are finite and run ranks are contiguous with no duplicate docids."
+  ],
+  "decision_rule": {
+    "representation_effect": "Report the paired Recall@100 delta and the change from 11 title-condition no-hit-at-100 queries; do not infer causality from aggregate MRR alone.",
+    "architecture_gate": "Do not test hybrid or dense retrieval unless a material candidate-set limitation remains after the best bounded representation.",
+    "publication_boundary": "Do not update README headline claims until complete runs, independent metric cross-checks, review, and CI are finished."
+  }
+}

--- a/docs/nfcorpus_first_stage_taxonomy_review.md
+++ b/docs/nfcorpus_first_stage_taxonomy_review.md
@@ -173,6 +173,10 @@ This sequence distinguishes benchmark representation effects from retriever
 capacity and avoids selecting an architecture to compensate for omitted query
 context.
 
+The resulting feasibility audit and frozen 102-query video comparison are
+specified in the
+[query-representation protocol](nfcorpus_video_query_representation_protocol.md).
+
 ## Further questions
 
 - Does the reranking gain remain stable when topic pages are excluded?

--- a/docs/nfcorpus_video_query_representation_protocol.md
+++ b/docs/nfcorpus_video_query_representation_protocol.md
@@ -1,5 +1,9 @@
 # NFCorpus Video Query-Representation Protocol
 
+Status: completed on 28 July 2026. The frozen protocol remains here so the
+decision and leakage boundaries can be distinguished from the
+[post-run result](reports/2026-07-28-nfcorpus-video-query-representation.md).
+
 ## Decision
 
 The next experiment will compare bounded query representations on the official
@@ -199,9 +203,29 @@ The cross-encoder may be run only after each BM25 condition passes its input,
 run-depth, score, and qid checks. It must rerank exactly that condition's
 top-100 candidates; it cannot add documents.
 
+## Completed result
+
+The title-plus-description treatment passes the predeclared primary
+Recall@100 decision rule:
+
+| Representation | BM25 Recall@100 | BM25 Recall@1000 | CE MRR@10 | CE nDCG@10 |
+|---|---:|---:|---:|---:|
+| Title | 0.282065 | 0.491892 | 0.522012 | 0.298003 |
+| Description | 0.327210 | 0.641349 | 0.635699 | 0.356809 |
+| Title + description | **0.370030** | **0.672296** | **0.668857** | **0.385310** |
+
+Against title, the title-plus-description Recall@100 delta is `+0.087965`
+with paired-bootstrap 95% CI `[+0.053494, +0.126537]` and `p < 0.0002`.
+Description alone has delta `+0.045145`, CI
+`[-0.002419, +0.094286]`, and `p = 0.0610`; that primary comparison is not
+conclusive.
+
+The complete report records all predeclared metrics, no-hit transitions,
+candidate-set checks, independent cross-checks, and interpretation limits.
+
 ## Acceptance and stopping rules
 
-The experiment is accepted only if:
+The experiment was accepted after all of the following checks passed:
 
 - all three conditions contain exactly the frozen 102 qids;
 - the title condition reproduces the fixed-run slice within `1e-12`;
@@ -214,6 +238,8 @@ The result will be interpreted through the paired Recall@100 change and the
 change from 11 no-hit-at-100 queries. A better MRR alone is not sufficient to
 claim that missing context repaired the candidate ceiling.
 
-Hybrid or dense retrieval should be considered only if a material first-stage
-limitation remains after the best bounded representation. README headline
-claims will not change until the complete result, review, and CI are finished.
+The best bounded representation improves coverage, but Recall@100 remains
+`0.370030`; a material first-stage limitation therefore remains. Hybrid or
+dense retrieval may be considered only as a new predeclared comparison.
+README headline claims will not change until the complete result, review, and
+CI are finished.

--- a/docs/nfcorpus_video_query_representation_protocol.md
+++ b/docs/nfcorpus_video_query_representation_protocol.md
@@ -134,6 +134,10 @@ title baseline is MRR@10 `0.47801898537192655`, nDCG@10
 `1e-12`. Published fixed-run deltas and positive-score Recall remain in the
 audit summary as diagnostics rather than cross-platform acceptance guards.
 
+On the same deterministic title candidate set, the frozen cross-encoder
+baseline is MRR@10 `0.5220121381886088`, nDCG@10
+`0.29800270457307226`, and Recall@100 `0.2820649478633883`.
+
 ## Execution
 
 Each condition uses an isolated output directory, the same cached NFCorpus

--- a/docs/nfcorpus_video_query_representation_protocol.md
+++ b/docs/nfcorpus_video_query_representation_protocol.md
@@ -109,6 +109,51 @@ recover a positive at ranks 101–1000, and six still have no positive at depth
 The new title condition must reproduce this slice before either treatment is
 accepted.
 
+## Execution
+
+Each condition uses an isolated output directory and the same cached NFCorpus
+BM25 index. The runner downloads the official archive only when it is absent,
+then verifies the contracted byte size, MD5, SHA-256, cohort hash, record hash,
+and title alignment before retrieval:
+
+```bash
+python -X utf8 experiments/run_retrieval.py \
+  --dataset beir/nfcorpus/test \
+  --query-representation title \
+  --output-dir outputs/beir_nfcorpus_video/title/bm25 \
+  --require-clean-tree
+
+python -X utf8 experiments/run_retrieval.py \
+  --dataset beir/nfcorpus/test \
+  --query-representation description \
+  --output-dir outputs/beir_nfcorpus_video/description/bm25 \
+  --require-clean-tree
+
+python -X utf8 experiments/run_retrieval.py \
+  --dataset beir/nfcorpus/test \
+  --query-representation title_plus_description \
+  --output-dir outputs/beir_nfcorpus_video/title_plus_description/bm25 \
+  --require-clean-tree
+```
+
+The cross-encoder must receive the matching representation explicitly. It
+checks the upstream representation and effective-query hashes before model
+loading:
+
+```bash
+python -X utf8 experiments/run_reranker.py \
+  --dataset beir/nfcorpus/test \
+  --query-representation title \
+  --input-run outputs/beir_nfcorpus_video/title/bm25/run.tsv \
+  --output-dir outputs/beir_nfcorpus_video/title/cross_encoder_rerank \
+  --require-clean-tree
+```
+
+Replace `title` in both paths and the argument with `description` or
+`title_plus_description` for the treatment runs. `--resume` is safe only
+within the same condition; the runner rejects a representation or input hash
+mismatch.
+
 ## Evaluation
 
 Recall@100 is the primary metric because the experiment targets the candidate

--- a/docs/nfcorpus_video_query_representation_protocol.md
+++ b/docs/nfcorpus_video_query_representation_protocol.md
@@ -127,10 +127,12 @@ neither BM25 scores nor the architecture; it removes a cross-platform
 tie-breaking artifact. The deterministic title result is frozen before either
 treatment is run.
 
-Before that freeze, the title guard requires exact reproduction of the
-published MRR@10, nDCG@10, and positive-score Recall@100/1000 invariants.
-After the freeze it also requires every deterministic aggregate metric to
-match within `1e-12`.
+The deterministic rule was committed before running either treatment. Its
+title baseline is MRR@10 `0.47801898537192655`, nDCG@10
+`0.2492523025557319`, Recall@100 `0.2820649478633883`, and Recall@1000
+`0.4918916912361657`. The runner now requires all four values to match within
+`1e-12`. Published fixed-run deltas and positive-score Recall remain in the
+audit summary as diagnostics rather than cross-platform acceptance guards.
 
 ## Execution
 

--- a/docs/nfcorpus_video_query_representation_protocol.md
+++ b/docs/nfcorpus_video_query_representation_protocol.md
@@ -1,0 +1,144 @@
+# NFCorpus Video Query-Representation Protocol
+
+## Decision
+
+The next experiment will compare bounded query representations on the official
+102-query NFCorpus video test subset. It will not replace the current BEIR
+benchmark, change the architecture, or use the official full-page `all` field
+as a headline condition.
+
+The three predeclared conditions are:
+
+1. the existing BEIR title;
+2. the official video description;
+3. title plus description.
+
+The corpus, qrels, BM25 implementation, index, cross-encoder, candidate depth,
+and evaluation rules remain fixed. Only the query text changes.
+
+## Why this is the next controlled test
+
+The 72-case first-stage review found that many NFCorpus failures depend on
+source-page context omitted from the BEIR title. Before testing a new
+retriever, the lower-risk question is whether a bounded source field recovers
+candidate coverage.
+
+The official dataset provides two relevant pieces of evidence:
+
+- [`nfcorpus/test/video`](https://ir-datasets.com/nfcorpus.html) exposes video
+  titles and descriptions for 102 test queries;
+- the [dataset authors](https://www.cl.uni-heidelberg.de/statnlpgroup/nfcorpus/)
+  state that queries come from NutritionFacts page content and that relevance
+  is constructed from direct citations, indirect internal links, and
+  topic/tag links.
+
+The video description is bounded: in the pinned v1 archive it has a median of
+21 words and a maximum of 65. The full-page `all` field has a median of 192
+words, exceeds 512 words for 136 of the 323 shared test queries, and reaches a
+maximum of 42,966 words. That is a different retrieval condition rather than a
+normal query expansion.
+
+## Data alignment
+
+The feasibility audit verified the following before any new retrieval run:
+
+| Check | Result |
+|---|---:|
+| BEIR test qids found in the official test set | 323/323 |
+| Normalized official titles matching BEIR query text | 323/323 |
+| Official qrels matching BEIR after the verified filtering/remapping | 12,334/12,334 |
+| Retained relevant docids present in the BEIR corpus | 3,128/3,128 |
+| Official non-topic qids matching the URL-derived project slice | 144/144 |
+| Official video qids matching the URL-derived project slice | 102/102 |
+
+The two official test queries absent from BEIR contain only the lowest
+relevance level, which BEIR excludes. Official relevance levels 3 and 2 map
+exactly to BEIR levels 2 and 1 respectively.
+
+The official NFCorpus v1 archive is pinned at:
+
+- bytes: `31,039,523`;
+- MD5: `49c061fbadc52ba4d35d0e42e2d742fd`;
+- SHA-256:
+  `e2325ace35d02185a22e96bb52e72e62f2caf45a4975757c81a1c4087d8c59e9`.
+
+`ir_datasets` 0.6.1 currently points to an obsolete Heidelberg download path.
+The experiment must use the current official download URL recorded in
+[`configs/nfcorpus_video_query_representation.json`](../configs/nfcorpus_video_query_representation.json)
+and must retain the published MD5 check. Integrity verification must not be
+disabled.
+
+## Leakage boundary
+
+Query construction may read only:
+
+- the frozen 102-qid membership;
+- the BEIR query title;
+- the official video title and description.
+
+It must not read qrels, corpus documents, ranked outputs, metrics, or
+case-specific annotations while constructing query text.
+
+As a conservative audit proxy, no four-token-or-longer direct-qrel document
+title occurred verbatim in the 91 video descriptions whose queries have a
+direct judgment. This does not prove that the descriptions are independent of
+the cited evidence. It only rules out one obvious form of literal leakage.
+The description condition should therefore be interpreted as a richer source
+representation, not as an independently authored user query.
+
+The following are excluded from the primary comparison:
+
+- full-page `all` text;
+- live scraping of current NutritionFacts pages;
+- manual rewriting;
+- qrel-conditioned or retrieved-document-conditioned expansion.
+
+## Frozen baseline
+
+The existing title-only fixed run gives the following 102-query video slice:
+
+| System | MRR@10 | nDCG@10 | Recall@100 | Recall@1000 |
+|---|---:|---:|---:|---:|
+| BM25 | 0.478019 | 0.249165 | 0.282065 | 0.532002 |
+| BM25 + cross-encoder | 0.517110 | 0.297206 | 0.282065 | n/a |
+
+Eleven video queries have no positive qrel in the BM25 top 100. Five first
+recover a positive at ranks 101–1000, and six still have no positive at depth
+1000.
+
+The new title condition must reproduce this slice before either treatment is
+accepted.
+
+## Evaluation
+
+Recall@100 is the primary metric because the experiment targets the candidate
+set. MRR@10, nDCG@10, Recall@1000, and the number of no-hit queries at depths
+100 and 1000 are secondary diagnostics.
+
+All aggregate comparisons use the same 102 qids. Query-level metric
+differences will be summarized with 10,000 paired-bootstrap resamples, a fixed
+seed, and 95% confidence intervals. Recall@1000 is not reported for reranked
+top-100 runs.
+
+The cross-encoder may be run only after each BM25 condition passes its input,
+run-depth, score, and qid checks. It must rerank exactly that condition's
+top-100 candidates; it cannot add documents.
+
+## Acceptance and stopping rules
+
+The experiment is accepted only if:
+
+- all three conditions contain exactly the frozen 102 qids;
+- the title condition reproduces the fixed-run slice within `1e-12`;
+- corpus, qrels, index fingerprint, and model configuration are identical;
+- query construction runs without access to outcome data;
+- run files have finite scores, contiguous ranks, and no duplicate documents;
+- an independent metric cross-check agrees with the project evaluator.
+
+The result will be interpreted through the paired Recall@100 change and the
+change from 11 no-hit-at-100 queries. A better MRR alone is not sufficient to
+claim that missing context repaired the candidate ceiling.
+
+Hybrid or dense retrieval should be considered only if a material first-stage
+limitation remains after the best bounded representation. README headline
+claims will not change until the complete result, review, and CI are finished.

--- a/docs/nfcorpus_video_query_representation_protocol.md
+++ b/docs/nfcorpus_video_query_representation_protocol.md
@@ -106,15 +106,39 @@ Eleven video queries have no positive qrel in the BM25 top 100. Five first
 recover a positive at ranks 101–1000, and six still have no positive at depth
 1000.
 
-The new title condition must reproduce this slice before either treatment is
-accepted.
+### Deterministic tie amendment
+
+The first guarded title rerun on 27 July 2026 reproduced MRR@10 and nDCG@10
+exactly, but produced Recall@100 `0.289741` and Recall@1000 `0.584427`.
+Comparison with the published fixed run isolated the drift to equal-score
+candidate selection:
+
+- only two queries changed Recall@100;
+- those queries had only 11 and 19 positive-score BM25 matches, so the
+  remaining top-100 positions had score `0.0`;
+- 54 queries changed Recall@1000, again at the zero-score boundary;
+- after excluding score-0 fillers, both runs give Recall@100
+  `0.2820649478633883` and Recall@1000 `0.4587958058307442`.
+
+The treatment comparison therefore uses a pre-treatment deterministic rule:
+retrieve all 3,633 NFCorpus documents, sort by score descending and then
+`doc_id` ascending, and only then truncate to the reported depth. This changes
+neither BM25 scores nor the architecture; it removes a cross-platform
+tie-breaking artifact. The deterministic title result is frozen before either
+treatment is run.
+
+Before that freeze, the title guard requires exact reproduction of the
+published MRR@10, nDCG@10, and positive-score Recall@100/1000 invariants.
+After the freeze it also requires every deterministic aggregate metric to
+match within `1e-12`.
 
 ## Execution
 
-Each condition uses an isolated output directory and the same cached NFCorpus
-BM25 index. The runner downloads the official archive only when it is absent,
-then verifies the contracted byte size, MD5, SHA-256, cohort hash, record hash,
-and title alignment before retrieval:
+Each condition uses an isolated output directory, the same cached NFCorpus
+BM25 index, and the deterministic tie rule above. The runner downloads the
+official archive only when it is absent, then verifies the contracted byte
+size, MD5, SHA-256, cohort hash, record hash, and title alignment before
+retrieval:
 
 ```bash
 python -X utf8 experiments/run_retrieval.py \

--- a/docs/reports/2026-07-28-nfcorpus-video-query-representation.md
+++ b/docs/reports/2026-07-28-nfcorpus-video-query-representation.md
@@ -1,0 +1,136 @@
+# NFCorpus Video Query Representation
+
+## Question
+
+Can bounded source-page context repair part of the NFCorpus first-stage
+candidate limitation without changing the corpus, qrels, BM25 implementation,
+cross-encoder, or architecture?
+
+## Setup
+
+The controlled comparison uses the official 102-query NFCorpus test/video
+subset and three predeclared representations:
+
+1. the existing BEIR title;
+2. the official video description;
+3. title plus description.
+
+All conditions use the same 3,633-document BEIR NFCorpus corpus, `rel >= 1`
+qrels, BM25 parameters, index fingerprint, and deterministic score-descending,
+document-id-ascending tie rule. BM25 retrieves to depth 1,000. The fixed
+`cross-encoder/ms-marco-MiniLM-L-6-v2` revision
+`c5ee24cb16019beea0893ab7796b1df96625c6b8` reranks the corresponding top 100
+without adding candidates.
+
+The query cohort, official source archive, field construction, leakage
+boundary, and stopping rules were frozen before the treatment runs in
+[`docs/nfcorpus_video_query_representation_protocol.md`](../nfcorpus_video_query_representation_protocol.md).
+
+## Result
+
+### BM25
+
+| Representation | MRR@10 | nDCG@10 | Recall@100 | Recall@1000 |
+|---|---:|---:|---:|---:|
+| Title | 0.478019 | 0.249252 | 0.282065 | 0.491892 |
+| Description | 0.530781 | 0.292925 | 0.327210 | 0.641349 |
+| Title + description | **0.603568** | **0.345704** | **0.370030** | **0.672296** |
+
+### BM25 plus cross-encoder
+
+| Representation | MRR@10 | nDCG@10 | Recall@100 |
+|---|---:|---:|---:|
+| Title | 0.522012 | 0.298003 | 0.282065 |
+| Description | 0.635699 | 0.356809 | 0.327210 |
+| Title + description | **0.668857** | **0.385310** | **0.370030** |
+
+Recall@100 is identical before and after reranking within each representation
+because the cross-encoder only reorders that representation's BM25 top 100.
+
+## Paired evidence
+
+The predeclared primary metric is Recall@100. Confidence intervals and
+two-sided p-values use 10,000 paired-bootstrap resamples over the same 102
+queries with seed `20260727`.
+
+| Treatment vs title | Metric | Mean delta | 95% CI | p-value |
+|---|---|---:|---:|---:|
+| Description | Recall@100 | +0.045145 | [-0.002419, +0.094286] | 0.0610 |
+| Title + description | Recall@100 | **+0.087965** | **[+0.053494, +0.126537]** | **< 0.0002** |
+| Title + description | BM25 MRR@10 | +0.125549 | [+0.054279, +0.200058] | 0.0002 |
+| Title + description | BM25 nDCG@10 | +0.096452 | [+0.060503, +0.136063] | < 0.0002 |
+| Title + description | CE MRR@10 | +0.146845 | [+0.068063, +0.224665] | < 0.0002 |
+| Title + description | CE nDCG@10 | +0.087307 | [+0.049858, +0.124981] | < 0.0002 |
+
+Description alone has a positive point estimate, but its primary Recall@100
+interval crosses zero. It should not be described as a robust candidate-recall
+improvement on this cohort.
+
+Title plus description also improves Recall@100 over description alone by
+`+0.042820`, with a 95% interval of `[+0.020324, +0.070412]` and
+`p < 0.0002`. After reranking, however, its MRR@10 and nDCG@10 differences
+from description alone are not conclusive: their intervals cross zero
+(`p = 0.2338` and `p = 0.0732`, respectively).
+
+## Candidate-coverage diagnostic
+
+| Representation | No hit at 100 | No hit at 1,000 |
+|---|---:|---:|
+| Title | 11 | 8 |
+| Description | 5 | 0 |
+| Title + description | 4 | 0 |
+
+Relative to title, title plus description recovers 10 of the 11 no-hit-at-100
+queries but loses coverage for 3 previously covered queries, giving a net
+reduction from 11 to 4. At depth 1,000 it recovers all 8 title misses and
+introduces none.
+
+These counts are query-level hit diagnostics. They do not imply complete
+coverage of all relevant documents; even the best Recall@100 remains only
+`0.370030`.
+
+## Validation
+
+- The three BM25 runs contain the same 102 qids at depth 1,000 and were
+  produced from clean commit `119a9c695547`.
+- All runs share BM25 index SHA-256
+  `bf3fbede5fb624bd3c4def66de8d690bdfcda1f3f43c47637a5328cc8459730f`.
+- The three reranked runs contain 102 qids at depth 100 and were produced from
+  clean commit `cc6ae1f9ac08`.
+- All 306 query-condition candidate-set checks confirm that each reranked run
+  contains exactly its corresponding BM25 top-100 documents.
+- Run parsing rejects duplicate documents, rank gaps, non-finite scores, and
+  malformed records.
+- Independent `ir-measures` evaluation reproduces every aggregate metric
+  within the `1e-12` acceptance tolerance.
+
+Run the complete contract, metric, candidate-set, and paired-bootstrap check
+with:
+
+```bash
+python -X utf8 scripts/analyze_nfcorpus_query_representations.py \
+  --bootstrap-resamples 10000 \
+  --bootstrap-seed 20260727 \
+  --tolerance 1e-12
+```
+
+## Interpretation
+
+The result supports a narrow conclusion: on the official NFCorpus video
+subset, the compact BEIR title omits useful source context, and combining that
+title with the bounded official description materially improves first-stage
+candidate coverage under the fixed BM25 system.
+
+This does not establish that BM25 was replaced, that the architecture
+improved, or that the result transfers to the other 221 NFCorpus test queries.
+The description is source-page context connected to how NFCorpus was built,
+not an independently authored user query. The experiment is retrieval-only
+and provides no evidence about answer generation or grounding.
+
+## Follow-up
+
+The architecture gate remains closed. The best bounded representation raises
+Recall@100, but the remaining value of `0.370030` still leaves a material
+candidate ceiling. A later hybrid or dense retrieval comparison is justified
+only as a separately predeclared experiment; it should not be folded into
+this result.

--- a/experiments/run_reranker.py
+++ b/experiments/run_reranker.py
@@ -63,8 +63,10 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 from msmarco_genqa.data.benchmark import (
+    BEIR_NFCORPUS_TEST,
     MSMARCO_DEV_SMALL,
     SUPPORTED_DATASETS,
+    BenchmarkQueries,
     BenchmarkSpec,
     default_retrieval_output_dir,
     default_reranker_output_dir,
@@ -72,6 +74,13 @@ from msmarco_genqa.data.benchmark import (
     load_benchmark_corpus,
     load_benchmark_queries,
     lookup_document_text,
+)
+from msmarco_genqa.data.nfcorpus_video import (
+    SUPPORTED_REPRESENTATIONS,
+    NFCorpusVideoQueryBundle,
+    load_nfcorpus_video_query_representation,
+    validate_frozen_title_reranker_metrics,
+    write_nfcorpus_video_query_artifacts,
 )
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
 from msmarco_genqa.evaluation.trec import evaluate_trec_retrieval, trec_metric_contract
@@ -96,6 +105,9 @@ from msmarco_genqa.util.manifest import (
 from msmarco_genqa.util.seeding import set_global_seed
 
 logger = logging.getLogger("run_reranker")
+DEFAULT_NFCORPUS_VIDEO_CONTRACT = (
+    PROJECT_ROOT / "configs/nfcorpus_video_query_representation.json"
+)
 
 
 def load_config(path: Path) -> dict:
@@ -205,6 +217,33 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Bypass the schema-v2 required-field contract on manifest write. "
             "Development-only escape hatch; production / headline runs must "
             "leave this off so missing reproducibility fields fail loudly."
+        ),
+    )
+    parser.add_argument(
+        "--query-representation",
+        choices=SUPPORTED_REPRESENTATIONS,
+        default=None,
+        help=(
+            "Rerank one predeclared 102-query NFCorpus video representation. "
+            "Requires explicit --input-run and --output-dir paths."
+        ),
+    )
+    parser.add_argument(
+        "--query-representation-contract",
+        type=Path,
+        default=None,
+        help=(
+            "Pinned NFCorpus video experiment contract. When "
+            "--query-representation is set, defaults to "
+            "configs/nfcorpus_video_query_representation.json."
+        ),
+    )
+    parser.add_argument(
+        "--no-query-source-download",
+        action="store_true",
+        help=(
+            "Refuse to download the pinned official NFCorpus archive when it "
+            "is absent. Integrity checks are always enforced."
         ),
     )
     return parser.parse_args(argv)
@@ -378,6 +417,118 @@ def metric_cutoffs_within_depth(
     return tuple(k for k in normalized if k <= run_depth)
 
 
+def _validate_query_representation_args(
+    args: argparse.Namespace,
+    cfg: dict,
+) -> Path | None:
+    """Validate reranker paths for the controlled representation experiment."""
+
+    if args.query_representation is None:
+        if args.query_representation_contract is not None:
+            raise SystemExit(
+                "--query-representation-contract requires --query-representation"
+            )
+        if args.no_query_source_download:
+            raise SystemExit(
+                "--no-query-source-download requires --query-representation"
+            )
+        return None
+
+    if args.dataset != BEIR_NFCORPUS_TEST:
+        raise SystemExit(
+            "--query-representation is restricted to --dataset beir/nfcorpus/test"
+        )
+    if args.input_run is None or args.output_dir is None:
+        raise SystemExit(
+            "--query-representation requires explicit --input-run and --output-dir "
+            "paths to prevent cross-condition mixing"
+        )
+    query_transform_method = str(
+        (cfg.get("query_transform") or {}).get("method", "none")
+    )
+    if query_transform_method != "none":
+        raise SystemExit(
+            "query_transform.method must remain 'none' for the controlled "
+            "NFCorpus query-representation experiment"
+        )
+
+    path = args.query_representation_contract or DEFAULT_NFCORPUS_VIDEO_CONTRACT
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _select_video_query_cohort(
+    benchmark: BenchmarkQueries,
+    bundle: NFCorpusVideoQueryBundle,
+) -> BenchmarkQueries:
+    query_ids = set(bundle.queries)
+    missing_qrels = sorted(query_ids - set(benchmark.graded_qrels))
+    if missing_qrels:
+        raise SystemExit(
+            f"{len(missing_qrels)} NFCorpus video queries are missing graded qrels"
+        )
+    return BenchmarkQueries(
+        spec=benchmark.spec,
+        queries=dict(bundle.queries),
+        qrels={qid: set(benchmark.qrels.get(qid, set())) for qid in bundle.queries},
+        graded_qrels={
+            qid: dict(benchmark.graded_qrels[qid]) for qid in bundle.queries
+        },
+    )
+
+
+def _validate_upstream_query_representation(
+    bundle: NFCorpusVideoQueryBundle,
+    upstream_benchmark: dict[str, object],
+) -> None:
+    upstream = upstream_benchmark.get("query_representation")
+    if not isinstance(upstream, dict):
+        raise SystemExit(
+            "input run metadata does not contain a query-representation contract"
+        )
+    for key in (
+        "representation",
+        "qid_sha256",
+        "official_query_records_sha256",
+        "effective_queries_sha256",
+    ):
+        if upstream.get(key) != bundle.summary.get(key):
+            raise SystemExit(
+                f"input run query representation {key} does not match the reranker"
+            )
+
+
+def _validate_representation_resume(
+    output_dir: Path,
+    bundle: NFCorpusVideoQueryBundle,
+    *,
+    resume: bool,
+) -> None:
+    rerank_run = output_dir / "run.tsv"
+    if not resume or not rerank_run.exists():
+        return
+    summary_path = output_dir / "query_representation" / "summary.json"
+    if not summary_path.exists():
+        raise SystemExit(
+            f"refusing to resume {rerank_run}: query-representation summary is missing"
+        )
+    try:
+        existing = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            f"refusing to resume {rerank_run}: query-representation summary is invalid"
+        ) from exc
+    for key in (
+        "representation",
+        "qid_sha256",
+        "official_query_records_sha256",
+        "effective_queries_sha256",
+    ):
+        if existing.get(key) != bundle.summary.get(key):
+            raise SystemExit(
+                f"refusing to resume {rerank_run}: query representation {key} differs"
+            )
+
+
 def main() -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -386,6 +537,7 @@ def main() -> None:
     args = parse_args()
     cfg = load_config(args.config)
     benchmark_spec = get_benchmark_spec(args.dataset)
+    query_representation_contract = _validate_query_representation_args(args, cfg)
     seed = cfg.get("seed", 42)
     seed_coverage = set_global_seed(seed)
 
@@ -446,23 +598,58 @@ def main() -> None:
     # ---------------------------------------------------------------- #
     # 2. Queries + qrels
     # ---------------------------------------------------------------- #
-    corpus_data = load_benchmark_corpus(
-        benchmark_spec,
-        cache_dir=cache_dir,
-        load_corpus=False,
-    )
-    docs_store = corpus_data.docs_store
     benchmark = load_benchmark_queries(
         args.dataset,
         cache_dir=cache_dir,
     )
+    query_representation_bundle: NFCorpusVideoQueryBundle | None = None
+    query_representation_outputs: list[Path] = []
+    query_representation_summary: dict[str, object] = {
+        "representation": "benchmark_default",
+        "n_queries": len(benchmark.queries),
+    }
+    if query_representation_contract is not None:
+        query_representation_bundle = load_nfcorpus_video_query_representation(
+            benchmark.queries,
+            representation=args.query_representation,
+            contract_path=query_representation_contract,
+            project_root=PROJECT_ROOT,
+            download_if_missing=not args.no_query_source_download,
+        )
+        _validate_representation_resume(
+            output_dir,
+            query_representation_bundle,
+            resume=args.resume,
+        )
+        benchmark = _select_video_query_cohort(
+            benchmark,
+            query_representation_bundle,
+        )
     upstream_benchmark = load_upstream_benchmark_metadata(input_stage_dir)
+    if query_representation_bundle is not None:
+        _validate_upstream_query_representation(
+            query_representation_bundle,
+            upstream_benchmark,
+        )
+        (
+            query_representation_summary,
+            query_representation_outputs,
+        ) = write_nfcorpus_video_query_artifacts(
+            query_representation_bundle,
+            output_dir / "query_representation",
+        )
     validate_trec_input_run(
         benchmark_spec,
         runs_topk,
         benchmark.queries,
         upstream_benchmark,
     )
+    corpus_data = load_benchmark_corpus(
+        benchmark_spec,
+        cache_dir=cache_dir,
+        load_corpus=False,
+    )
+    docs_store = corpus_data.docs_store
     sample_qrels = (
         benchmark.qrels
         if benchmark_spec.dataset_id != MSMARCO_DEV_SMALL
@@ -668,6 +855,23 @@ def main() -> None:
         )
     logger.info("%s (input) metrics: %s", input_label, input_metrics)
     logger.info("%s + CE rerank metrics: %s", input_label, rerank_metrics)
+    if query_representation_bundle is not None:
+        query_representation_summary["title_baseline_reproduction"] = (
+            validate_frozen_title_reranker_metrics(
+                query_representation_bundle,
+                input_metrics,
+                rerank_metrics,
+            )
+        )
+        summary_path = output_dir / "query_representation" / "summary.json"
+        with summary_path.open("w", encoding="utf-8", newline="\n") as handle:
+            json.dump(
+                query_representation_summary,
+                handle,
+                indent=2,
+                ensure_ascii=False,
+            )
+            handle.write("\n")
 
     # ---------------------------------------------------------------- #
     # 7. Qualitative examples (before vs after) — reads reranked from disk
@@ -734,6 +938,7 @@ def main() -> None:
                 if benchmark.graded_qrels
                 else 0.0
             ),
+            "query_representation": query_representation_summary,
         }
     )
 
@@ -788,6 +993,7 @@ def main() -> None:
         },
         "peak_memory_mib": peak_mem_mb,
         "environment": (env_dict := capture_environment()),
+        "query_representation": query_representation_summary,
     }
     if benchmark_spec.has_graded_qrels:
         payload["evaluation"] = {
@@ -828,7 +1034,21 @@ def main() -> None:
             "dataset_id": benchmark_spec.dataset_id,
             "corpus_id": benchmark_spec.corpus_id,
         },
-        extra_files={"input_run": input_run_path},
+        extra_files={
+            "input_run": input_run_path,
+            **(
+                {
+                    "query_representation_contract": (
+                        query_representation_bundle.contract_path
+                    ),
+                    "query_representation_archive": (
+                        query_representation_bundle.archive_path
+                    ),
+                }
+                if query_representation_bundle is not None
+                else {}
+            ),
+        },
     )
     env_fingerprint = compute_env_fingerprint(env_dict)
 
@@ -837,7 +1057,12 @@ def main() -> None:
         output_dir=output_dir,
         command=sys.argv,
         config_path=args.config,
-        extra_outputs=[rerank_run_path, examples_path, resolved_config_path],
+        extra_outputs=[
+            rerank_run_path,
+            examples_path,
+            resolved_config_path,
+            *query_representation_outputs,
+        ],
         extra={
             "task": "reranking",
             "model_name": model_name,
@@ -866,6 +1091,7 @@ def main() -> None:
             "resolved_config_hash": resolved_config_hash,
             "data_fingerprint": data_fingerprint,
             "env_fingerprint": env_fingerprint,
+            "query_representation": query_representation_summary,
         },
         require_clean_tree=args.require_clean_tree,
         allow_incomplete=args.allow_incomplete_manifest,

--- a/experiments/run_reranker.py
+++ b/experiments/run_reranker.py
@@ -59,6 +59,7 @@ except ImportError:  # pragma: no cover - exercised on Windows hosts.
 import sys
 import time
 from pathlib import Path
+from typing import Mapping
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
@@ -76,6 +77,10 @@ from msmarco_genqa.data.benchmark import (
     lookup_document_text,
 )
 from msmarco_genqa.data.nfcorpus_video import (
+    FIXED_RERANK_DEPTH,
+    FIXED_RERANK_MAX_LENGTH,
+    FIXED_RERANKER_MODEL,
+    FIXED_RERANKER_REVISION,
     SUPPORTED_REPRESENTATIONS,
     NFCorpusVideoQueryBundle,
     load_nfcorpus_video_query_representation,
@@ -83,6 +88,7 @@ from msmarco_genqa.data.nfcorpus_video import (
     write_nfcorpus_video_query_artifacts,
 )
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
+from msmarco_genqa.evaluation.retrieval_contract import sha256_file
 from msmarco_genqa.evaluation.trec import evaluate_trec_retrieval, trec_metric_contract
 from msmarco_genqa.reranking.cross_encoder import CrossEncoderReranker
 from msmarco_genqa.reranking.io import (
@@ -451,6 +457,22 @@ def _validate_query_representation_args(
             "query_transform.method must remain 'none' for the controlled "
             "NFCorpus query-representation experiment"
         )
+    reranker = cfg.get("reranker") or {}
+    model_name = args.model_name or reranker.get("model_name")
+    rerank_depth = int(
+        args.rerank_top_k
+        or reranker.get("rerank_top_k", FIXED_RERANK_DEPTH)
+    )
+    if (
+        model_name != FIXED_RERANKER_MODEL
+        or reranker.get("revision") != FIXED_RERANKER_REVISION
+        or rerank_depth != FIXED_RERANK_DEPTH
+        or int(reranker.get("max_length", 0)) != FIXED_RERANK_MAX_LENGTH
+    ):
+        raise SystemExit(
+            "the controlled NFCorpus query-representation experiment requires "
+            "the frozen cross-encoder model, revision, depth, and max length"
+        )
 
     path = args.query_representation_contract or DEFAULT_NFCORPUS_VIDEO_CONTRACT
     return path if path.is_absolute() else PROJECT_ROOT / path
@@ -499,7 +521,7 @@ def _validate_upstream_query_representation(
 
 def _validate_representation_resume(
     output_dir: Path,
-    bundle: NFCorpusVideoQueryBundle,
+    expected: Mapping[str, object],
     *,
     resume: bool,
 ) -> None:
@@ -522,10 +544,11 @@ def _validate_representation_resume(
         "qid_sha256",
         "official_query_records_sha256",
         "effective_queries_sha256",
+        "reranker_system",
     ):
-        if existing.get(key) != bundle.summary.get(key):
+        if existing.get(key) != expected.get(key):
             raise SystemExit(
-                f"refusing to resume {rerank_run}: query representation {key} differs"
+                f"refusing to resume {rerank_run}: resume contract {key} differs"
             )
 
 
@@ -616,11 +639,6 @@ def main() -> None:
             project_root=PROJECT_ROOT,
             download_if_missing=not args.no_query_source_download,
         )
-        _validate_representation_resume(
-            output_dir,
-            query_representation_bundle,
-            resume=args.resume,
-        )
         benchmark = _select_video_query_cohort(
             benchmark,
             query_representation_bundle,
@@ -631,12 +649,29 @@ def main() -> None:
             query_representation_bundle,
             upstream_benchmark,
         )
+        reranker_system = {
+            "model_name": model_name,
+            "revision": rerank_cfg.get("revision"),
+            "rerank_top_k": rerank_top_k,
+            "max_length": max_length,
+            "input_run_sha256": sha256_file(input_run_path),
+        }
+        expected_summary = {
+            **query_representation_bundle.summary,
+            "reranker_system": reranker_system,
+        }
+        _validate_representation_resume(
+            output_dir,
+            expected_summary,
+            resume=args.resume,
+        )
         (
             query_representation_summary,
             query_representation_outputs,
         ) = write_nfcorpus_video_query_artifacts(
             query_representation_bundle,
             output_dir / "query_representation",
+            summary_updates={"reranker_system": reranker_system},
         )
     validate_trec_input_run(
         benchmark_spec,

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -34,8 +34,10 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 from msmarco_genqa.data.benchmark import (
+    BEIR_NFCORPUS_TEST,
     MSMARCO_DEV_SMALL,
     SUPPORTED_DATASETS,
+    BenchmarkQueries,
     BenchmarkSpec,
     default_retrieval_index_dir,
     default_retrieval_output_dir,
@@ -43,6 +45,13 @@ from msmarco_genqa.data.benchmark import (
     load_benchmark_corpus,
     load_benchmark_queries,
     lookup_document_text,
+)
+from msmarco_genqa.data.nfcorpus_video import (
+    SUPPORTED_REPRESENTATIONS,
+    NFCorpusVideoQueryBundle,
+    load_nfcorpus_video_query_representation,
+    validate_frozen_title_metrics,
+    write_nfcorpus_video_query_artifacts,
 )
 from msmarco_genqa.evaluation.retrieval import evaluate_retrieval
 from msmarco_genqa.evaluation.trec import evaluate_trec_retrieval, trec_metric_contract
@@ -61,6 +70,9 @@ from msmarco_genqa.util.manifest import (
 from msmarco_genqa.util.seeding import set_global_seed
 
 logger = logging.getLogger("run_retrieval")
+DEFAULT_NFCORPUS_VIDEO_CONTRACT = (
+    PROJECT_ROOT / "configs/nfcorpus_video_query_representation.json"
+)
 
 
 def load_config(path: Path) -> dict:
@@ -124,6 +136,34 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "leave this off so missing reproducibility fields fail loudly."
         ),
     )
+    parser.add_argument(
+        "--query-representation",
+        choices=SUPPORTED_REPRESENTATIONS,
+        default=None,
+        help=(
+            "Run the predeclared 102-query NFCorpus video representation "
+            "experiment. Requires --dataset beir/nfcorpus/test and an explicit "
+            "--output-dir so the full benchmark output cannot be overwritten."
+        ),
+    )
+    parser.add_argument(
+        "--query-representation-contract",
+        type=Path,
+        default=None,
+        help=(
+            "Pinned NFCorpus video experiment contract. When "
+            "--query-representation is set, defaults to "
+            "configs/nfcorpus_video_query_representation.json."
+        ),
+    )
+    parser.add_argument(
+        "--no-query-source-download",
+        action="store_true",
+        help=(
+            "Refuse to download the pinned official NFCorpus archive when it "
+            "is absent. Integrity checks are always enforced."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -177,6 +217,102 @@ def _read_runs_from_tsv(run_path: Path) -> tuple[dict[str, list[str]], dict[str,
     )
 
 
+def _validate_query_representation_args(
+    args: argparse.Namespace,
+    cfg: dict,
+) -> Path | None:
+    """Validate the experiment boundary and return its resolved contract path."""
+
+    if args.query_representation is None:
+        if args.query_representation_contract is not None:
+            raise SystemExit(
+                "--query-representation-contract requires --query-representation"
+            )
+        if args.no_query_source_download:
+            raise SystemExit(
+                "--no-query-source-download requires --query-representation"
+            )
+        return None
+
+    if args.dataset != BEIR_NFCORPUS_TEST:
+        raise SystemExit(
+            "--query-representation is restricted to --dataset beir/nfcorpus/test"
+        )
+    if args.output_dir is None:
+        raise SystemExit(
+            "--query-representation requires an explicit --output-dir to avoid "
+            "overwriting the full NFCorpus benchmark"
+        )
+    query_transform_method = str(
+        (cfg.get("query_transform") or {}).get("method", "none")
+    )
+    if query_transform_method != "none":
+        raise SystemExit(
+            "query_transform.method must remain 'none' for the controlled "
+            "NFCorpus query-representation experiment"
+        )
+
+    path = args.query_representation_contract or DEFAULT_NFCORPUS_VIDEO_CONTRACT
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _select_video_query_cohort(
+    benchmark: BenchmarkQueries,
+    bundle: NFCorpusVideoQueryBundle,
+) -> BenchmarkQueries:
+    """Apply a constructed query cohort to judgments after construction."""
+
+    query_ids = set(bundle.queries)
+    missing_qrels = sorted(query_ids - set(benchmark.graded_qrels))
+    if missing_qrels:
+        raise SystemExit(
+            f"{len(missing_qrels)} NFCorpus video queries are missing graded qrels"
+        )
+    return BenchmarkQueries(
+        spec=benchmark.spec,
+        queries=dict(bundle.queries),
+        qrels={qid: set(benchmark.qrels.get(qid, set())) for qid in bundle.queries},
+        graded_qrels={
+            qid: dict(benchmark.graded_qrels[qid]) for qid in bundle.queries
+        },
+    )
+
+
+def _validate_representation_resume(
+    output_dir: Path,
+    bundle: NFCorpusVideoQueryBundle,
+    *,
+    resume: bool,
+) -> None:
+    """Prevent a resumed run from mixing query representations."""
+
+    run_path = output_dir / "run.tsv"
+    if not resume or not run_path.exists():
+        return
+    summary_path = output_dir / "query_representation" / "summary.json"
+    if not summary_path.exists():
+        raise SystemExit(
+            f"refusing to resume {run_path}: query-representation summary is missing"
+        )
+    try:
+        existing = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            f"refusing to resume {run_path}: query-representation summary is invalid"
+        ) from exc
+    expected = bundle.summary
+    for key in (
+        "representation",
+        "qid_sha256",
+        "official_query_records_sha256",
+        "effective_queries_sha256",
+    ):
+        if existing.get(key) != expected.get(key):
+            raise SystemExit(
+                f"refusing to resume {run_path}: query representation {key} differs"
+            )
+
+
 def main() -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -185,6 +321,7 @@ def main() -> None:
     args = parse_args()
     cfg = load_config(args.config)
     benchmark_spec = get_benchmark_spec(args.dataset)
+    query_representation_contract = _validate_query_representation_args(args, cfg)
     seed = cfg.get("seed", 42)
     seed_coverage = set_global_seed(seed)
 
@@ -223,6 +360,41 @@ def main() -> None:
         args.dataset,
         cache_dir=cache_dir,
     )
+    query_representation_bundle: NFCorpusVideoQueryBundle | None = None
+    query_representation_outputs: list[Path] = []
+    query_representation_summary: dict[str, object] = {
+        "representation": "benchmark_default",
+        "n_queries": len(benchmark.queries),
+    }
+    if query_representation_contract is not None:
+        query_representation_bundle = load_nfcorpus_video_query_representation(
+            benchmark.queries,
+            representation=args.query_representation,
+            contract_path=query_representation_contract,
+            project_root=PROJECT_ROOT,
+            download_if_missing=not args.no_query_source_download,
+        )
+        _validate_representation_resume(
+            output_dir,
+            query_representation_bundle,
+            resume=args.resume,
+        )
+        benchmark = _select_video_query_cohort(
+            benchmark,
+            query_representation_bundle,
+        )
+        (
+            query_representation_summary,
+            query_representation_outputs,
+        ) = write_nfcorpus_video_query_artifacts(
+            query_representation_bundle,
+            output_dir / "query_representation",
+        )
+        logger.info(
+            "NFCorpus video query representation %s: %d validated queries.",
+            args.query_representation,
+            len(benchmark.queries),
+        )
     query_text_by_qid, query_transform_summary, query_transform_outputs = (
         materialize_query_transform(
             benchmark.queries,
@@ -405,6 +577,22 @@ def main() -> None:
             ks_ndcg=ks_ndcg,
         )
     logger.info("Metrics: %s", metrics)
+    if query_representation_bundle is not None:
+        query_representation_summary["title_baseline_reproduction"] = (
+            validate_frozen_title_metrics(
+                query_representation_bundle,
+                metrics,
+            )
+        )
+        summary_path = output_dir / "query_representation" / "summary.json"
+        with summary_path.open("w", encoding="utf-8", newline="\n") as handle:
+            json.dump(
+                query_representation_summary,
+                handle,
+                indent=2,
+                ensure_ascii=False,
+            )
+            handle.write("\n")
 
     # ---- 6. Qualitative examples ----
     # Resolve passage text. If we built the index in this run, the corpus is
@@ -482,6 +670,7 @@ def main() -> None:
             "judged_topic_coverage": (
                 len(set(runs) & judged_qids) / len(judged_qids) if judged_qids else 0.0
             ),
+            "query_representation": query_representation_summary,
         }
     )
     payload = {
@@ -500,6 +689,7 @@ def main() -> None:
         "environment": env_dict,
         "top_k": top_k,
         "query_transform": query_transform_summary,
+        "query_representation": query_representation_summary,
         "resumed": args.resume and bool(set(qids) - set(pending_qids)),
     }
     if benchmark_spec.has_graded_qrels:
@@ -527,6 +717,14 @@ def main() -> None:
             "dataset_id": benchmark_spec.dataset_id,
             "corpus_id": benchmark_spec.corpus_id,
         },
+        extra_files=(
+            {
+                "query_representation_contract": query_representation_bundle.contract_path,
+                "query_representation_archive": query_representation_bundle.archive_path,
+            }
+            if query_representation_bundle is not None
+            else None
+        ),
     )
     env_fingerprint = compute_env_fingerprint(env_dict)
 
@@ -535,7 +733,13 @@ def main() -> None:
         output_dir=output_dir,
         command=sys.argv,
         config_path=args.config,
-        extra_outputs=[run_path, examples_path, resolved_config_path, *query_transform_outputs],
+        extra_outputs=[
+            run_path,
+            examples_path,
+            resolved_config_path,
+            *query_transform_outputs,
+            *query_representation_outputs,
+        ],
         extra={
             "task": "retrieval",
             "backend": cfg["retrieval"].get("backend", "bm25s"),
@@ -558,6 +762,7 @@ def main() -> None:
             "data_fingerprint": data_fingerprint,
             "env_fingerprint": env_fingerprint,
             "query_transform": query_transform_summary,
+            "query_representation": query_representation_summary,
         },
         require_clean_tree=args.require_clean_tree,
         allow_incomplete=args.allow_incomplete_manifest,

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -24,6 +24,7 @@ Run from the project root::
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import random
@@ -251,6 +252,29 @@ def _positive_score_recall(
     return metrics
 
 
+def _index_fingerprint(index_dir: Path) -> dict[str, object]:
+    """Hash a small experiment index as an ordered set of files."""
+
+    digest = hashlib.sha256()
+    files = sorted(path for path in index_dir.rglob("*") if path.is_file())
+    total_bytes = 0
+    for path in files:
+        relative = path.relative_to(index_dir).as_posix()
+        size = path.stat().st_size
+        total_bytes += size
+        digest.update(f"{relative}\0{size}\0".encode("utf-8"))
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return {
+        "algorithm": "sha256",
+        "sha256": digest.hexdigest(),
+        "file_count": len(files),
+        "bytes": total_bytes,
+        "path": index_dir.relative_to(PROJECT_ROOT).as_posix(),
+    }
+
+
 def _validate_query_representation_args(
     args: argparse.Namespace,
     cfg: dict,
@@ -476,6 +500,10 @@ def main() -> None:
         retriever.build()
         index_time = time.time() - t0
         retriever.save(index_dir)
+    if query_representation_bundle is not None:
+        query_representation_summary["index_fingerprint"] = _index_fingerprint(
+            index_dir
+        )
 
     # ---- 3. Plan retrieval ----
     qids = list(benchmark.queries.keys())

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -31,6 +31,7 @@ import random
 import sys
 import time
 from pathlib import Path
+from typing import Mapping
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
@@ -309,6 +310,31 @@ def _validate_query_representation_args(
             "query_transform.method must remain 'none' for the controlled "
             "NFCorpus query-representation experiment"
         )
+    retrieval = cfg.get("retrieval") or {}
+    expected_retrieval = {
+        "backend": "bm25s",
+        "k1": 1.5,
+        "b": 0.75,
+        "stopwords": "en",
+        "top_k": 1000,
+    }
+    observed_retrieval = {
+        "backend": retrieval.get("backend"),
+        "k1": retrieval.get("k1"),
+        "b": retrieval.get("b"),
+        "stopwords": retrieval.get("stopwords"),
+        "top_k": retrieval.get("top_k"),
+    }
+    if observed_retrieval != expected_retrieval:
+        raise SystemExit(
+            "the controlled NFCorpus query-representation experiment requires "
+            f"the frozen retrieval configuration {expected_retrieval}"
+        )
+    if (cfg.get("data") or {}).get("corpus_limit") is not None:
+        raise SystemExit(
+            "the controlled NFCorpus query-representation experiment requires "
+            "the full corpus (data.corpus_limit must be null)"
+        )
 
     path = args.query_representation_contract or DEFAULT_NFCORPUS_VIDEO_CONTRACT
     return path if path.is_absolute() else PROJECT_ROOT / path
@@ -338,7 +364,7 @@ def _select_video_query_cohort(
 
 def _validate_representation_resume(
     output_dir: Path,
-    bundle: NFCorpusVideoQueryBundle,
+    expected: Mapping[str, object],
     *,
     resume: bool,
 ) -> None:
@@ -358,16 +384,17 @@ def _validate_representation_resume(
         raise SystemExit(
             f"refusing to resume {run_path}: query-representation summary is invalid"
         ) from exc
-    expected = bundle.summary
     for key in (
         "representation",
         "qid_sha256",
         "official_query_records_sha256",
         "effective_queries_sha256",
+        "index_fingerprint",
+        "retrieval_system",
     ):
         if existing.get(key) != expected.get(key):
             raise SystemExit(
-                f"refusing to resume {run_path}: query representation {key} differs"
+                f"refusing to resume {run_path}: resume contract {key} differs"
             )
 
 
@@ -432,22 +459,11 @@ def main() -> None:
             project_root=PROJECT_ROOT,
             download_if_missing=not args.no_query_source_download,
         )
-        _validate_representation_resume(
-            output_dir,
-            query_representation_bundle,
-            resume=args.resume,
-        )
         benchmark = _select_video_query_cohort(
             benchmark,
             query_representation_bundle,
         )
-        (
-            query_representation_summary,
-            query_representation_outputs,
-        ) = write_nfcorpus_video_query_artifacts(
-            query_representation_bundle,
-            output_dir / "query_representation",
-        )
+        query_representation_summary = dict(query_representation_bundle.summary)
         logger.info(
             "NFCorpus video query representation %s: %d validated queries.",
             args.query_representation,
@@ -501,8 +517,32 @@ def main() -> None:
         index_time = time.time() - t0
         retriever.save(index_dir)
     if query_representation_bundle is not None:
-        query_representation_summary["index_fingerprint"] = _index_fingerprint(
-            index_dir
+        representation_updates: dict[str, object] = {
+            "index_fingerprint": _index_fingerprint(index_dir),
+            "retrieval_system": {
+                "backend": cfg["retrieval"].get("backend"),
+                "k1": float(cfg["retrieval"]["k1"]),
+                "b": float(cfg["retrieval"]["b"]),
+                "stopwords": cfg["retrieval"].get("stopwords"),
+                "top_k": top_k,
+            },
+        }
+        expected_summary = {
+            **query_representation_summary,
+            **representation_updates,
+        }
+        _validate_representation_resume(
+            output_dir,
+            expected_summary,
+            resume=args.resume,
+        )
+        (
+            query_representation_summary,
+            query_representation_outputs,
+        ) = write_nfcorpus_video_query_artifacts(
+            query_representation_bundle,
+            output_dir / "query_representation",
+            summary_updates=representation_updates,
         )
 
     # ---- 3. Plan retrieval ----

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -217,6 +217,40 @@ def _read_runs_from_tsv(run_path: Path) -> tuple[dict[str, list[str]], dict[str,
     )
 
 
+def _positive_score_recall(
+    runs: dict[str, list[str]],
+    scores_by_qid: dict[str, list[float]],
+    qrels: dict[str, set[str]],
+    *,
+    cutoffs: tuple[int, ...],
+) -> dict[str, float]:
+    """Macro recall after excluding non-retrieved (score <= 0) fillers."""
+
+    qids = [qid for qid in qrels if qid in runs]
+    metrics: dict[str, float] = {}
+    for cutoff in cutoffs:
+        values = []
+        for qid in qids:
+            positive_docs = [
+                doc_id
+                for doc_id, score in zip(
+                    runs[qid][:cutoff],
+                    scores_by_qid.get(qid, [])[:cutoff],
+                )
+                if score > 0.0
+            ]
+            relevant = qrels[qid]
+            values.append(
+                len(set(positive_docs) & relevant) / len(relevant)
+                if relevant
+                else 0.0
+            )
+        metrics[f"positive_score_recall@{cutoff}"] = (
+            sum(values) / len(values) if values else 0.0
+        )
+    return metrics
+
+
 def _validate_query_representation_args(
     args: argparse.Namespace,
     cfg: dict,
@@ -517,6 +551,7 @@ def main() -> None:
                 chunk_scores, chunk_doc_ids = retriever.retrieve_batch(
                     chunk_texts,
                     k=top_k,
+                    deterministic_ties=query_representation_bundle is not None,
                 )
                 chunk_seconds = time.time() - t0
 
@@ -578,10 +613,20 @@ def main() -> None:
         )
     logger.info("Metrics: %s", metrics)
     if query_representation_bundle is not None:
+        positive_score_metrics = _positive_score_recall(
+            runs,
+            scores_by_qid,
+            benchmark.qrels,
+            cutoffs=tuple(ks_recall),
+        )
+        query_representation_summary["positive_score_metrics"] = (
+            positive_score_metrics
+        )
         query_representation_summary["title_baseline_reproduction"] = (
             validate_frozen_title_metrics(
                 query_representation_bundle,
                 metrics,
+                positive_score_metrics=positive_score_metrics,
             )
         )
         summary_path = output_dir / "query_representation" / "summary.json"

--- a/reports/generated/artifacts/nfcorpus_video_query_representation.json
+++ b/reports/generated/artifacts/nfcorpus_video_query_representation.json
@@ -1,0 +1,189 @@
+{
+  "schema": "msmarco-genqa.table-artifact.v1",
+  "artifact_id": "nfcorpus_video_query_representation",
+  "metric_schema": "retrieval.nfcorpus_video_query_representation.v1",
+  "query_set": {
+    "id": "nfcorpus-test-video",
+    "n_queries": 102,
+    "qid_sha256": "55dc5fa5b71077fd35046d45b674d70a0d033dad7eaacb83c56032e60347213f"
+  },
+  "model_revision": {
+    "first_stage": "bm25s-0.3.9",
+    "reranker": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    "reranker_revision": "c5ee24cb16019beea0893ab7796b1df96625c6b8",
+    "candidate_depth": 100
+  },
+  "experiment": {
+    "git_commits": {
+      "bm25": "119a9c695547",
+      "reranker": "cc6ae1f9ac08"
+    },
+    "dataset": "beir/nfcorpus/test",
+    "subset": "official_test_video",
+    "corpus_documents": 3633,
+    "corpus_scope": "full",
+    "source_archive_sha256": "e2325ace35d02185a22e96bb52e72e62f2caf45a4975757c81a1c4087d8c59e9",
+    "index_sha256": "bf3fbede5fb624bd3c4def66de8d690bdfcda1f3f43c47637a5328cc8459730f",
+    "bm25": {
+      "k1": 1.5,
+      "b": 0.75,
+      "stopwords": "en",
+      "retrieval_depth": 1000,
+      "tie_break": "score descending, then doc_id ascending"
+    },
+    "reranker": {
+      "depth": 100,
+      "batch_size": 64,
+      "max_length": 512,
+      "device": "cpu"
+    },
+    "evaluation": {
+      "qrels_type": "graded",
+      "binary_relevance_threshold": 1,
+      "primary_metric": "recall@100",
+      "bootstrap_resamples": 10000,
+      "bootstrap_seed": 20260727,
+      "confidence_level": 0.95,
+      "independent_backend": "ir-measures",
+      "cross_check_tolerance": 1e-12,
+      "cross_check_max_abs_delta": 4.44089209850063e-16,
+      "candidate_set_checks": 306
+    }
+  },
+  "results": {
+    "title": {
+      "bm25": {
+        "mrr@10": 0.47801898537192655,
+        "ndcg@10": 0.2492523025557319,
+        "recall@100": 0.2820649478633883,
+        "recall@1000": 0.4918916912361657,
+        "no_hit@100": 11,
+        "no_hit@1000": 8
+      },
+      "bm25_ce": {
+        "mrr@10": 0.5220121381886088,
+        "ndcg@10": 0.29800270457307226,
+        "recall@100": 0.2820649478633883
+      },
+      "artifact_sha256": {
+        "bm25_run": "b513c5f2c71eff11c96ca17415d284303b8a4158316fd4f26fca9a0777eebe4b",
+        "bm25_manifest": "bd328a7472e235aa91aeee147751e4616b03bc9d718886e2143fb19326f7770a",
+        "rerank_run": "c3b21ad0a93a3b0e89625dad3e5ba81235ba7da1890749caed45f40492196f3c",
+        "rerank_manifest": "0e7479338688da77dd1989d62f88777f7dca0c66660458b4f7effcad1216485b"
+      }
+    },
+    "description": {
+      "bm25": {
+        "mrr@10": 0.5307812013694366,
+        "ndcg@10": 0.29292519150640756,
+        "recall@100": 0.32720991968215124,
+        "recall@1000": 0.6413485526903693,
+        "no_hit@100": 5,
+        "no_hit@1000": 0
+      },
+      "bm25_ce": {
+        "mrr@10": 0.6356987239340179,
+        "ndcg@10": 0.35680885115652944,
+        "recall@100": 0.32720991968215124
+      },
+      "paired_vs_title": {
+        "recall@100": {
+          "mean_delta": 0.045144971818762945,
+          "ci_low": -0.002418811420296822,
+          "ci_high": 0.09428571585868889,
+          "p_two_sided": 0.061
+        }
+      },
+      "artifact_sha256": {
+        "bm25_run": "d50eea2413808cb2091d5da3e40c52aebee5d7d44d71558f9a635ccf3111dfbf",
+        "bm25_manifest": "3a63c47e62e7dd645a4bc88949a513973fb3ae5c39c4aebf95469ddc220716a2",
+        "rerank_run": "d07eeff242e0c9a70a7df3bc5c98731211153e91f2f5d85434ca9ab4c1f37760",
+        "rerank_manifest": "0a1df9ddb43a8f9dc9626128e840ed16a6ff6880962def40d000101187e70722"
+      }
+    },
+    "title_plus_description": {
+      "bm25": {
+        "mrr@10": 0.6035675381263617,
+        "ndcg@10": 0.3457044547975855,
+        "recall@100": 0.37003019770278456,
+        "recall@1000": 0.6722956698813402,
+        "no_hit@100": 4,
+        "no_hit@1000": 0
+      },
+      "bm25_ce": {
+        "mrr@10": 0.6688569872393402,
+        "ndcg@10": 0.3853098932484767,
+        "recall@100": 0.37003019770278456
+      },
+      "paired_vs_title": {
+        "recall@100": {
+          "mean_delta": 0.08796524983939633,
+          "ci_low": 0.053493571705883924,
+          "ci_high": 0.12653714645075242,
+          "p_two_sided": 0.0
+        },
+        "bm25_mrr@10": {
+          "mean_delta": 0.1255485527544351,
+          "ci_low": 0.05427948957360724,
+          "ci_high": 0.20005835667600377,
+          "p_two_sided": 0.0002
+        },
+        "bm25_ndcg@10": {
+          "mean_delta": 0.09645215224185358,
+          "ci_low": 0.06050257728295668,
+          "ci_high": 0.1360630823778087,
+          "p_two_sided": 0.0
+        },
+        "bm25_ce_mrr@10": {
+          "mean_delta": 0.1468448490507314,
+          "ci_low": 0.06806333644568938,
+          "ci_high": 0.22466542172424533,
+          "p_two_sided": 0.0
+        },
+        "bm25_ce_ndcg@10": {
+          "mean_delta": 0.08730718867540446,
+          "ci_low": 0.04985774088388443,
+          "ci_high": 0.12498123747417648,
+          "p_two_sided": 0.0
+        }
+      },
+      "artifact_sha256": {
+        "bm25_run": "0aa39b63e47f7b1b1ae1091b80a67ee3ac670cdb0f215617cbb59522533c18b4",
+        "bm25_manifest": "92d059fd5a289ec57dd1e4687d8def04f7e5f00d319790ec91556207c866645f",
+        "rerank_run": "5e7807fb66c5567a1aacebb1410fd80fd24b7e9a4a3e33113065b4d2f3603e9a",
+        "rerank_manifest": "82626bbb0c9ec4e4b0f5f966eb4b60d5707e97f37341f2b17a8132e08edaa37e"
+      }
+    }
+  },
+  "tables": [
+    {
+      "id": "nfcorpus_video_query_representation_bm25",
+      "columns": [
+        {"heading": "Representation", "align": "l"},
+        {"heading": "MRR@10", "align": "r"},
+        {"heading": "nDCG@10", "align": "r"},
+        {"heading": "Recall@100", "align": "r"},
+        {"heading": "Recall@1000", "align": "r"}
+      ],
+      "rows": [
+        {"cells": ["Title", "0.4780", "0.2493", "0.2821", "0.4919"]},
+        {"cells": ["Description", "0.5308", "0.2929", "0.3272", "0.6413"]},
+        {"cells": ["Title + description", "0.6036", "0.3457", "0.3700", "0.6723"]}
+      ]
+    },
+    {
+      "id": "nfcorpus_video_query_representation_bm25_ce",
+      "columns": [
+        {"heading": "Representation", "align": "l"},
+        {"heading": "MRR@10", "align": "r"},
+        {"heading": "nDCG@10", "align": "r"},
+        {"heading": "Recall@100", "align": "r"}
+      ],
+      "rows": [
+        {"cells": ["Title", "0.5220", "0.2980", "0.2821"]},
+        {"cells": ["Description", "0.6357", "0.3568", "0.3272"]},
+        {"cells": ["Title + description", "0.6689", "0.3853", "0.3700"]}
+      ]
+    }
+  ]
+}

--- a/reports/generated/tables/nfcorpus_video_query_representation_bm25.sources.json
+++ b/reports/generated/tables/nfcorpus_video_query_representation_bm25.sources.json
@@ -1,0 +1,25 @@
+{
+  "schema": "msmarco-genqa.table-sources.v1",
+  "table_id": "nfcorpus_video_query_representation_bm25",
+  "hash_convention": "sha256_lf",
+  "sources": [
+    {
+      "path": "reports/generated/artifacts/nfcorpus_video_query_representation.json",
+      "sha256_16": "8485566947c393a2",
+      "artifact_schema": "msmarco-genqa.table-artifact.v1",
+      "artifact_id": "nfcorpus_video_query_representation",
+      "metric_schema": "retrieval.nfcorpus_video_query_representation.v1",
+      "query_set": {
+        "id": "nfcorpus-test-video",
+        "n_queries": 102,
+        "qid_sha256": "55dc5fa5b71077fd35046d45b674d70a0d033dad7eaacb83c56032e60347213f"
+      },
+      "model_revision": {
+        "first_stage": "bm25s-0.3.9",
+        "reranker": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        "reranker_revision": "c5ee24cb16019beea0893ab7796b1df96625c6b8",
+        "candidate_depth": 100
+      }
+    }
+  ]
+}

--- a/reports/generated/tables/nfcorpus_video_query_representation_bm25.tex
+++ b/reports/generated/tables/nfcorpus_video_query_representation_bm25.tex
@@ -1,0 +1,10 @@
+% Refresh with: python scripts/export_report_tables.py
+\begin{tabular}{lrrrr}
+    \toprule
+    Representation & MRR@10 & nDCG@10 & Recall@100 & Recall@1000 \\
+    \midrule
+    Title & 0.4780 & 0.2493 & 0.2821 & 0.4919 \\
+    Description & 0.5308 & 0.2929 & 0.3272 & 0.6413 \\
+    Title + description & 0.6036 & 0.3457 & 0.3700 & 0.6723 \\
+    \bottomrule
+\end{tabular}

--- a/reports/generated/tables/nfcorpus_video_query_representation_bm25_ce.sources.json
+++ b/reports/generated/tables/nfcorpus_video_query_representation_bm25_ce.sources.json
@@ -1,0 +1,25 @@
+{
+  "schema": "msmarco-genqa.table-sources.v1",
+  "table_id": "nfcorpus_video_query_representation_bm25_ce",
+  "hash_convention": "sha256_lf",
+  "sources": [
+    {
+      "path": "reports/generated/artifacts/nfcorpus_video_query_representation.json",
+      "sha256_16": "8485566947c393a2",
+      "artifact_schema": "msmarco-genqa.table-artifact.v1",
+      "artifact_id": "nfcorpus_video_query_representation",
+      "metric_schema": "retrieval.nfcorpus_video_query_representation.v1",
+      "query_set": {
+        "id": "nfcorpus-test-video",
+        "n_queries": 102,
+        "qid_sha256": "55dc5fa5b71077fd35046d45b674d70a0d033dad7eaacb83c56032e60347213f"
+      },
+      "model_revision": {
+        "first_stage": "bm25s-0.3.9",
+        "reranker": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        "reranker_revision": "c5ee24cb16019beea0893ab7796b1df96625c6b8",
+        "candidate_depth": 100
+      }
+    }
+  ]
+}

--- a/reports/generated/tables/nfcorpus_video_query_representation_bm25_ce.tex
+++ b/reports/generated/tables/nfcorpus_video_query_representation_bm25_ce.tex
@@ -1,0 +1,10 @@
+% Refresh with: python scripts/export_report_tables.py
+\begin{tabular}{lrrr}
+    \toprule
+    Representation & MRR@10 & nDCG@10 & Recall@100 \\
+    \midrule
+    Title & 0.5220 & 0.2980 & 0.2821 \\
+    Description & 0.6357 & 0.3568 & 0.3272 \\
+    Title + description & 0.6689 & 0.3853 & 0.3700 \\
+    \bottomrule
+\end{tabular}

--- a/scripts/analyze_nfcorpus_query_representations.py
+++ b/scripts/analyze_nfcorpus_query_representations.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate and compare the three frozen NFCorpus video query representations."""
+"""Validate and compare the frozen NFCorpus video query representations."""
 
 from __future__ import annotations
 
@@ -32,13 +32,16 @@ from msmarco_genqa.reranking.io import read_run_tsv
 
 
 REPRESENTATIONS = ("title", "description", "title_plus_description")
-METRICS = ("mrr@10", "ndcg@10", "recall@100", "recall@1000")
-PER_QUERY_METRICS = ("rr@10", "ndcg@10", "recall@100", "recall@1000")
+BM25_METRICS = ("mrr@10", "ndcg@10", "recall@100", "recall@1000")
+RERANK_METRICS = ("mrr@10", "ndcg@10", "recall@100")
+BM25_PER_QUERY_METRICS = ("rr@10", "ndcg@10", "recall@100", "recall@1000")
+RERANK_PER_QUERY_METRICS = ("rr@10", "ndcg@10", "recall@100")
 
 
 @dataclass(frozen=True)
 class Condition:
     name: str
+    stage: str
     directory: Path
     run: dict[str, list[tuple[str, float]]]
     metrics_payload: dict[str, object]
@@ -74,10 +77,16 @@ def _read_json(path: Path) -> dict[str, object]:
     return payload
 
 
-def load_condition(input_root: Path, representation: str) -> Condition:
-    directory = input_root / representation / "bm25"
+def load_condition(
+    input_root: Path,
+    representation: str,
+    *,
+    stage: str,
+) -> Condition:
+    directory = input_root / representation / stage
     return Condition(
         name=representation,
+        stage=stage,
         directory=directory,
         run=read_run_tsv(directory / "run.tsv"),
         metrics_payload=_read_json(directory / "metrics.json"),
@@ -151,9 +160,111 @@ def validate_shared_contract(
     }
 
 
+def validate_rerank_contract(
+    bm25_conditions: Mapping[str, Condition],
+    rerank_conditions: Mapping[str, Condition],
+    *,
+    expected_queries: int = 102,
+    expected_depth: int = 100,
+) -> dict[str, object]:
+    if set(bm25_conditions) != set(REPRESENTATIONS):
+        raise ValueError(f"expected BM25 conditions {REPRESENTATIONS}")
+    if set(rerank_conditions) != set(REPRESENTATIONS):
+        raise ValueError(f"expected rerank conditions {REPRESENTATIONS}")
+
+    commits: set[str] = set()
+    model_names: set[str] = set()
+    model_revisions: set[str] = set()
+    candidate_checks = 0
+    for name in REPRESENTATIONS:
+        bm25 = bm25_conditions[name]
+        rerank = rerank_conditions[name]
+        if set(rerank.run) != set(bm25.run):
+            raise ValueError(f"{name}: rerank and BM25 qid sets differ")
+        if len(rerank.run) != expected_queries:
+            raise ValueError(
+                f"{name}: rerank has {len(rerank.run)} qids; "
+                f"expected {expected_queries}"
+            )
+        if any(len(rows) != expected_depth for rows in rerank.run.values()):
+            raise ValueError(
+                f"{name}: not every reranked block has depth {expected_depth}"
+            )
+        for qid in sorted(rerank.run):
+            bm25_candidates = {
+                doc_id for doc_id, _score in bm25.run[qid][:expected_depth]
+            }
+            rerank_candidates = {
+                doc_id for doc_id, _score in rerank.run[qid]
+            }
+            if rerank_candidates != bm25_candidates:
+                raise ValueError(
+                    f"{name}/{qid}: reranker candidate set differs from "
+                    f"BM25 top-{expected_depth}"
+                )
+            candidate_checks += 1
+
+        if rerank.query_summary.get("representation") != name:
+            raise ValueError(f"{name}: rerank query summary names another representation")
+        for field in (
+            "qid_sha256",
+            "official_query_records_sha256",
+            "effective_queries_sha256",
+        ):
+            if rerank.query_summary.get(field) != bm25.query_summary.get(field):
+                raise ValueError(
+                    f"{name}: rerank and BM25 query summaries differ on {field}"
+                )
+
+        git = rerank.manifest.get("git")
+        if not isinstance(git, dict) or git.get("dirty") is not False:
+            raise ValueError(f"{name}: rerank manifest must record a clean git tree")
+        commit = git.get("commit")
+        if not isinstance(commit, str) or not commit:
+            raise ValueError(f"{name}: rerank manifest git commit is missing")
+        commits.add(commit)
+
+        config = rerank.metrics_payload.get("config")
+        if not isinstance(config, dict):
+            raise ValueError(f"{name}: rerank metrics config is missing")
+        reranker = config.get("reranker")
+        if not isinstance(reranker, dict):
+            raise ValueError(f"{name}: reranker config is missing")
+        model_name = reranker.get("model_name")
+        revision = reranker.get("revision")
+        if not isinstance(model_name, str) or not model_name:
+            raise ValueError(f"{name}: reranker model name is missing")
+        if (
+            not isinstance(revision, str)
+            or len(revision) != 40
+            or any(character not in "0123456789abcdef" for character in revision)
+        ):
+            raise ValueError(f"{name}: reranker model revision is not pinned")
+        model_names.add(model_name)
+        model_revisions.add(revision)
+
+    if len(commits) != 1:
+        raise ValueError("rerank conditions were produced from different commits")
+    if len(model_names) != 1 or len(model_revisions) != 1:
+        raise ValueError("rerank conditions do not share one pinned model")
+
+    return {
+        "query_count": expected_queries,
+        "run_depth": expected_depth,
+        "git_commit": next(iter(commits)),
+        "model_name": next(iter(model_names)),
+        "model_revision": next(iter(model_revisions)),
+        "candidate_set_checks": candidate_checks,
+        "candidate_sets_match_bm25_top_100": True,
+        "run_structure_valid": True,
+    }
+
+
 def build_per_query_rows(
     runs: Mapping[str, dict[str, list[tuple[str, float]]]],
     graded_qrels: Mapping[str, dict[str, int]],
+    *,
+    include_recall_at_1000: bool = True,
 ) -> list[dict[str, object]]:
     qids = sorted(graded_qrels)
     if any(set(run) != set(qids) for run in runs.values()):
@@ -173,22 +284,24 @@ def build_per_query_rows(
         condition_metrics: dict[str, object] = {}
         for name, run in runs.items():
             ranked = [doc_id for doc_id, _score in run[qid]]
-            condition_metrics[name] = {
+            metrics: dict[str, object] = {
                 "rr@10": reciprocal_rank(ranked, relevant, 10),
                 "ndcg@10": graded_ndcg_at_k(ranked, judgments, k=10),
                 "recall@100": recall_at_k(ranked, relevant, 100),
-                "recall@1000": recall_at_k(ranked, relevant, 1000),
                 "first_relevant_rank@100": first_relevant_rank(
                     ranked,
                     relevant,
                     100,
                 ),
-                "first_relevant_rank@1000": first_relevant_rank(
+            }
+            if include_recall_at_1000:
+                metrics["recall@1000"] = recall_at_k(ranked, relevant, 1000)
+                metrics["first_relevant_rank@1000"] = first_relevant_rank(
                     ranked,
                     relevant,
                     1000,
-                ),
-            }
+                )
+            condition_metrics[name] = metrics
         row["conditions"] = condition_metrics
         rows.append(row)
     return rows
@@ -199,6 +312,8 @@ def build_paired_comparisons(
     *,
     n_resamples: int,
     seed: int,
+    metric_names: Sequence[str] = BM25_PER_QUERY_METRICS,
+    no_hit_cutoffs: Sequence[int] = (100, 1000),
 ) -> dict[str, object]:
     pairs = (
         ("description_vs_title", "title", "description"),
@@ -216,7 +331,7 @@ def build_paired_comparisons(
     comparisons: dict[str, object] = {}
     for label, baseline, treatment in pairs:
         metrics: dict[str, object] = {}
-        for metric in PER_QUERY_METRICS:
+        for metric in metric_names:
             baseline_scores = [
                 float(row["conditions"][baseline][metric])  # type: ignore[index]
                 for row in rows
@@ -244,7 +359,7 @@ def build_paired_comparisons(
             metrics[metric] = bootstrap
 
         no_hit: dict[str, object] = {}
-        for cutoff in (100, 1000):
+        for cutoff in no_hit_cutoffs:
             key = f"first_relevant_rank@{cutoff}"
             baseline_miss = [
                 row["conditions"][baseline][key] is None  # type: ignore[index]
@@ -279,6 +394,8 @@ def _condition_metrics(
     conditions: Mapping[str, Condition],
     graded_qrels: dict[str, dict[str, int]],
     *,
+    metric_names: tuple[str, ...],
+    reported_section: str | None,
     tolerance: float,
 ) -> tuple[dict[str, object], dict[str, object]]:
     aggregate: dict[str, object] = {}
@@ -288,13 +405,18 @@ def _condition_metrics(
             qid: [doc_id for doc_id, _score in rows]
             for qid, rows in condition.run.items()
         }
+        recall_cutoffs = tuple(
+            int(metric.split("@", maxsplit=1)[1])
+            for metric in metric_names
+            if metric.startswith("recall@")
+        )
         internal = evaluate_trec_retrieval(
             ranked,
             graded_qrels,
             rel_threshold=1,
             ks_mrr=(10,),
             ks_ndcg=(10,),
-            ks_recall=(100, 1000),
+            ks_recall=recall_cutoffs,
         )
         external = evaluate_ir_measures(
             condition.run,
@@ -305,20 +427,32 @@ def _condition_metrics(
             internal,
             external,
             tolerance=tolerance,
+            metric_names=metric_names,
         )
         reported = condition.metrics_payload.get("metrics")
         if not isinstance(reported, dict):
             raise ValueError(f"{name}: metrics.json is missing metrics")
+        if reported_section is not None:
+            reported = reported.get(reported_section)
+            if not isinstance(reported, dict):
+                raise ValueError(
+                    f"{name}: metrics.json is missing metrics.{reported_section}"
+                )
         report_deltas = compare_metric_sets(
             internal,
-            {metric: float(reported[metric]) for metric in METRICS},
+            {metric: float(reported[metric]) for metric in metric_names},
             tolerance=tolerance,
+            metric_names=metric_names,
         )
-        aggregate[name] = {metric: float(internal[metric]) for metric in METRICS}
+        aggregate[name] = {
+            metric: float(internal[metric]) for metric in metric_names
+        }
         cross_checks[name] = {
             "backend": "ir-measures",
             "status": "passed",
-            "external_metrics": external,
+            "external_metrics": {
+                metric: float(external[metric]) for metric in metric_names
+            },
             "external_absolute_deltas": deltas,
             "reported_absolute_deltas": report_deltas,
         }
@@ -330,56 +464,76 @@ def _format_p(value: float) -> str:
 
 
 def render_report(summary: Mapping[str, object]) -> str:
-    aggregate = summary["aggregate_metrics"]
-    comparisons = summary["paired_comparisons"]
+    aggregate_by_stage = summary["aggregate_metrics"]
+    comparisons_by_stage = summary["paired_comparisons"]
     lines = [
         "# NFCorpus Video Query-Representation Analysis",
         "",
-        "## Result",
-        "",
-        "| Representation | MRR@10 | nDCG@10 | Recall@100 | Recall@1000 |",
-        "|---|---:|---:|---:|---:|",
     ]
     labels = {
         "title": "Title",
         "description": "Description",
         "title_plus_description": "Title + description",
     }
-    for name in REPRESENTATIONS:
-        metrics = aggregate[name]
-        lines.append(
-            f"| {labels[name]} | {metrics['mrr@10']:.6f} | "
-            f"{metrics['ndcg@10']:.6f} | {metrics['recall@100']:.6f} | "
-            f"{metrics['recall@1000']:.6f} |"
-        )
-
-    lines.extend(
-        [
-            "",
-            "## Paired comparison against title",
-            "",
-            "| Treatment | Metric | Delta | 95% CI | p (two-sided) | W/T/L |",
-            "|---|---|---:|---:|---:|---:|",
-        ]
-    )
-    for comparison_name in (
-        "description_vs_title",
-        "title_plus_description_vs_title",
+    for stage, stage_label, metric_names in (
+        ("bm25", "BM25", BM25_METRICS),
+        ("cross_encoder_rerank", "BM25 + cross-encoder", RERANK_METRICS),
     ):
-        comparison = comparisons[comparison_name]
-        treatment = labels[comparison["treatment"]]
-        for metric in PER_QUERY_METRICS:
-            result = comparison["metrics"][metric]
+        aggregate = aggregate_by_stage[stage]
+        comparisons = comparisons_by_stage[stage]
+        lines.extend(
+            [
+                f"## {stage_label} result",
+                "",
+                "| Representation | MRR@10 | nDCG@10 | Recall@100"
+                + (" | Recall@1000 |" if "recall@1000" in metric_names else " |"),
+                "|---|---:|---:|---:"
+                + ("|---:|" if "recall@1000" in metric_names else "|"),
+            ]
+        )
+        for name in REPRESENTATIONS:
+            metrics = aggregate[name]
             lines.append(
-                f"| {treatment} | {metric} | {result['mean_delta']:+.6f} | "
-                f"[{result['ci_low']:+.6f}, {result['ci_high']:+.6f}] | "
-                f"{_format_p(result['p_two_sided'])} | "
-                f"{result['wins']}/{result['ties']}/{result['losses']} |"
+                f"| {labels[name]} | {metrics['mrr@10']:.6f} | "
+                f"{metrics['ndcg@10']:.6f} | {metrics['recall@100']:.6f}"
+                + (
+                    f" | {metrics['recall@1000']:.6f} |"
+                    if "recall@1000" in metric_names
+                    else " |"
+                )
             )
+        lines.extend(
+            [
+                "",
+                f"### {stage_label} paired comparison against title",
+                "",
+                "| Treatment | Metric | Delta | 95% CI | p (two-sided) | W/T/L |",
+                "|---|---|---:|---:|---:|---:|",
+            ]
+        )
+        paired_metrics = (
+            BM25_PER_QUERY_METRICS
+            if stage == "bm25"
+            else RERANK_PER_QUERY_METRICS
+        )
+        for comparison_name in (
+            "description_vs_title",
+            "title_plus_description_vs_title",
+        ):
+            comparison = comparisons[comparison_name]
+            treatment = labels[comparison["treatment"]]
+            for metric in paired_metrics:
+                result = comparison["metrics"][metric]
+                lines.append(
+                    f"| {treatment} | {metric} | {result['mean_delta']:+.6f} | "
+                    f"[{result['ci_low']:+.6f}, {result['ci_high']:+.6f}] | "
+                    f"{_format_p(result['p_two_sided'])} | "
+                    f"{result['wins']}/{result['ties']}/{result['losses']} |"
+                )
+        lines.append("")
 
     lines.extend(
         [
-            "",
             "## Interpretation boundary",
             "",
             "The comparison changes only the query representation on the official "
@@ -388,9 +542,12 @@ def render_report(summary: Mapping[str, object]) -> str:
             "descriptions are source-page context, not independently authored user "
             "queries.",
             "",
-            "All three runs use the same qids, qrels, corpus index, BM25 parameters, "
-            "deterministic tie rule, code commit, and clean-tree manifest. Aggregate "
-            "metrics were independently cross-checked with ir-measures.",
+            "All three BM25 runs use the same qids, qrels, corpus index, parameters, "
+            "deterministic tie rule, code commit, and clean-tree manifest. Each "
+            "reranked run contains exactly its corresponding BM25 top-100 candidate "
+            "set, and all reranked runs use the same pinned model and clean-tree "
+            "commit. Aggregate metrics were independently cross-checked with "
+            "ir-measures.",
             "",
         ]
     )
@@ -414,44 +571,99 @@ def main(argv: Sequence[str] | None = None) -> None:
         if args.output_dir.is_absolute()
         else PROJECT_ROOT / args.output_dir
     )
-    conditions = {
-        representation: load_condition(input_root, representation)
+    bm25_conditions = {
+        representation: load_condition(
+            input_root,
+            representation,
+            stage="bm25",
+        )
         for representation in REPRESENTATIONS
     }
-    contract = validate_shared_contract(conditions)
+    rerank_conditions = {
+        representation: load_condition(
+            input_root,
+            representation,
+            stage="cross_encoder_rerank",
+        )
+        for representation in REPRESENTATIONS
+    }
+    bm25_contract = validate_shared_contract(bm25_conditions)
+    rerank_contract = validate_rerank_contract(
+        bm25_conditions,
+        rerank_conditions,
+    )
 
     benchmark = load_benchmark_queries(
         "beir/nfcorpus/test",
         cache_dir=PROJECT_ROOT / "data/raw",
     )
-    qids = set(conditions["title"].run)
+    qids = set(bm25_conditions["title"].run)
     graded_qrels = {
         qid: dict(benchmark.graded_qrels[qid])
         for qid in sorted(qids)
     }
-    aggregate, cross_checks = _condition_metrics(
-        conditions,
+    bm25_aggregate, bm25_cross_checks = _condition_metrics(
+        bm25_conditions,
         graded_qrels,
+        metric_names=BM25_METRICS,
+        reported_section=None,
         tolerance=args.tolerance,
     )
-    rows = build_per_query_rows(
-        {name: condition.run for name, condition in conditions.items()},
+    rerank_aggregate, rerank_cross_checks = _condition_metrics(
+        rerank_conditions,
+        graded_qrels,
+        metric_names=RERANK_METRICS,
+        reported_section="rerank",
+        tolerance=args.tolerance,
+    )
+    bm25_rows = build_per_query_rows(
+        {
+            name: condition.run
+            for name, condition in bm25_conditions.items()
+        },
         graded_qrels,
     )
-    comparisons = build_paired_comparisons(
-        rows,
+    rerank_rows = build_per_query_rows(
+        {
+            name: condition.run
+            for name, condition in rerank_conditions.items()
+        },
+        graded_qrels,
+        include_recall_at_1000=False,
+    )
+    bm25_comparisons = build_paired_comparisons(
+        bm25_rows,
         n_resamples=args.bootstrap_resamples,
         seed=args.bootstrap_seed,
     )
+    rerank_comparisons = build_paired_comparisons(
+        rerank_rows,
+        n_resamples=args.bootstrap_resamples,
+        seed=args.bootstrap_seed,
+        metric_names=RERANK_PER_QUERY_METRICS,
+        no_hit_cutoffs=(100,),
+    )
 
     summary: dict[str, object] = {
-        "schema": "msmarco-genqa.nfcorpus-video-query-analysis.v1",
+        "schema": "msmarco-genqa.nfcorpus-video-query-analysis.v2",
         "dataset": "beir/nfcorpus/test",
         "subset": "official_test_video",
-        "contract": contract,
-        "aggregate_metrics": aggregate,
-        "independent_cross_checks": cross_checks,
-        "paired_comparisons": comparisons,
+        "contracts": {
+            "bm25": bm25_contract,
+            "cross_encoder_rerank": rerank_contract,
+        },
+        "aggregate_metrics": {
+            "bm25": bm25_aggregate,
+            "cross_encoder_rerank": rerank_aggregate,
+        },
+        "independent_cross_checks": {
+            "bm25": bm25_cross_checks,
+            "cross_encoder_rerank": rerank_cross_checks,
+        },
+        "paired_comparisons": {
+            "bm25": bm25_comparisons,
+            "cross_encoder_rerank": rerank_comparisons,
+        },
         "bootstrap": {
             "resamples": args.bootstrap_resamples,
             "seed": args.bootstrap_seed,
@@ -472,7 +684,17 @@ def main(argv: Sequence[str] | None = None) -> None:
         encoding="utf-8",
         newline="\n",
     ) as handle:
-        for row in rows:
+        for bm25_row, rerank_row in zip(bm25_rows, rerank_rows):
+            if bm25_row["query_id"] != rerank_row["query_id"]:
+                raise ValueError("BM25 and rerank per-query row order differs")
+            row = {
+                "query_id": bm25_row["query_id"],
+                "n_relevant": bm25_row["n_relevant"],
+                "stages": {
+                    "bm25": bm25_row["conditions"],
+                    "cross_encoder_rerank": rerank_row["conditions"],
+                },
+            }
             handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
     (output_dir / "report.md").write_text(
         render_report(summary),
@@ -481,14 +703,19 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
 
     print("NFCorpus video query-representation analysis complete")
-    for name in REPRESENTATIONS:
-        metrics = aggregate[name]
-        print(
-            f"  {name:24s} "
-            f"MRR@10={metrics['mrr@10']:.6f} "
-            f"nDCG@10={metrics['ndcg@10']:.6f} "
-            f"Recall@100={metrics['recall@100']:.6f}"
-        )
+    for stage, aggregate in (
+        ("bm25", bm25_aggregate),
+        ("cross_encoder_rerank", rerank_aggregate),
+    ):
+        print(f"  {stage}")
+        for name in REPRESENTATIONS:
+            metrics = aggregate[name]
+            print(
+                f"    {name:24s} "
+                f"MRR@10={metrics['mrr@10']:.6f} "
+                f"nDCG@10={metrics['ndcg@10']:.6f} "
+                f"Recall@100={metrics['recall@100']:.6f}"
+            )
     print(f"outputs: {output_dir}")
 
 

--- a/scripts/analyze_nfcorpus_query_representations.py
+++ b/scripts/analyze_nfcorpus_query_representations.py
@@ -16,6 +16,12 @@ if str(PROJECT_ROOT / "src") not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from msmarco_genqa.data.benchmark import load_benchmark_queries
+from msmarco_genqa.data.nfcorpus_video import (
+    FIXED_RERANK_DEPTH,
+    FIXED_RERANK_MAX_LENGTH,
+    FIXED_RERANKER_MODEL,
+    FIXED_RERANKER_REVISION,
+)
 from msmarco_genqa.evaluation.bootstrap import paired_bootstrap_diff
 from msmarco_genqa.evaluation.retrieval import (
     first_relevant_rank,
@@ -240,6 +246,12 @@ def validate_rerank_contract(
             or any(character not in "0123456789abcdef" for character in revision)
         ):
             raise ValueError(f"{name}: reranker model revision is not pinned")
+        if reranker.get("rerank_top_k") != FIXED_RERANK_DEPTH:
+            raise ValueError(f"{name}: reranker depth differs from the frozen value")
+        if reranker.get("max_length") != FIXED_RERANK_MAX_LENGTH:
+            raise ValueError(
+                f"{name}: reranker max length differs from the frozen value"
+            )
         model_names.add(model_name)
         model_revisions.add(revision)
 
@@ -247,6 +259,10 @@ def validate_rerank_contract(
         raise ValueError("rerank conditions were produced from different commits")
     if len(model_names) != 1 or len(model_revisions) != 1:
         raise ValueError("rerank conditions do not share one pinned model")
+    if model_names != {FIXED_RERANKER_MODEL}:
+        raise ValueError("rerank conditions do not use the frozen model")
+    if model_revisions != {FIXED_RERANKER_REVISION}:
+        raise ValueError("rerank conditions do not use the frozen model revision")
 
     return {
         "query_count": expected_queries,

--- a/scripts/analyze_nfcorpus_query_representations.py
+++ b/scripts/analyze_nfcorpus_query_representations.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Validate and compare the three frozen NFCorpus video query representations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from msmarco_genqa.data.benchmark import load_benchmark_queries
+from msmarco_genqa.evaluation.bootstrap import paired_bootstrap_diff
+from msmarco_genqa.evaluation.retrieval import (
+    first_relevant_rank,
+    recall_at_k,
+    reciprocal_rank,
+)
+from msmarco_genqa.evaluation.trec import (
+    compare_metric_sets,
+    evaluate_ir_measures,
+    evaluate_trec_retrieval,
+    graded_ndcg_at_k,
+)
+from msmarco_genqa.reranking.io import read_run_tsv
+
+
+REPRESENTATIONS = ("title", "description", "title_plus_description")
+METRICS = ("mrr@10", "ndcg@10", "recall@100", "recall@1000")
+PER_QUERY_METRICS = ("rr@10", "ndcg@10", "recall@100", "recall@1000")
+
+
+@dataclass(frozen=True)
+class Condition:
+    name: str
+    directory: Path
+    run: dict[str, list[tuple[str, float]]]
+    metrics_payload: dict[str, object]
+    manifest: dict[str, object]
+    query_summary: dict[str, object]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input-root",
+        type=Path,
+        default=PROJECT_ROOT / "outputs/beir_nfcorpus_video",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=PROJECT_ROOT / "outputs/analysis/nfcorpus_video_query_representation",
+    )
+    parser.add_argument("--bootstrap-resamples", type=int, default=10000)
+    parser.add_argument("--bootstrap-seed", type=int, default=20260727)
+    parser.add_argument("--tolerance", type=float, default=1e-12)
+    return parser.parse_args(argv)
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read JSON artifact {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def load_condition(input_root: Path, representation: str) -> Condition:
+    directory = input_root / representation / "bm25"
+    return Condition(
+        name=representation,
+        directory=directory,
+        run=read_run_tsv(directory / "run.tsv"),
+        metrics_payload=_read_json(directory / "metrics.json"),
+        manifest=_read_json(directory / "manifest.json"),
+        query_summary=_read_json(directory / "query_representation/summary.json"),
+    )
+
+
+def validate_shared_contract(
+    conditions: Mapping[str, Condition],
+    *,
+    expected_queries: int = 102,
+    expected_depth: int = 1000,
+) -> dict[str, object]:
+    if set(conditions) != set(REPRESENTATIONS):
+        raise ValueError(f"expected conditions {REPRESENTATIONS}")
+
+    qid_sets = {name: set(condition.run) for name, condition in conditions.items()}
+    reference_qids = qid_sets["title"]
+    if len(reference_qids) != expected_queries:
+        raise ValueError(
+            f"title condition has {len(reference_qids)} qids; expected {expected_queries}"
+        )
+    if any(qids != reference_qids for qids in qid_sets.values()):
+        raise ValueError("query-id sets differ across representation conditions")
+
+    commits: set[str] = set()
+    index_hashes: set[str] = set()
+    cohort_hashes: set[str] = set()
+    record_hashes: set[str] = set()
+    for name, condition in conditions.items():
+        if condition.query_summary.get("representation") != name:
+            raise ValueError(f"{name}: query summary names another representation")
+        if any(len(rows) != expected_depth for rows in condition.run.values()):
+            raise ValueError(f"{name}: not every run block has depth {expected_depth}")
+        git = condition.manifest.get("git")
+        if not isinstance(git, dict) or git.get("dirty") is not False:
+            raise ValueError(f"{name}: canonical manifest must record a clean git tree")
+        commit = git.get("commit")
+        if not isinstance(commit, str) or not commit:
+            raise ValueError(f"{name}: manifest git commit is missing")
+        commits.add(commit)
+
+        fingerprint = condition.query_summary.get("index_fingerprint")
+        if not isinstance(fingerprint, dict):
+            raise ValueError(f"{name}: index fingerprint is missing")
+        index_hash = fingerprint.get("sha256")
+        if not isinstance(index_hash, str) or len(index_hash) != 64:
+            raise ValueError(f"{name}: index SHA-256 is invalid")
+        index_hashes.add(index_hash)
+        cohort_hashes.add(str(condition.query_summary.get("qid_sha256")))
+        record_hashes.add(
+            str(condition.query_summary.get("official_query_records_sha256"))
+        )
+
+    if len(commits) != 1:
+        raise ValueError("conditions were produced from different commits")
+    if len(index_hashes) != 1:
+        raise ValueError("conditions were produced from different BM25 indexes")
+    if len(cohort_hashes) != 1 or len(record_hashes) != 1:
+        raise ValueError("conditions do not share the same query cohort/source records")
+
+    return {
+        "query_count": len(reference_qids),
+        "run_depth": expected_depth,
+        "git_commit": next(iter(commits)),
+        "index_sha256": next(iter(index_hashes)),
+        "qid_sha256": next(iter(cohort_hashes)),
+        "official_query_records_sha256": next(iter(record_hashes)),
+        "run_structure_valid": True,
+    }
+
+
+def build_per_query_rows(
+    runs: Mapping[str, dict[str, list[tuple[str, float]]]],
+    graded_qrels: Mapping[str, dict[str, int]],
+) -> list[dict[str, object]]:
+    qids = sorted(graded_qrels)
+    if any(set(run) != set(qids) for run in runs.values()):
+        raise ValueError("run qids must exactly match the evaluation qids")
+
+    rows: list[dict[str, object]] = []
+    for qid in qids:
+        judgments = graded_qrels[qid]
+        relevant = {
+            doc_id for doc_id, relevance in judgments.items() if relevance >= 1
+        }
+        row: dict[str, object] = {
+            "query_id": qid,
+            "n_relevant": len(relevant),
+            "conditions": {},
+        }
+        condition_metrics: dict[str, object] = {}
+        for name, run in runs.items():
+            ranked = [doc_id for doc_id, _score in run[qid]]
+            condition_metrics[name] = {
+                "rr@10": reciprocal_rank(ranked, relevant, 10),
+                "ndcg@10": graded_ndcg_at_k(ranked, judgments, k=10),
+                "recall@100": recall_at_k(ranked, relevant, 100),
+                "recall@1000": recall_at_k(ranked, relevant, 1000),
+                "first_relevant_rank@100": first_relevant_rank(
+                    ranked,
+                    relevant,
+                    100,
+                ),
+                "first_relevant_rank@1000": first_relevant_rank(
+                    ranked,
+                    relevant,
+                    1000,
+                ),
+            }
+        row["conditions"] = condition_metrics
+        rows.append(row)
+    return rows
+
+
+def build_paired_comparisons(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    n_resamples: int,
+    seed: int,
+) -> dict[str, object]:
+    pairs = (
+        ("description_vs_title", "title", "description"),
+        (
+            "title_plus_description_vs_title",
+            "title",
+            "title_plus_description",
+        ),
+        (
+            "title_plus_description_vs_description",
+            "description",
+            "title_plus_description",
+        ),
+    )
+    comparisons: dict[str, object] = {}
+    for label, baseline, treatment in pairs:
+        metrics: dict[str, object] = {}
+        for metric in PER_QUERY_METRICS:
+            baseline_scores = [
+                float(row["conditions"][baseline][metric])  # type: ignore[index]
+                for row in rows
+            ]
+            treatment_scores = [
+                float(row["conditions"][treatment][metric])  # type: ignore[index]
+                for row in rows
+            ]
+            bootstrap = paired_bootstrap_diff(
+                baseline_scores,
+                treatment_scores,
+                n_resamples=n_resamples,
+                seed=seed,
+            )
+            deltas = [
+                treatment_score - baseline_score
+                for baseline_score, treatment_score in zip(
+                    baseline_scores,
+                    treatment_scores,
+                )
+            ]
+            bootstrap["wins"] = sum(delta > 0 for delta in deltas)
+            bootstrap["ties"] = sum(delta == 0 for delta in deltas)
+            bootstrap["losses"] = sum(delta < 0 for delta in deltas)
+            metrics[metric] = bootstrap
+
+        no_hit: dict[str, object] = {}
+        for cutoff in (100, 1000):
+            key = f"first_relevant_rank@{cutoff}"
+            baseline_miss = [
+                row["conditions"][baseline][key] is None  # type: ignore[index]
+                for row in rows
+            ]
+            treatment_miss = [
+                row["conditions"][treatment][key] is None  # type: ignore[index]
+                for row in rows
+            ]
+            no_hit[f"@{cutoff}"] = {
+                "baseline": sum(baseline_miss),
+                "treatment": sum(treatment_miss),
+                "recovered": sum(
+                    before and not after
+                    for before, after in zip(baseline_miss, treatment_miss)
+                ),
+                "lost": sum(
+                    not before and after
+                    for before, after in zip(baseline_miss, treatment_miss)
+                ),
+            }
+        comparisons[label] = {
+            "baseline": baseline,
+            "treatment": treatment,
+            "metrics": metrics,
+            "no_hit_queries": no_hit,
+        }
+    return comparisons
+
+
+def _condition_metrics(
+    conditions: Mapping[str, Condition],
+    graded_qrels: dict[str, dict[str, int]],
+    *,
+    tolerance: float,
+) -> tuple[dict[str, object], dict[str, object]]:
+    aggregate: dict[str, object] = {}
+    cross_checks: dict[str, object] = {}
+    for name, condition in conditions.items():
+        ranked = {
+            qid: [doc_id for doc_id, _score in rows]
+            for qid, rows in condition.run.items()
+        }
+        internal = evaluate_trec_retrieval(
+            ranked,
+            graded_qrels,
+            rel_threshold=1,
+            ks_mrr=(10,),
+            ks_ndcg=(10,),
+            ks_recall=(100, 1000),
+        )
+        external = evaluate_ir_measures(
+            condition.run,
+            graded_qrels,
+            rel_threshold=1,
+        )
+        deltas = compare_metric_sets(
+            internal,
+            external,
+            tolerance=tolerance,
+        )
+        reported = condition.metrics_payload.get("metrics")
+        if not isinstance(reported, dict):
+            raise ValueError(f"{name}: metrics.json is missing metrics")
+        report_deltas = compare_metric_sets(
+            internal,
+            {metric: float(reported[metric]) for metric in METRICS},
+            tolerance=tolerance,
+        )
+        aggregate[name] = {metric: float(internal[metric]) for metric in METRICS}
+        cross_checks[name] = {
+            "backend": "ir-measures",
+            "status": "passed",
+            "external_metrics": external,
+            "external_absolute_deltas": deltas,
+            "reported_absolute_deltas": report_deltas,
+        }
+    return aggregate, cross_checks
+
+
+def _format_p(value: float) -> str:
+    return "< 0.0002" if value == 0.0 else f"= {value:.4f}"
+
+
+def render_report(summary: Mapping[str, object]) -> str:
+    aggregate = summary["aggregate_metrics"]
+    comparisons = summary["paired_comparisons"]
+    lines = [
+        "# NFCorpus Video Query-Representation Analysis",
+        "",
+        "## Result",
+        "",
+        "| Representation | MRR@10 | nDCG@10 | Recall@100 | Recall@1000 |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    labels = {
+        "title": "Title",
+        "description": "Description",
+        "title_plus_description": "Title + description",
+    }
+    for name in REPRESENTATIONS:
+        metrics = aggregate[name]
+        lines.append(
+            f"| {labels[name]} | {metrics['mrr@10']:.6f} | "
+            f"{metrics['ndcg@10']:.6f} | {metrics['recall@100']:.6f} | "
+            f"{metrics['recall@1000']:.6f} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Paired comparison against title",
+            "",
+            "| Treatment | Metric | Delta | 95% CI | p (two-sided) | W/T/L |",
+            "|---|---|---:|---:|---:|---:|",
+        ]
+    )
+    for comparison_name in (
+        "description_vs_title",
+        "title_plus_description_vs_title",
+    ):
+        comparison = comparisons[comparison_name]
+        treatment = labels[comparison["treatment"]]
+        for metric in PER_QUERY_METRICS:
+            result = comparison["metrics"][metric]
+            lines.append(
+                f"| {treatment} | {metric} | {result['mean_delta']:+.6f} | "
+                f"[{result['ci_low']:+.6f}, {result['ci_high']:+.6f}] | "
+                f"{_format_p(result['p_two_sided'])} | "
+                f"{result['wins']}/{result['ties']}/{result['losses']} |"
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Interpretation boundary",
+            "",
+            "The comparison changes only the query representation on the official "
+            "102-query video subset. It does not establish generation quality, "
+            "cross-dataset transfer, or an architecture improvement. Official video "
+            "descriptions are source-page context, not independently authored user "
+            "queries.",
+            "",
+            "All three runs use the same qids, qrels, corpus index, BM25 parameters, "
+            "deterministic tie rule, code commit, and clean-tree manifest. Aggregate "
+            "metrics were independently cross-checked with ir-measures.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.bootstrap_resamples < 1:
+        raise SystemExit("--bootstrap-resamples must be positive")
+    if not math.isfinite(args.tolerance) or args.tolerance < 0:
+        raise SystemExit("--tolerance must be a finite non-negative number")
+
+    input_root = (
+        args.input_root
+        if args.input_root.is_absolute()
+        else PROJECT_ROOT / args.input_root
+    )
+    output_dir = (
+        args.output_dir
+        if args.output_dir.is_absolute()
+        else PROJECT_ROOT / args.output_dir
+    )
+    conditions = {
+        representation: load_condition(input_root, representation)
+        for representation in REPRESENTATIONS
+    }
+    contract = validate_shared_contract(conditions)
+
+    benchmark = load_benchmark_queries(
+        "beir/nfcorpus/test",
+        cache_dir=PROJECT_ROOT / "data/raw",
+    )
+    qids = set(conditions["title"].run)
+    graded_qrels = {
+        qid: dict(benchmark.graded_qrels[qid])
+        for qid in sorted(qids)
+    }
+    aggregate, cross_checks = _condition_metrics(
+        conditions,
+        graded_qrels,
+        tolerance=args.tolerance,
+    )
+    rows = build_per_query_rows(
+        {name: condition.run for name, condition in conditions.items()},
+        graded_qrels,
+    )
+    comparisons = build_paired_comparisons(
+        rows,
+        n_resamples=args.bootstrap_resamples,
+        seed=args.bootstrap_seed,
+    )
+
+    summary: dict[str, object] = {
+        "schema": "msmarco-genqa.nfcorpus-video-query-analysis.v1",
+        "dataset": "beir/nfcorpus/test",
+        "subset": "official_test_video",
+        "contract": contract,
+        "aggregate_metrics": aggregate,
+        "independent_cross_checks": cross_checks,
+        "paired_comparisons": comparisons,
+        "bootstrap": {
+            "resamples": args.bootstrap_resamples,
+            "seed": args.bootstrap_seed,
+            "confidence_level": 0.95,
+        },
+        "interpretation_boundary": (
+            "Retrieval-only comparison of richer source representations on the "
+            "official 102-query NFCorpus video subset."
+        ),
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    with (output_dir / "per_query.jsonl").open(
+        "w",
+        encoding="utf-8",
+        newline="\n",
+    ) as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+    (output_dir / "report.md").write_text(
+        render_report(summary),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    print("NFCorpus video query-representation analysis complete")
+    for name in REPRESENTATIONS:
+        metrics = aggregate[name]
+        print(
+            f"  {name:24s} "
+            f"MRR@10={metrics['mrr@10']:.6f} "
+            f"nDCG@10={metrics['ndcg@10']:.6f} "
+            f"Recall@100={metrics['recall@100']:.6f}"
+        )
+    print(f"outputs: {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/msmarco_genqa/data/nfcorpus_video.py
+++ b/src/msmarco_genqa/data/nfcorpus_video.py
@@ -1,0 +1,591 @@
+"""Pinned NFCorpus video query representations for the controlled ablation.
+
+The loader deliberately accepts query text only. It has no qrels, corpus,
+ranked-run, or metric input, which keeps query construction outside the
+outcome-data path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tarfile
+import unicodedata
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlparse
+
+
+CONTRACT_SCHEMA = "msmarco-genqa.nfcorpus-video-query-representation.v1"
+SUPPORTED_REPRESENTATIONS = ("title", "description", "title_plus_description")
+TITLE_MEMBER = "nfcorpus/test.vid-titles.queries"
+DESCRIPTION_MEMBER = "nfcorpus/test.vid-desc.queries"
+_SPACE_RE = re.compile(r"\s+")
+_ALIGNMENT_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_MAX_QUERY_MEMBER_BYTES = 5 * 1024 * 1024
+
+
+class NFCorpusVideoContractError(ValueError):
+    """Raised when a pinned query-representation input violates its contract."""
+
+
+@dataclass(frozen=True)
+class NFCorpusVideoQueryRecord:
+    """One official video record aligned to its BEIR query title."""
+
+    query_id: str
+    beir_title: str
+    official_title: str
+    description: str
+    effective_query: str
+
+    def to_json(self, *, representation: str) -> dict[str, str]:
+        return {
+            "query_id": self.query_id,
+            "representation": representation,
+            "beir_title": self.beir_title,
+            "official_title": self.official_title,
+            "description": self.description,
+            "effective_query": self.effective_query,
+        }
+
+
+@dataclass(frozen=True)
+class NFCorpusVideoQueryBundle:
+    """Validated 102-query treatment bundle."""
+
+    representation: str
+    queries: dict[str, str]
+    records: tuple[NFCorpusVideoQueryRecord, ...]
+    summary: dict[str, object]
+    contract_path: Path
+    archive_path: Path
+    frozen_title_metrics: dict[str, float]
+    frozen_title_rerank_metrics: dict[str, float]
+
+
+def normalize_query_field(text: str) -> str:
+    """Normalize Unicode and collapse whitespace without lexical rewriting."""
+
+    return _SPACE_RE.sub(" ", unicodedata.normalize("NFKC", str(text)).strip())
+
+
+def _alignment_key(text: str) -> str:
+    """Loose key used only to verify official/BEIR title identity."""
+
+    return " ".join(_ALIGNMENT_TOKEN_RE.findall(str(text).casefold()))
+
+
+def _file_hash(path: Path, algorithm: str) -> str:
+    digest = hashlib.new(algorithm)
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise NFCorpusVideoContractError(f"{label} must be a JSON object")
+    return value
+
+
+def _require_string(mapping: Mapping[str, object], key: str, label: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise NFCorpusVideoContractError(f"{label}.{key} must be a non-empty string")
+    return value
+
+
+def _resolve_repo_path(raw_path: str, project_root: Path) -> Path:
+    root = project_root.resolve()
+    path = Path(raw_path)
+    resolved = (path if path.is_absolute() else root / path).resolve()
+    if not resolved.is_relative_to(root):
+        raise NFCorpusVideoContractError(
+            f"official archive path must stay inside the project root: {raw_path!r}"
+        )
+    return resolved
+
+
+def _download_pinned_archive(
+    url: str,
+    destination: Path,
+    *,
+    expected_bytes: int,
+) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise NFCorpusVideoContractError("official archive URL must use HTTPS")
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_name(f"{destination.name}.part")
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response, partial.open("wb") as output:
+            final_url = urlparse(response.geturl())
+            if final_url.scheme != "https":
+                raise NFCorpusVideoContractError(
+                    "official archive download redirected away from HTTPS"
+                )
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None and int(content_length) != expected_bytes:
+                raise NFCorpusVideoContractError(
+                    "official archive Content-Length differs from the contract"
+                )
+            downloaded = 0
+            for chunk in iter(lambda: response.read(1024 * 1024), b""):
+                downloaded += len(chunk)
+                if downloaded > expected_bytes:
+                    raise NFCorpusVideoContractError(
+                        "official archive download exceeds the contracted byte size"
+                    )
+                output.write(chunk)
+            if downloaded != expected_bytes:
+                raise NFCorpusVideoContractError(
+                    "official archive download ended before the contracted byte size"
+                )
+        os.replace(partial, destination)
+    finally:
+        partial.unlink(missing_ok=True)
+
+
+def _verify_archive(path: Path, contract: Mapping[str, object]) -> None:
+    expected_bytes = contract.get("bytes")
+    if not isinstance(expected_bytes, int) or expected_bytes <= 0:
+        raise NFCorpusVideoContractError(
+            "inputs.official_nfcorpus_v1.bytes must be a positive integer"
+        )
+    if path.stat().st_size != expected_bytes:
+        raise NFCorpusVideoContractError(
+            "official archive byte-size drift: "
+            f"expected {expected_bytes}, found {path.stat().st_size}"
+        )
+
+    for algorithm in ("md5", "sha256"):
+        expected = _require_string(
+            contract,
+            algorithm,
+            "inputs.official_nfcorpus_v1",
+        ).casefold()
+        observed = _file_hash(path, algorithm)
+        if observed != expected:
+            raise NFCorpusVideoContractError(
+                f"official archive {algorithm.upper()} drift: "
+                f"expected {expected}, found {observed}"
+            )
+
+
+def _read_query_member(archive: tarfile.TarFile, member_name: str) -> dict[str, str]:
+    try:
+        member = archive.getmember(member_name)
+    except KeyError as exc:
+        raise NFCorpusVideoContractError(
+            f"official archive is missing {member_name!r}"
+        ) from exc
+    if not member.isfile():
+        raise NFCorpusVideoContractError(f"{member_name!r} is not a regular file")
+    if member.size > _MAX_QUERY_MEMBER_BYTES:
+        raise NFCorpusVideoContractError(
+            f"{member_name!r} exceeds the query-member size limit"
+        )
+
+    extracted = archive.extractfile(member)
+    if extracted is None:
+        raise NFCorpusVideoContractError(f"could not read {member_name!r}")
+    try:
+        text = extracted.read().decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise NFCorpusVideoContractError(f"{member_name!r} is not UTF-8") from exc
+
+    records: dict[str, str] = {}
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            query_id, value = line.split("\t", 1)
+        except ValueError as exc:
+            raise NFCorpusVideoContractError(
+                f"{member_name}:{line_number} is not a two-column TSV row"
+            ) from exc
+        query_id = query_id.strip()
+        if not query_id or not value.strip():
+            raise NFCorpusVideoContractError(
+                f"{member_name}:{line_number} contains an empty id or text field"
+            )
+        if query_id in records:
+            raise NFCorpusVideoContractError(
+                f"{member_name}:{line_number} duplicates query id {query_id!r}"
+            )
+        records[query_id] = value
+    return records
+
+
+def _qid_hash(query_ids: list[str]) -> str:
+    canonical = "".join(f"{query_id}\n" for query_id in sorted(query_ids))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _record_hash(titles: Mapping[str, str], descriptions: Mapping[str, str]) -> str:
+    digest = hashlib.sha256()
+    for query_id in sorted(titles):
+        row = {
+            "description": descriptions[query_id],
+            "qid": query_id,
+            "title": titles[query_id],
+        }
+        encoded = json.dumps(
+            row,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest.update(f"{encoded}\n".encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _effective_query_hash(queries: Mapping[str, str]) -> str:
+    digest = hashlib.sha256()
+    for query_id in sorted(queries):
+        row = {"query_id": query_id, "text": queries[query_id]}
+        encoded = json.dumps(
+            row,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest.update(f"{encoded}\n".encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _build_effective_query(
+    representation: str,
+    *,
+    beir_title: str,
+    description: str,
+) -> str:
+    title = normalize_query_field(beir_title)
+    desc = normalize_query_field(description)
+    if representation == "title":
+        return title
+    if representation == "description":
+        return desc
+    if representation == "title_plus_description":
+        return f"{title}\n{desc}"
+    raise NFCorpusVideoContractError(
+        f"unsupported query representation {representation!r}; "
+        f"expected one of {SUPPORTED_REPRESENTATIONS}"
+    )
+
+
+def load_nfcorpus_video_query_representation(
+    baseline_queries: Mapping[str, str],
+    *,
+    representation: str,
+    contract_path: Path,
+    project_root: Path,
+    download_if_missing: bool = True,
+) -> NFCorpusVideoQueryBundle:
+    """Load and validate one predeclared query representation.
+
+    Only ``baseline_queries`` and the pinned official title/description members
+    are visible to this function. The caller applies the returned qid cohort to
+    qrels after query construction.
+    """
+
+    if representation not in SUPPORTED_REPRESENTATIONS:
+        raise NFCorpusVideoContractError(
+            f"unsupported query representation {representation!r}; "
+            f"expected one of {SUPPORTED_REPRESENTATIONS}"
+        )
+
+    contract_path = contract_path.resolve()
+    try:
+        contract_raw = json.loads(contract_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise NFCorpusVideoContractError(
+            f"could not read query-representation contract {contract_path}"
+        ) from exc
+    contract = _require_mapping(contract_raw, "contract")
+    if contract.get("schema") != CONTRACT_SCHEMA:
+        raise NFCorpusVideoContractError(
+            f"unsupported contract schema {contract.get('schema')!r}"
+        )
+
+    declared_representations = _require_mapping(
+        contract.get("query_representations"),
+        "query_representations",
+    )
+    if representation not in declared_representations:
+        raise NFCorpusVideoContractError(
+            f"representation {representation!r} is not predeclared by the contract"
+        )
+
+    inputs = _require_mapping(contract.get("inputs"), "inputs")
+    official = _require_mapping(
+        inputs.get("official_nfcorpus_v1"),
+        "inputs.official_nfcorpus_v1",
+    )
+    archive_path = _resolve_repo_path(
+        _require_string(official, "path", "inputs.official_nfcorpus_v1"),
+        project_root,
+    )
+    expected_bytes = official.get("bytes")
+    if not isinstance(expected_bytes, int) or expected_bytes <= 0:
+        raise NFCorpusVideoContractError(
+            "inputs.official_nfcorpus_v1.bytes must be a positive integer"
+        )
+    if not archive_path.exists():
+        if not download_if_missing:
+            raise NFCorpusVideoContractError(
+                f"official archive is missing and downloads are disabled: {archive_path}"
+            )
+        _download_pinned_archive(
+            _require_string(official, "url", "inputs.official_nfcorpus_v1"),
+            archive_path,
+            expected_bytes=expected_bytes,
+        )
+    _verify_archive(archive_path, official)
+
+    try:
+        with tarfile.open(archive_path, mode="r:gz") as archive:
+            official_titles = _read_query_member(archive, TITLE_MEMBER)
+            descriptions = _read_query_member(archive, DESCRIPTION_MEMBER)
+    except (tarfile.TarError, OSError) as exc:
+        raise NFCorpusVideoContractError("official archive is not a valid tar.gz") from exc
+
+    if set(official_titles) != set(descriptions):
+        raise NFCorpusVideoContractError(
+            "official video title and description query-id sets differ"
+        )
+
+    cohort = _require_mapping(contract.get("cohort"), "cohort")
+    expected_count = cohort.get("n_queries")
+    if not isinstance(expected_count, int) or expected_count <= 0:
+        raise NFCorpusVideoContractError("cohort.n_queries must be a positive integer")
+    if len(official_titles) != expected_count:
+        raise NFCorpusVideoContractError(
+            f"video cohort size drift: expected {expected_count}, found {len(official_titles)}"
+        )
+
+    observed_qid_hash = _qid_hash(list(official_titles))
+    expected_qid_hash = _require_string(cohort, "qid_sha256", "cohort").casefold()
+    if observed_qid_hash != expected_qid_hash:
+        raise NFCorpusVideoContractError(
+            f"video cohort qid hash drift: expected {expected_qid_hash}, "
+            f"found {observed_qid_hash}"
+        )
+
+    observed_record_hash = _record_hash(official_titles, descriptions)
+    expected_record_hash = _require_string(
+        cohort,
+        "official_query_records_sha256",
+        "cohort",
+    ).casefold()
+    if observed_record_hash != expected_record_hash:
+        raise NFCorpusVideoContractError(
+            f"official video record hash drift: expected {expected_record_hash}, "
+            f"found {observed_record_hash}"
+        )
+
+    missing_baseline = sorted(set(official_titles) - set(baseline_queries))
+    if missing_baseline:
+        raise NFCorpusVideoContractError(
+            f"{len(missing_baseline)} video qids are absent from the BEIR test queries"
+        )
+
+    mismatched_titles = [
+        query_id
+        for query_id, title in official_titles.items()
+        if _alignment_key(title) != _alignment_key(baseline_queries[query_id])
+    ]
+    if mismatched_titles:
+        raise NFCorpusVideoContractError(
+            f"{len(mismatched_titles)} official titles do not align with BEIR query text"
+        )
+
+    records: list[NFCorpusVideoQueryRecord] = []
+    queries: dict[str, str] = {}
+    for query_id in sorted(official_titles):
+        effective_query = _build_effective_query(
+            representation,
+            beir_title=baseline_queries[query_id],
+            description=descriptions[query_id],
+        )
+        record = NFCorpusVideoQueryRecord(
+            query_id=query_id,
+            beir_title=normalize_query_field(baseline_queries[query_id]),
+            official_title=normalize_query_field(official_titles[query_id]),
+            description=normalize_query_field(descriptions[query_id]),
+            effective_query=effective_query,
+        )
+        records.append(record)
+        queries[query_id] = effective_query
+
+    frozen = _require_mapping(contract.get("frozen_title_baseline"), "frozen_title_baseline")
+    frozen_bm25 = _require_mapping(frozen.get("bm25"), "frozen_title_baseline.bm25")
+    frozen_bm25_ce = _require_mapping(
+        frozen.get("bm25_ce"),
+        "frozen_title_baseline.bm25_ce",
+    )
+    frozen_title_metrics = {
+        metric: float(frozen_bm25[metric])
+        for metric in ("mrr@10", "ndcg@10", "recall@100", "recall@1000")
+    }
+    frozen_title_rerank_metrics = {
+        metric: float(frozen_bm25_ce[metric])
+        for metric in ("mrr@10", "ndcg@10", "recall@100")
+    }
+    summary: dict[str, object] = {
+        "schema": CONTRACT_SCHEMA,
+        "dataset_id": _require_string(
+            official,
+            "dataset_id",
+            "inputs.official_nfcorpus_v1",
+        ),
+        "representation": representation,
+        "n_queries": len(queries),
+        "qid_sha256": observed_qid_hash,
+        "official_query_records_sha256": observed_record_hash,
+        "effective_queries_sha256": _effective_query_hash(queries),
+        "source_archive": {
+            "path": archive_path.relative_to(project_root.resolve()).as_posix(),
+            "bytes": archive_path.stat().st_size,
+            "md5": _file_hash(archive_path, "md5"),
+            "sha256": _file_hash(archive_path, "sha256"),
+        },
+        "title_alignment": {
+            "matched": len(queries),
+            "mismatched": 0,
+        },
+        "leakage_boundary": {
+            "inputs": [
+                "frozen_video_qids",
+                "beir_query_title",
+                "official_video_title",
+                "official_video_description",
+            ],
+            "excluded": [
+                "qrels",
+                "corpus_documents",
+                "ranked_outputs",
+                "metrics",
+                "manual_rewrites",
+            ],
+        },
+    }
+    return NFCorpusVideoQueryBundle(
+        representation=representation,
+        queries=queries,
+        records=tuple(records),
+        summary=summary,
+        contract_path=contract_path,
+        archive_path=archive_path,
+        frozen_title_metrics=frozen_title_metrics,
+        frozen_title_rerank_metrics=frozen_title_rerank_metrics,
+    )
+
+
+def write_nfcorpus_video_query_artifacts(
+    bundle: NFCorpusVideoQueryBundle,
+    output_dir: Path,
+) -> tuple[dict[str, object], list[Path]]:
+    """Write the effective-query audit trail for one retrieval run."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    queries_path = output_dir / "queries.jsonl"
+    summary_path = output_dir / "summary.json"
+    with queries_path.open("w", encoding="utf-8", newline="\n") as handle:
+        for record in bundle.records:
+            handle.write(
+                json.dumps(
+                    record.to_json(representation=bundle.representation),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+    summary = dict(bundle.summary)
+    summary["queries_path"] = "query_representation/queries.jsonl"
+    with summary_path.open("w", encoding="utf-8", newline="\n") as handle:
+        json.dump(summary, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    return summary, [queries_path, summary_path]
+
+
+def validate_frozen_title_metrics(
+    bundle: NFCorpusVideoQueryBundle,
+    metrics: Mapping[str, object],
+    *,
+    tolerance: float = 1e-12,
+) -> dict[str, object]:
+    """Require the title condition to reproduce its predeclared fixed-run slice."""
+
+    if bundle.representation != "title":
+        return {"required": False, "passed": None}
+
+    deltas: dict[str, float] = {}
+    for metric, expected in bundle.frozen_title_metrics.items():
+        if metric not in metrics:
+            raise NFCorpusVideoContractError(
+                f"title reproduction is missing required metric {metric}"
+            )
+        observed = float(metrics[metric])
+        delta = observed - expected
+        deltas[metric] = delta
+        if abs(delta) > tolerance:
+            raise NFCorpusVideoContractError(
+                f"title baseline metric drift for {metric}: expected {expected:.16g}, "
+                f"found {observed:.16g}, delta {delta:.3g}"
+            )
+    return {
+        "required": True,
+        "passed": True,
+        "tolerance": tolerance,
+        "metric_deltas": deltas,
+    }
+
+
+def validate_frozen_title_reranker_metrics(
+    bundle: NFCorpusVideoQueryBundle,
+    input_metrics: Mapping[str, object],
+    rerank_metrics: Mapping[str, object],
+    *,
+    tolerance: float = 1e-12,
+) -> dict[str, object]:
+    """Require title-only BM25 and CE metrics to reproduce the frozen slice."""
+
+    if bundle.representation != "title":
+        return {"required": False, "passed": None}
+
+    metric_deltas: dict[str, dict[str, float]] = {"bm25": {}, "bm25_ce": {}}
+    expected_groups = (
+        ("bm25", bundle.frozen_title_metrics, input_metrics),
+        ("bm25_ce", bundle.frozen_title_rerank_metrics, rerank_metrics),
+    )
+    for group, expected_metrics, observed_metrics in expected_groups:
+        for metric, expected in expected_metrics.items():
+            if metric == "recall@1000":
+                continue
+            if metric not in observed_metrics:
+                raise NFCorpusVideoContractError(
+                    f"title reranker reproduction is missing {group} metric {metric}"
+                )
+            observed = float(observed_metrics[metric])
+            delta = observed - expected
+            metric_deltas[group][metric] = delta
+            if abs(delta) > tolerance:
+                raise NFCorpusVideoContractError(
+                    f"title reranker metric drift for {group}.{metric}: "
+                    f"expected {expected:.16g}, found {observed:.16g}, "
+                    f"delta {delta:.3g}"
+                )
+    return {
+        "required": True,
+        "passed": True,
+        "tolerance": tolerance,
+        "metric_deltas": metric_deltas,
+    }

--- a/src/msmarco_genqa/data/nfcorpus_video.py
+++ b/src/msmarco_genqa/data/nfcorpus_video.py
@@ -66,6 +66,9 @@ class NFCorpusVideoQueryBundle:
     archive_path: Path
     frozen_title_metrics: dict[str, float]
     frozen_title_rerank_metrics: dict[str, float]
+    positive_score_title_metrics: dict[str, float]
+    deterministic_title_metrics: dict[str, float] | None
+    deterministic_title_rerank_metrics: dict[str, float] | None
 
 
 def normalize_query_field(text: str) -> str:
@@ -439,6 +442,35 @@ def load_nfcorpus_video_query_representation(
         metric: float(frozen_bm25_ce[metric])
         for metric in ("mrr@10", "ndcg@10", "recall@100")
     }
+    positive_score_bm25 = _require_mapping(
+        frozen.get("positive_score_bm25"),
+        "frozen_title_baseline.positive_score_bm25",
+    )
+    positive_score_title_metrics = {
+        metric: float(positive_score_bm25[metric])
+        for metric in (
+            "positive_score_recall@100",
+            "positive_score_recall@1000",
+        )
+    }
+    deterministic_bm25_raw = frozen.get("deterministic_tie_bm25")
+    deterministic_title_metrics = (
+        {
+            metric: float(deterministic_bm25_raw[metric])
+            for metric in ("mrr@10", "ndcg@10", "recall@100", "recall@1000")
+        }
+        if isinstance(deterministic_bm25_raw, dict)
+        else None
+    )
+    deterministic_ce_raw = frozen.get("deterministic_tie_bm25_ce")
+    deterministic_title_rerank_metrics = (
+        {
+            metric: float(deterministic_ce_raw[metric])
+            for metric in ("mrr@10", "ndcg@10", "recall@100")
+        }
+        if isinstance(deterministic_ce_raw, dict)
+        else None
+    )
     summary: dict[str, object] = {
         "schema": CONTRACT_SCHEMA,
         "dataset_id": _require_string(
@@ -460,6 +492,11 @@ def load_nfcorpus_video_query_representation(
         "title_alignment": {
             "matched": len(queries),
             "mismatched": 0,
+        },
+        "ranking_tie_break": {
+            "order": "score descending, then doc_id ascending",
+            "candidate_pool": "full 3,633-document corpus before top-k truncation",
+            "reason": "Cross-platform BM25 top-k selection is unstable among equal scores.",
         },
         "leakage_boundary": {
             "inputs": [
@@ -486,6 +523,9 @@ def load_nfcorpus_video_query_representation(
         archive_path=archive_path,
         frozen_title_metrics=frozen_title_metrics,
         frozen_title_rerank_metrics=frozen_title_rerank_metrics,
+        positive_score_title_metrics=positive_score_title_metrics,
+        deterministic_title_metrics=deterministic_title_metrics,
+        deterministic_title_rerank_metrics=deterministic_title_rerank_metrics,
     )
 
 
@@ -520,32 +560,72 @@ def validate_frozen_title_metrics(
     bundle: NFCorpusVideoQueryBundle,
     metrics: Mapping[str, object],
     *,
+    positive_score_metrics: Mapping[str, object],
     tolerance: float = 1e-12,
 ) -> dict[str, object]:
-    """Require the title condition to reproduce its predeclared fixed-run slice."""
+    """Validate stable published invariants and any frozen deterministic baseline."""
 
     if bundle.representation != "title":
         return {"required": False, "passed": None}
 
-    deltas: dict[str, float] = {}
-    for metric, expected in bundle.frozen_title_metrics.items():
+    invariant_deltas: dict[str, float] = {}
+    for metric in ("mrr@10", "ndcg@10"):
+        expected = bundle.frozen_title_metrics[metric]
         if metric not in metrics:
             raise NFCorpusVideoContractError(
                 f"title reproduction is missing required metric {metric}"
             )
         observed = float(metrics[metric])
         delta = observed - expected
-        deltas[metric] = delta
+        invariant_deltas[metric] = delta
         if abs(delta) > tolerance:
             raise NFCorpusVideoContractError(
                 f"title baseline metric drift for {metric}: expected {expected:.16g}, "
                 f"found {observed:.16g}, delta {delta:.3g}"
             )
+
+    for metric, expected in bundle.positive_score_title_metrics.items():
+        if metric not in positive_score_metrics:
+            raise NFCorpusVideoContractError(
+                f"title reproduction is missing required metric {metric}"
+            )
+        observed = float(positive_score_metrics[metric])
+        delta = observed - expected
+        invariant_deltas[metric] = delta
+        if abs(delta) > tolerance:
+            raise NFCorpusVideoContractError(
+                f"title baseline metric drift for {metric}: expected {expected:.16g}, "
+                f"found {observed:.16g}, delta {delta:.3g}"
+            )
+
+    deterministic_deltas: dict[str, float] | None = None
+    deterministic_status = "pending_freeze"
+    if bundle.deterministic_title_metrics is not None:
+        deterministic_deltas = {}
+        for metric, expected in bundle.deterministic_title_metrics.items():
+            if metric not in metrics:
+                raise NFCorpusVideoContractError(
+                    f"deterministic title baseline is missing metric {metric}"
+                )
+            observed = float(metrics[metric])
+            delta = observed - expected
+            deterministic_deltas[metric] = delta
+            if abs(delta) > tolerance:
+                raise NFCorpusVideoContractError(
+                    f"deterministic title metric drift for {metric}: "
+                    f"expected {expected:.16g}, found {observed:.16g}, "
+                    f"delta {delta:.3g}"
+                )
+        deterministic_status = "passed"
     return {
         "required": True,
         "passed": True,
         "tolerance": tolerance,
-        "metric_deltas": deltas,
+        "published_invariant_deltas": invariant_deltas,
+        "deterministic_baseline": {
+            "status": deterministic_status,
+            "metric_deltas": deterministic_deltas,
+        },
     }
 
 
@@ -561,10 +641,20 @@ def validate_frozen_title_reranker_metrics(
     if bundle.representation != "title":
         return {"required": False, "passed": None}
 
+    if (
+        bundle.deterministic_title_metrics is None
+        or bundle.deterministic_title_rerank_metrics is None
+    ):
+        return {
+            "required": False,
+            "passed": None,
+            "status": "pending_deterministic_baseline_freeze",
+        }
+
     metric_deltas: dict[str, dict[str, float]] = {"bm25": {}, "bm25_ce": {}}
     expected_groups = (
-        ("bm25", bundle.frozen_title_metrics, input_metrics),
-        ("bm25_ce", bundle.frozen_title_rerank_metrics, rerank_metrics),
+        ("bm25", bundle.deterministic_title_metrics, input_metrics),
+        ("bm25_ce", bundle.deterministic_title_rerank_metrics, rerank_metrics),
     )
     for group, expected_metrics, observed_metrics in expected_groups:
         for metric, expected in expected_metrics.items():

--- a/src/msmarco_genqa/data/nfcorpus_video.py
+++ b/src/msmarco_genqa/data/nfcorpus_video.py
@@ -563,39 +563,19 @@ def validate_frozen_title_metrics(
     positive_score_metrics: Mapping[str, object],
     tolerance: float = 1e-12,
 ) -> dict[str, object]:
-    """Validate stable published invariants and any frozen deterministic baseline."""
+    """Validate the frozen deterministic baseline and report historical deltas."""
 
     if bundle.representation != "title":
         return {"required": False, "passed": None}
 
-    invariant_deltas: dict[str, float] = {}
-    for metric in ("mrr@10", "ndcg@10"):
-        expected = bundle.frozen_title_metrics[metric]
-        if metric not in metrics:
-            raise NFCorpusVideoContractError(
-                f"title reproduction is missing required metric {metric}"
-            )
-        observed = float(metrics[metric])
-        delta = observed - expected
-        invariant_deltas[metric] = delta
-        if abs(delta) > tolerance:
-            raise NFCorpusVideoContractError(
-                f"title baseline metric drift for {metric}: expected {expected:.16g}, "
-                f"found {observed:.16g}, delta {delta:.3g}"
-            )
-
+    published_reference_deltas: dict[str, float] = {}
+    for metric, expected in bundle.frozen_title_metrics.items():
+        if metric in metrics:
+            published_reference_deltas[metric] = float(metrics[metric]) - expected
     for metric, expected in bundle.positive_score_title_metrics.items():
-        if metric not in positive_score_metrics:
-            raise NFCorpusVideoContractError(
-                f"title reproduction is missing required metric {metric}"
-            )
-        observed = float(positive_score_metrics[metric])
-        delta = observed - expected
-        invariant_deltas[metric] = delta
-        if abs(delta) > tolerance:
-            raise NFCorpusVideoContractError(
-                f"title baseline metric drift for {metric}: expected {expected:.16g}, "
-                f"found {observed:.16g}, delta {delta:.3g}"
+        if metric in positive_score_metrics:
+            published_reference_deltas[metric] = (
+                float(positive_score_metrics[metric]) - expected
             )
 
     deterministic_deltas: dict[str, float] | None = None
@@ -621,7 +601,7 @@ def validate_frozen_title_metrics(
         "required": True,
         "passed": True,
         "tolerance": tolerance,
-        "published_invariant_deltas": invariant_deltas,
+        "published_reference_deltas": published_reference_deltas,
         "deterministic_baseline": {
             "status": deterministic_status,
             "metric_deltas": deterministic_deltas,

--- a/src/msmarco_genqa/data/nfcorpus_video.py
+++ b/src/msmarco_genqa/data/nfcorpus_video.py
@@ -22,6 +22,10 @@ from urllib.parse import urlparse
 
 CONTRACT_SCHEMA = "msmarco-genqa.nfcorpus-video-query-representation.v1"
 SUPPORTED_REPRESENTATIONS = ("title", "description", "title_plus_description")
+FIXED_RERANKER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+FIXED_RERANKER_REVISION = "c5ee24cb16019beea0893ab7796b1df96625c6b8"
+FIXED_RERANK_DEPTH = 100
+FIXED_RERANK_MAX_LENGTH = 512
 TITLE_MEMBER = "nfcorpus/test.vid-titles.queries"
 DESCRIPTION_MEMBER = "nfcorpus/test.vid-desc.queries"
 _SPACE_RE = re.compile(r"\s+")
@@ -532,6 +536,8 @@ def load_nfcorpus_video_query_representation(
 def write_nfcorpus_video_query_artifacts(
     bundle: NFCorpusVideoQueryBundle,
     output_dir: Path,
+    *,
+    summary_updates: Mapping[str, object] | None = None,
 ) -> tuple[dict[str, object], list[Path]]:
     """Write the effective-query audit trail for one retrieval run."""
 
@@ -549,6 +555,8 @@ def write_nfcorpus_video_query_artifacts(
                 + "\n"
             )
     summary = dict(bundle.summary)
+    if summary_updates:
+        summary.update(summary_updates)
     summary["queries_path"] = "query_representation/queries.jsonl"
     with summary_path.open("w", encoding="utf-8", newline="\n") as handle:
         json.dump(summary, handle, indent=2, ensure_ascii=False)

--- a/src/msmarco_genqa/retrieval/bm25.py
+++ b/src/msmarco_genqa/retrieval/bm25.py
@@ -168,8 +168,16 @@ class BM25Retriever:
         self,
         queries: Sequence[str],
         k: int = 1000,
+        *,
+        deterministic_ties: bool = False,
     ) -> tuple[np.ndarray, list[list[str]]]:
         """Retrieve top-k for a batch of queries.
+
+        ``deterministic_ties`` is intended for small-corpus controlled
+        experiments. It requests every corpus document, then orders equal-score
+        documents by ``doc_id`` before truncating to ``k``. The default remains
+        off because retrieving the full 8.8M-document MS MARCO corpus per query
+        would be infeasible.
 
         Returns
         -------
@@ -181,13 +189,28 @@ class BM25Retriever:
         import bm25s
 
         tokens = bm25s.tokenize(list(queries), stopwords=self.stopwords)
+        retrieve_k = len(self.doc_ids) if deterministic_ties else k
         results, scores = self._bm25.retrieve(
             tokens,
-            k=k,
+            k=retrieve_k,
             n_threads=self.n_threads,
             chunksize=self.chunksize,
             show_progress=True,
         )
+        if deterministic_ties:
+            stable_doc_ids: list[list[str]] = []
+            stable_scores: list[list[float]] = []
+            for result_row, score_row in zip(results, scores):
+                candidates = [
+                    (self.doc_ids[int(index)], float(score))
+                    for index, score in zip(result_row, score_row)
+                ]
+                candidates.sort(key=lambda item: (-item[1], item[0]))
+                selected = candidates[:k]
+                stable_doc_ids.append([doc_id for doc_id, _score in selected])
+                stable_scores.append([score for _doc_id, score in selected])
+            return np.asarray(stable_scores), stable_doc_ids
+
         # results: (n_queries, k) of doc indices into the original corpus order
         doc_ids_lists = [
             [self.doc_ids[int(i)] for i in row] for row in results

--- a/tests/test_nfcorpus_query_representation_analysis.py
+++ b/tests/test_nfcorpus_query_representation_analysis.py
@@ -10,6 +10,10 @@ from scripts.analyze_nfcorpus_query_representations import (
     build_per_query_rows,
     validate_rerank_contract,
 )
+from msmarco_genqa.data.nfcorpus_video import (
+    FIXED_RERANKER_MODEL,
+    FIXED_RERANKER_REVISION,
+)
 
 
 def test_per_query_rows_keep_graded_ndcg_and_binary_recall() -> None:
@@ -93,8 +97,10 @@ def _condition(
     if stage == "cross_encoder_rerank":
         metrics_payload["config"] = {
             "reranker": {
-                "model_name": "fixed-model",
-                "revision": "a" * 40,
+                "model_name": FIXED_RERANKER_MODEL,
+                "revision": FIXED_RERANKER_REVISION,
+                "rerank_top_k": 100,
+                "max_length": 512,
             }
         }
     return Condition(

--- a/tests/test_nfcorpus_query_representation_analysis.py
+++ b/tests/test_nfcorpus_query_representation_analysis.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from scripts.analyze_nfcorpus_query_representations import (
+    build_paired_comparisons,
+    build_per_query_rows,
+)
+
+
+def test_per_query_rows_keep_graded_ndcg_and_binary_recall() -> None:
+    runs = {
+        "title": {
+            "q1": [("d2", 2.0), ("d1", 1.0)],
+            "q2": [("x", 1.0), ("d3", 0.5)],
+        },
+        "description": {
+            "q1": [("d1", 2.0), ("d2", 1.0)],
+            "q2": [("d3", 1.0), ("x", 0.5)],
+        },
+        "title_plus_description": {
+            "q1": [("d1", 2.0), ("d2", 1.0)],
+            "q2": [("d3", 1.0), ("x", 0.5)],
+        },
+    }
+    qrels = {
+        "q1": {"d1": 2, "d2": 1},
+        "q2": {"d3": 1},
+    }
+
+    rows = build_per_query_rows(runs, qrels)
+
+    assert len(rows) == 2
+    assert rows[0]["conditions"]["description"]["rr@10"] == 1.0
+    assert rows[0]["conditions"]["description"]["ndcg@10"] == 1.0
+    assert rows[1]["conditions"]["title"]["recall@100"] == 1.0
+    assert rows[1]["conditions"]["title"]["first_relevant_rank@100"] == 2
+
+
+def test_paired_comparison_reports_recovery_and_win_counts() -> None:
+    runs = {
+        "title": {
+            "q1": [("x", 1.0)],
+            "q2": [("d2", 1.0)],
+        },
+        "description": {
+            "q1": [("d1", 1.0)],
+            "q2": [("d2", 1.0)],
+        },
+        "title_plus_description": {
+            "q1": [("d1", 1.0)],
+            "q2": [("d2", 1.0)],
+        },
+    }
+    qrels = {"q1": {"d1": 1}, "q2": {"d2": 1}}
+    rows = build_per_query_rows(runs, qrels)
+
+    comparisons = build_paired_comparisons(
+        rows,
+        n_resamples=200,
+        seed=7,
+    )
+
+    result = comparisons["description_vs_title"]
+    assert result["metrics"]["recall@100"]["mean_delta"] == 0.5
+    assert result["metrics"]["recall@100"]["wins"] == 1
+    assert result["metrics"]["recall@100"]["ties"] == 1
+    assert result["metrics"]["recall@100"]["losses"] == 0
+    assert result["no_hit_queries"]["@100"] == {
+        "baseline": 1,
+        "treatment": 0,
+        "recovered": 1,
+        "lost": 0,
+    }

--- a/tests/test_nfcorpus_query_representation_analysis.py
+++ b/tests/test_nfcorpus_query_representation_analysis.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from scripts.analyze_nfcorpus_query_representations import (
+    Condition,
     build_paired_comparisons,
     build_per_query_rows,
+    validate_rerank_contract,
 )
 
 
@@ -70,3 +76,94 @@ def test_paired_comparison_reports_recovery_and_win_counts() -> None:
         "recovered": 1,
         "lost": 0,
     }
+
+
+def _condition(
+    name: str,
+    stage: str,
+    run: dict[str, list[tuple[str, float]]],
+) -> Condition:
+    query_summary = {
+        "representation": name,
+        "qid_sha256": "qids",
+        "official_query_records_sha256": "records",
+        "effective_queries_sha256": f"queries-{name}",
+    }
+    metrics_payload: dict[str, object] = {}
+    if stage == "cross_encoder_rerank":
+        metrics_payload["config"] = {
+            "reranker": {
+                "model_name": "fixed-model",
+                "revision": "a" * 40,
+            }
+        }
+    return Condition(
+        name=name,
+        stage=stage,
+        directory=Path(name) / stage,
+        run=run,
+        metrics_payload=metrics_payload,
+        manifest={"git": {"commit": "abc123", "dirty": False}},
+        query_summary=query_summary,
+    )
+
+
+def test_rerank_contract_requires_exact_bm25_candidate_sets() -> None:
+    bm25 = {
+        name: _condition(
+            name,
+            "bm25",
+            {"q1": [("d1", 2.0), ("d2", 1.0), ("d3", 0.0)]},
+        )
+        for name in ("title", "description", "title_plus_description")
+    }
+    rerank = {
+        name: _condition(
+            name,
+            "cross_encoder_rerank",
+            {"q1": [("d2", 2.0), ("d1", 1.0)]},
+        )
+        for name in ("title", "description", "title_plus_description")
+    }
+
+    contract = validate_rerank_contract(
+        bm25,
+        rerank,
+        expected_queries=1,
+        expected_depth=2,
+    )
+
+    assert contract["candidate_set_checks"] == 3
+    assert contract["candidate_sets_match_bm25_top_100"] is True
+
+    rerank["description"].run["q1"] = [("d2", 2.0), ("other", 1.0)]
+    with pytest.raises(ValueError, match="candidate set differs"):
+        validate_rerank_contract(
+            bm25,
+            rerank,
+            expected_queries=1,
+            expected_depth=2,
+        )
+
+
+def test_rerank_rows_omit_invalid_recall_at_1000() -> None:
+    runs = {
+        name: {"q1": [("d1", 1.0)]}
+        for name in ("title", "description", "title_plus_description")
+    }
+    rows = build_per_query_rows(
+        runs,
+        {"q1": {"d1": 1}},
+        include_recall_at_1000=False,
+    )
+    comparisons = build_paired_comparisons(
+        rows,
+        n_resamples=20,
+        seed=7,
+        metric_names=("rr@10", "ndcg@10", "recall@100"),
+        no_hit_cutoffs=(100,),
+    )
+
+    assert "recall@1000" not in rows[0]["conditions"]["title"]
+    assert "recall@1000" not in comparisons["description_vs_title"]["metrics"]
+    assert set(comparisons["description_vs_title"]["no_hit_queries"]) == {"@100"}

--- a/tests/test_nfcorpus_video_query_representation.py
+++ b/tests/test_nfcorpus_video_query_representation.py
@@ -13,6 +13,7 @@ import pytest
 
 from experiments.run_reranker import (
     _validate_query_representation_args as validate_reranker_representation_args,
+    _validate_representation_resume as validate_reranker_resume,
     _validate_upstream_query_representation,
     parse_args as parse_reranker_args,
 )
@@ -25,6 +26,8 @@ from experiments.run_retrieval import (
 )
 from msmarco_genqa.data.benchmark import BenchmarkQueries, get_benchmark_spec
 from msmarco_genqa.data.nfcorpus_video import (
+    FIXED_RERANKER_MODEL,
+    FIXED_RERANKER_REVISION,
     NFCorpusVideoContractError,
     load_nfcorpus_video_query_representation,
     validate_frozen_title_metrics,
@@ -405,6 +408,58 @@ def test_runner_requires_isolated_nfcorpus_output(tmp_path: Path) -> None:
     with pytest.raises(SystemExit, match="explicit --input-run and --output-dir"):
         validate_reranker_representation_args(reranker_missing_paths, cfg)
 
+    fixed_cfg = {
+        "query_transform": {"method": "none"},
+        "reranker": {
+            "model_name": FIXED_RERANKER_MODEL,
+            "revision": FIXED_RERANKER_REVISION,
+            "rerank_top_k": 100,
+            "max_length": 512,
+        },
+    }
+    model_override = parse_reranker_args(
+        [
+            "--dataset",
+            "beir/nfcorpus/test",
+            "--query-representation",
+            "title",
+            "--input-run",
+            str(tmp_path / "input.tsv"),
+            "--output-dir",
+            str(tmp_path / "rerank"),
+            "--model-name",
+            "unfrozen/model",
+        ]
+    )
+    with pytest.raises(SystemExit, match="frozen cross-encoder"):
+        validate_reranker_representation_args(model_override, fixed_cfg)
+
+    retrieval_args = parse_args(
+        [
+            "--dataset",
+            "beir/nfcorpus/test",
+            "--query-representation",
+            "title",
+            "--output-dir",
+            str(tmp_path / "retrieval"),
+        ]
+    )
+    retrieval_cfg = {
+        "query_transform": {"method": "none"},
+        "retrieval": {
+            "backend": "bm25s",
+            "k1": 1.5,
+            "b": 0.75,
+            "stopwords": "en",
+            "top_k": 1000,
+        },
+        "data": {"corpus_limit": None},
+    }
+    assert _validate_query_representation_args(retrieval_args, retrieval_cfg)
+    retrieval_cfg["retrieval"]["top_k"] = 100
+    with pytest.raises(SystemExit, match="frozen retrieval configuration"):
+        _validate_query_representation_args(retrieval_args, retrieval_cfg)
+
 
 def test_cohort_selection_happens_after_query_construction(tmp_path: Path) -> None:
     contract_path, baseline_queries = _make_fixture(tmp_path)
@@ -454,7 +509,23 @@ def test_resume_rejects_mixed_query_representation(tmp_path: Path) -> None:
     )
 
     with pytest.raises(SystemExit, match="representation differs"):
-        _validate_representation_resume(output_dir, bundle, resume=True)
+        _validate_representation_resume(output_dir, bundle.summary, resume=True)
+
+    expected = {
+        **bundle.summary,
+        "index_fingerprint": {"sha256": "new"},
+        "retrieval_system": {"backend": "bm25s"},
+    }
+    stale = {
+        **expected,
+        "index_fingerprint": {"sha256": "old"},
+    }
+    (representation_dir / "summary.json").write_text(
+        json.dumps(stale),
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit, match="index_fingerprint differs"):
+        _validate_representation_resume(output_dir, expected, resume=True)
 
 
 def test_reranker_requires_matching_upstream_representation(tmp_path: Path) -> None:
@@ -472,3 +543,43 @@ def test_reranker_requires_matching_upstream_representation(tmp_path: Path) -> N
     upstream["query_representation"]["effective_queries_sha256"] = "0" * 64
     with pytest.raises(SystemExit, match="effective_queries_sha256"):
         _validate_upstream_query_representation(bundle, upstream)
+
+
+def test_reranker_resume_rejects_input_or_model_drift(tmp_path: Path) -> None:
+    contract_path, baseline_queries = _make_fixture(tmp_path)
+    bundle = load_nfcorpus_video_query_representation(
+        baseline_queries,
+        representation="title",
+        contract_path=contract_path,
+        project_root=tmp_path,
+        download_if_missing=False,
+    )
+    output_dir = tmp_path / "rerank"
+    representation_dir = output_dir / "query_representation"
+    representation_dir.mkdir(parents=True)
+    (output_dir / "run.tsv").write_text(
+        "q1\tQ0\td1\t1\t1.0\tbm25+ce\n",
+        encoding="utf-8",
+    )
+    expected = {
+        **bundle.summary,
+        "reranker_system": {
+            "model_name": FIXED_RERANKER_MODEL,
+            "revision": FIXED_RERANKER_REVISION,
+            "input_run_sha256": "new",
+        },
+    }
+    stale = {
+        **expected,
+        "reranker_system": {
+            **expected["reranker_system"],
+            "input_run_sha256": "old",
+        },
+    }
+    (representation_dir / "summary.json").write_text(
+        json.dumps(stale),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="reranker_system differs"):
+        validate_reranker_resume(output_dir, expected, resume=True)

--- a/tests/test_nfcorpus_video_query_representation.py
+++ b/tests/test_nfcorpus_video_query_representation.py
@@ -17,6 +17,7 @@ from experiments.run_reranker import (
     parse_args as parse_reranker_args,
 )
 from experiments.run_retrieval import (
+    _index_fingerprint,
     _select_video_query_cohort,
     _validate_query_representation_args,
     _validate_representation_resume,
@@ -342,6 +343,28 @@ def test_bm25_deterministic_ties_score_then_doc_id(
 
     assert doc_ids == [["d1", "d4", "d2"]]
     assert scores.tolist() == [[1.0, 1.0, 0.0]]
+
+
+def test_index_fingerprint_is_order_stable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    index_dir = tmp_path / "index"
+    index_dir.mkdir()
+    (index_dir / "b.bin").write_bytes(b"two")
+    (index_dir / "a.bin").write_bytes(b"one")
+    monkeypatch.setattr(
+        "experiments.run_retrieval.PROJECT_ROOT",
+        tmp_path,
+    )
+
+    first = _index_fingerprint(index_dir)
+    second = _index_fingerprint(index_dir)
+
+    assert first == second
+    assert first["file_count"] == 2
+    assert first["bytes"] == 6
+    assert first["path"] == "index"
 
 
 def test_runner_requires_isolated_nfcorpus_output(tmp_path: Path) -> None:

--- a/tests/test_nfcorpus_video_query_representation.py
+++ b/tests/test_nfcorpus_video_query_representation.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import sys
 import tarfile
 from pathlib import Path
+from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from experiments.run_reranker import (
@@ -27,6 +30,7 @@ from msmarco_genqa.data.nfcorpus_video import (
     validate_frozen_title_reranker_metrics,
     write_nfcorpus_video_query_artifacts,
 )
+from msmarco_genqa.retrieval.bm25 import BM25Retriever
 
 
 def _digest(path: Path, algorithm: str) -> str:
@@ -132,7 +136,22 @@ def _make_fixture(tmp_path: Path) -> tuple[Path, dict[str, str]]:
                 "mrr@10": 0.6,
                 "ndcg@10": 0.5,
                 "recall@100": 0.3,
-            }
+            },
+            "positive_score_bm25": {
+                "positive_score_recall@100": 0.3,
+                "positive_score_recall@1000": 0.6,
+            },
+            "deterministic_tie_bm25": {
+                "mrr@10": 0.5,
+                "ndcg@10": 0.4,
+                "recall@100": 0.3,
+                "recall@1000": 0.6,
+            },
+            "deterministic_tie_bm25_ce": {
+                "mrr@10": 0.6,
+                "ndcg@10": 0.5,
+                "recall@100": 0.3,
+            },
         },
     }
     contract_path = tmp_path / "contract.json"
@@ -255,6 +274,10 @@ def test_artifacts_and_title_reproduction_guard(tmp_path: Path) -> None:
             "recall@100": 0.3,
             "recall@1000": 0.6,
         },
+        positive_score_metrics={
+            "positive_score_recall@100": 0.3,
+            "positive_score_recall@1000": 0.6,
+        },
     )
 
     assert summary["representation"] == "title"
@@ -282,7 +305,43 @@ def test_artifacts_and_title_reproduction_guard(tmp_path: Path) -> None:
                 "recall@100": 0.3,
                 "recall@1000": 0.6,
             },
+            positive_score_metrics={
+                "positive_score_recall@100": 0.3,
+                "positive_score_recall@1000": 0.6,
+            },
         )
+
+
+def test_bm25_deterministic_ties_score_then_doc_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeBackend:
+        def retrieve(self, _tokens, *, k, **_kwargs):
+            assert k == 4
+            return (
+                np.asarray([[0, 1, 2, 3]]),
+                np.asarray([[0.0, 1.0, 1.0, 0.0]]),
+            )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "bm25s",
+        SimpleNamespace(tokenize=lambda queries, **_kwargs: queries),
+    )
+    retriever = BM25Retriever(
+        corpus_texts=[],
+        doc_ids=["d2", "d1", "d4", "d3"],
+    )
+    retriever._bm25 = FakeBackend()
+
+    scores, doc_ids = retriever.retrieve_batch(
+        ["query"],
+        k=3,
+        deterministic_ties=True,
+    )
+
+    assert doc_ids == [["d1", "d4", "d2"]]
+    assert scores.tolist() == [[1.0, 1.0, 0.0]]
 
 
 def test_runner_requires_isolated_nfcorpus_output(tmp_path: Path) -> None:

--- a/tests/test_nfcorpus_video_query_representation.py
+++ b/tests/test_nfcorpus_video_query_representation.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from experiments.run_reranker import (
+    _validate_query_representation_args as validate_reranker_representation_args,
+    _validate_upstream_query_representation,
+    parse_args as parse_reranker_args,
+)
+from experiments.run_retrieval import (
+    _select_video_query_cohort,
+    _validate_query_representation_args,
+    _validate_representation_resume,
+    parse_args,
+)
+from msmarco_genqa.data.benchmark import BenchmarkQueries, get_benchmark_spec
+from msmarco_genqa.data.nfcorpus_video import (
+    NFCorpusVideoContractError,
+    load_nfcorpus_video_query_representation,
+    validate_frozen_title_metrics,
+    validate_frozen_title_reranker_metrics,
+    write_nfcorpus_video_query_artifacts,
+)
+
+
+def _digest(path: Path, algorithm: str) -> str:
+    return hashlib.new(algorithm, path.read_bytes()).hexdigest()
+
+
+def _canonical_qid_hash(query_ids: list[str]) -> str:
+    text = "".join(f"{query_id}\n" for query_id in sorted(query_ids))
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _canonical_record_hash(
+    titles: dict[str, str],
+    descriptions: dict[str, str],
+) -> str:
+    digest = hashlib.sha256()
+    for query_id in sorted(titles):
+        row = {
+            "description": descriptions[query_id],
+            "qid": query_id,
+            "title": titles[query_id],
+        }
+        encoded = json.dumps(
+            row,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        digest.update(f"{encoded}\n".encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _write_tar_member(
+    archive: tarfile.TarFile,
+    name: str,
+    rows: dict[str, str],
+) -> None:
+    payload = "".join(
+        f"{query_id}\t{value}\n" for query_id, value in rows.items()
+    ).encode("utf-8")
+    info = tarfile.TarInfo(name)
+    info.size = len(payload)
+    info.mtime = 0
+    archive.addfile(info, io.BytesIO(payload))
+
+
+def _make_fixture(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    titles = {
+        "q1": "Vitamin B12 — Benefits ?",
+        "q2": "Organic foods : safety",
+    }
+    descriptions = {
+        "q1": "  A bounded   description about B12.  ",
+        "q2": "Evidence about organic foods.",
+    }
+    archive_path = tmp_path / "cache" / "nfcorpus.tar.gz"
+    archive_path.parent.mkdir(parents=True)
+    with tarfile.open(archive_path, "w:gz") as archive:
+        _write_tar_member(
+            archive,
+            "nfcorpus/test.vid-titles.queries",
+            titles,
+        )
+        _write_tar_member(
+            archive,
+            "nfcorpus/test.vid-desc.queries",
+            descriptions,
+        )
+
+    contract = {
+        "schema": "msmarco-genqa.nfcorpus-video-query-representation.v1",
+        "inputs": {
+            "official_nfcorpus_v1": {
+                "dataset_id": "nfcorpus/test/video",
+                "path": "cache/nfcorpus.tar.gz",
+                "url": "https://example.test/nfcorpus.tar.gz",
+                "bytes": archive_path.stat().st_size,
+                "md5": _digest(archive_path, "md5"),
+                "sha256": _digest(archive_path, "sha256"),
+            }
+        },
+        "cohort": {
+            "n_queries": 2,
+            "qid_sha256": _canonical_qid_hash(list(titles)),
+            "official_query_records_sha256": _canonical_record_hash(
+                titles,
+                descriptions,
+            ),
+        },
+        "query_representations": {
+            "title": {},
+            "description": {},
+            "title_plus_description": {},
+        },
+        "frozen_title_baseline": {
+            "bm25": {
+                "mrr@10": 0.5,
+                "ndcg@10": 0.4,
+                "recall@100": 0.3,
+                "recall@1000": 0.6,
+            },
+            "bm25_ce": {
+                "mrr@10": 0.6,
+                "ndcg@10": 0.5,
+                "recall@100": 0.3,
+            }
+        },
+    }
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(
+        json.dumps(contract, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    baseline_queries = {
+        "q1": "Vitamin B12 - Benefits?",
+        "q2": "Organic foods: safety",
+        "other": "not in the video cohort",
+    }
+    return contract_path, baseline_queries
+
+
+@pytest.mark.parametrize(
+    ("representation", "expected"),
+    [
+        (
+            "title",
+            {
+                "q1": "Vitamin B12 - Benefits?",
+                "q2": "Organic foods: safety",
+            },
+        ),
+        (
+            "description",
+            {
+                "q1": "A bounded description about B12.",
+                "q2": "Evidence about organic foods.",
+            },
+        ),
+        (
+            "title_plus_description",
+            {
+                "q1": "Vitamin B12 - Benefits?\nA bounded description about B12.",
+                "q2": "Organic foods: safety\nEvidence about organic foods.",
+            },
+        ),
+    ],
+)
+def test_loader_constructs_only_predeclared_video_queries(
+    tmp_path: Path,
+    representation: str,
+    expected: dict[str, str],
+) -> None:
+    contract_path, baseline_queries = _make_fixture(tmp_path)
+
+    bundle = load_nfcorpus_video_query_representation(
+        baseline_queries,
+        representation=representation,
+        contract_path=contract_path,
+        project_root=tmp_path,
+        download_if_missing=False,
+    )
+
+    assert bundle.queries == expected
+    assert bundle.summary["n_queries"] == 2
+    assert bundle.summary["title_alignment"] == {"matched": 2, "mismatched": 0}
+    assert bundle.summary["leakage_boundary"]["excluded"] == [
+        "qrels",
+        "corpus_documents",
+        "ranked_outputs",
+        "metrics",
+        "manual_rewrites",
+    ]
+
+
+def test_loader_rejects_archive_hash_drift(tmp_path: Path) -> None:
+    contract_path, baseline_queries = _make_fixture(tmp_path)
+    archive_path = tmp_path / "cache" / "nfcorpus.tar.gz"
+    archive_path.write_bytes(archive_path.read_bytes() + b"drift")
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    contract["inputs"]["official_nfcorpus_v1"]["bytes"] = archive_path.stat().st_size
+    contract_path.write_text(json.dumps(contract), encoding="utf-8")
+
+    with pytest.raises(NFCorpusVideoContractError, match="MD5 drift"):
+        load_nfcorpus_video_query_representation(
+            baseline_queries,
+            representation="title",
+            contract_path=contract_path,
+            project_root=tmp_path,
+            download_if_missing=False,
+        )
+
+
+def test_loader_rejects_beir_title_mismatch(tmp_path: Path) -> None:
+    contract_path, baseline_queries = _make_fixture(tmp_path)
+    baseline_queries["q2"] = "unrelated query"
+
+    with pytest.raises(NFCorpusVideoContractError, match="do not align"):
+        load_nfcorpus_video_query_representation(
+            baseline_queries,
+            representation="description",
+            contract_path=contract_path,
+            project_root=tmp_path,
+            download_if_missing=False,
+        )
+
+
+def test_artifacts_and_title_reproduction_guard(tmp_path: Path) -> None:
+    contract_path, baseline_queries = _make_fixture(tmp_path)
+    bundle = load_nfcorpus_video_query_representation(
+        baseline_queries,
+        representation="title",
+        contract_path=contract_path,
+        project_root=tmp_path,
+        download_if_missing=False,
+    )
+
+    summary, paths = write_nfcorpus_video_query_artifacts(
+        bundle,
+        tmp_path / "outputs" / "query_representation",
+    )
+    guard = validate_frozen_title_metrics(
+        bundle,
+        {
+            "mrr@10": 0.5,
+            "ndcg@10": 0.4,
+            "recall@100": 0.3,
+            "recall@1000": 0.6,
+        },
+    )
+
+    assert summary["representation"] == "title"
+    assert len(paths) == 2
+    assert guard["passed"] is True
+    assert validate_frozen_title_reranker_metrics(
+        bundle,
+        {
+            "mrr@10": 0.5,
+            "ndcg@10": 0.4,
+            "recall@100": 0.3,
+        },
+        {
+            "mrr@10": 0.6,
+            "ndcg@10": 0.5,
+            "recall@100": 0.3,
+        },
+    )["passed"] is True
+    with pytest.raises(NFCorpusVideoContractError, match="metric drift"):
+        validate_frozen_title_metrics(
+            bundle,
+            {
+                "mrr@10": 0.4,
+                "ndcg@10": 0.4,
+                "recall@100": 0.3,
+                "recall@1000": 0.6,
+            },
+        )
+
+
+def test_runner_requires_isolated_nfcorpus_output(tmp_path: Path) -> None:
+    cfg = {"query_transform": {"method": "none"}}
+
+    missing_output = parse_args(
+        [
+            "--dataset",
+            "beir/nfcorpus/test",
+            "--query-representation",
+            "title",
+        ]
+    )
+    with pytest.raises(SystemExit, match="explicit --output-dir"):
+        _validate_query_representation_args(missing_output, cfg)
+
+    wrong_dataset = parse_args(
+        [
+            "--dataset",
+            "beir/scifact/test",
+            "--query-representation",
+            "title",
+            "--output-dir",
+            str(tmp_path / "run"),
+        ]
+    )
+    with pytest.raises(SystemExit, match="restricted"):
+        _validate_query_representation_args(wrong_dataset, cfg)
+
+    reranker_missing_paths = parse_reranker_args(
+        [
+            "--dataset",
+            "beir/nfcorpus/test",
+            "--query-representation",
+            "title",
+        ]
+    )
+    with pytest.raises(SystemExit, match="explicit --input-run and --output-dir"):
+        validate_reranker_representation_args(reranker_missing_paths, cfg)
+
+
+def test_cohort_selection_happens_after_query_construction(tmp_path: Path) -> None:
+    contract_path, baseline_queries = _make_fixture(tmp_path)
+    bundle = load_nfcorpus_video_query_representation(
+        baseline_queries,
+        representation="description",
+        contract_path=contract_path,
+        project_root=tmp_path,
+        download_if_missing=False,
+    )
+    benchmark = BenchmarkQueries(
+        spec=get_benchmark_spec("beir/nfcorpus/test"),
+        queries=baseline_queries,
+        qrels={"q1": {"d1"}, "q2": {"d2"}, "other": {"d3"}},
+        graded_qrels={
+            "q1": {"d1": 1},
+            "q2": {"d2": 2},
+            "other": {"d3": 1},
+        },
+    )
+
+    selected = _select_video_query_cohort(benchmark, bundle)
+
+    assert selected.queries == bundle.queries
+    assert selected.qrels == {"q1": {"d1"}, "q2": {"d2"}}
+    assert selected.graded_qrels == {"q1": {"d1": 1}, "q2": {"d2": 2}}
+
+
+def test_resume_rejects_mixed_query_representation(tmp_path: Path) -> None:
+    contract_path, baseline_queries = _make_fixture(tmp_path)
+    bundle = load_nfcorpus_video_query_representation(
+        baseline_queries,
+        representation="title",
+        contract_path=contract_path,
+        project_root=tmp_path,
+        download_if_missing=False,
+    )
+    output_dir = tmp_path / "run"
+    representation_dir = output_dir / "query_representation"
+    representation_dir.mkdir(parents=True)
+    (output_dir / "run.tsv").write_text("q1\tQ0\td1\t1\t1.0\tbm25\n", encoding="utf-8")
+    stale = dict(bundle.summary)
+    stale["representation"] = "description"
+    (representation_dir / "summary.json").write_text(
+        json.dumps(stale),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="representation differs"):
+        _validate_representation_resume(output_dir, bundle, resume=True)
+
+
+def test_reranker_requires_matching_upstream_representation(tmp_path: Path) -> None:
+    contract_path, baseline_queries = _make_fixture(tmp_path)
+    bundle = load_nfcorpus_video_query_representation(
+        baseline_queries,
+        representation="description",
+        contract_path=contract_path,
+        project_root=tmp_path,
+        download_if_missing=False,
+    )
+    upstream = {"query_representation": dict(bundle.summary)}
+
+    _validate_upstream_query_representation(bundle, upstream)
+    upstream["query_representation"]["effective_queries_sha256"] = "0" * 64
+    with pytest.raises(SystemExit, match="effective_queries_sha256"):
+        _validate_upstream_query_representation(bundle, upstream)


### PR DESCRIPTION
## Summary

- freeze and enforce the data, cohort, leakage, and evaluation contract for the official 102-query NFCorpus test/video subset
- compare the existing BEIR title, official video description, and title plus description while keeping the corpus, qrels, BM25 parameters, shared index, cross-encoder, and architecture fixed
- remove cross-platform zero-score tie drift by sorting the full 3,633-document BM25 result by score descending and document id ascending before truncation
- validate all BM25 and cross-encoder runs, independently recompute the metrics, run 10,000 paired-bootstrap resamples, and publish the bounded result in the repository

## Result

| Representation | System | MRR@10 | nDCG@10 | Recall@100 | Recall@1000 |
|---|---|---:|---:|---:|---:|
| Title | BM25 | 0.4780 | 0.2493 | 0.2821 | 0.4919 |
| Description | BM25 | 0.5308 | 0.2929 | 0.3272 | 0.6413 |
| Title + description | BM25 | 0.6036 | 0.3457 | 0.3700 | 0.6723 |
| Title | BM25 + CE | 0.5220 | 0.2980 | 0.2821 | n/a |
| Description | BM25 + CE | 0.6357 | 0.3568 | 0.3272 | n/a |
| Title + description | BM25 + CE | 0.6689 | 0.3853 | 0.3700 | n/a |

Recall@100 is the predeclared primary metric. Description alone has a positive point estimate against title, but its paired interval crosses zero: delta `+0.0451`, 95% CI `[-0.0024, +0.0943]`, `p = 0.0610`.

Title plus description gives a Recall@100 delta of `+0.0880`, 95% CI `[+0.0535, +0.1265]`, `p < 0.0002`. It reduces no-hit-at-100 queries from 11 to 4 and no-hit-at-1000 queries from 8 to 0.

## Validation and review

- 102 qids at BM25 depth 1,000 for all three representations
- one shared BM25 index fingerprint and clean production commit
- 102 qids at rerank depth 100 for all three representations
- 306/306 query-condition checks confirm that each CE run contains exactly its corresponding BM25 top-100 candidate set
- fixed cross-encoder revision `c5ee24cb16019beea0893ab7796b1df96625c6b8`
- independent `ir-measures` agreement within `1e-12` (maximum absolute delta `4.44e-16`)
- 10,000 paired-bootstrap resamples with frozen seed `20260727`
- `655 passed, 1 skipped, 1 deselected`
- Ruff, artifact boundary, artifact registry, headline consistency, and high-confidence secret checks pass locally

The machine-readable result record is `reports/generated/artifacts/nfcorpus_video_query_representation.json`; the full interpretation is in `docs/reports/2026-07-28-nfcorpus-video-query-representation.md`.

## Interpretation boundary

This is retrieval-only evidence on the official 102-query video subset. The descriptions are bounded source-page context, not independently authored user queries. The result supports a source-context limitation under the fixed BM25 system; it does not establish an architecture improvement, transfer to the remaining NFCorpus queries, generation quality, or grounding.

Closes #19.
