### PR TITLE
repro: publish NFCorpus video ablation bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Python dependencies are installed (``pip install -r requirements.txt &&
 # pip install -e .``).
 
-.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts check-registry export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline reproduce-trec-eval build-trec-release reproduce-beir-eval build-beir-release analyze-nfcorpus-first-stage review-nfcorpus-first-stage
+.PHONY: help install test test-slow lint check-results check-fixture-metrics check-lockfile check-notebooks check-artifacts check-registry export-report-tables check-report-tables pipeline-dry-run rag-eval-dry-run model-stack-smoke serve-dev clean-pycache reproduce-small reproduce-baseline reproduce-trec-eval build-trec-release reproduce-beir-eval build-beir-release reproduce-nfcorpus-video-eval build-nfcorpus-video-release analyze-nfcorpus-first-stage review-nfcorpus-first-stage
 
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
@@ -34,6 +34,8 @@ help:
 	@echo "  make build-trec-release   -- build the maintainer release ZIP from canonical runs"
 	@echo "  make reproduce-beir-eval  -- fetch + verify published BEIR runs and metrics"
 	@echo "  make build-beir-release   -- build the maintainer BEIR release ZIP"
+	@echo "  make reproduce-nfcorpus-video-eval -- verify + evaluate six query-ablation runs"
+	@echo "  make build-nfcorpus-video-release -- build the maintainer query-ablation ZIP"
 	@echo "  make analyze-nfcorpus-first-stage -- reproduce inputs + diagnose BM25 coverage"
 	@echo "  make review-nfcorpus-first-stage -- validate the 72-case taxonomy review"
 
@@ -167,6 +169,18 @@ reproduce-beir-eval:
 # outputs/ and is published only after its exact size and SHA-256 are pinned.
 build-beir-release:
 	$(PYTHON) -m msmarco_genqa.cli.beir_release build --output outputs/releases/beir-cross-domain-baselines-v1.zip
+
+# Fast reproduction of the NFCorpus test/video query-representation evidence.
+# The release contains six fixed text-only runs (three representations x two
+# systems). Public qrels are recovered through ir_datasets before aggregate
+# metrics, candidate-set invariants, and the pinned paired bootstrap are checked.
+reproduce-nfcorpus-video-eval:
+	$(PYTHON) -m msmarco_genqa.cli.nfcorpus_video_release reproduce --cache-dir outputs/reproductions/beir_irds_cache
+
+# Maintainer-only deterministic packaging target. The generated ZIP remains
+# ignored; the tracked pointer pins its exact byte size and SHA-256 digest.
+build-nfcorpus-video-release:
+	$(PYTHON) -m msmarco_genqa.cli.nfcorpus_video_release build --output outputs/releases/nfcorpus-video-query-ablation-v1.zip
 
 # Query-level diagnosis over the immutable NFCorpus BM25 run. The dependency
 # materializes and verifies the public release, qrels, and source archive; this

--- a/README.md
+++ b/README.md
@@ -665,7 +665,23 @@ the video subset, not an architecture or full-dataset generalization result.
 See the
 [`query-representation report`](docs/reports/2026-07-28-nfcorpus-video-query-representation.md).
 
-The four ranked runs are published as a checksummed, text-only
+The six exact runs behind this ablation (three query representations, before
+and after reranking) are published as a checksummed, text-only
+[GitHub Release bundle](https://github.com/GioiaZheng/msmarco-genqa/releases/tag/v2.3-nfcorpus-video-query-ablation).
+Download the asset, verify the archive and member hashes, recover the public
+qrels, and recompute all metrics and paired comparisons with:
+
+```bash
+make reproduce-nfcorpus-video-eval
+```
+
+The command follows
+[`artifacts/nfcorpus_video_query_representation_v1.json`](artifacts/nfcorpus_video_query_representation_v1.json).
+It does not rerun retrieval or the cross-encoder, and the bundle excludes query
+and document text, qrels mirrors, model weights, caches, and local manifests.
+
+Separately, the four cross-domain NFCorpus/SciFact ranked runs are published as
+a checksummed, text-only
 [GitHub Release bundle](https://github.com/GioiaZheng/msmarco-genqa/releases/tag/v2.2-beir-cross-domain-baselines).
 Recompute all four rows without rebuilding either corpus index or rerunning
 the cross-encoder:

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -170,6 +170,38 @@ document/query text, qrels mirror, model weights, caches, or machine-local
 manifests. This validates the published evidence without rebuilding the
 NFCorpus/SciFact indexes or rerunning the cross-encoder.
 
+## Reproducing the NFCorpus Video Query Ablation
+
+The six fixed runs from the 102-query query-representation experiment can be
+recovered and checked with:
+
+```bash
+make reproduce-nfcorpus-video-eval
+```
+
+The equivalent direct Python command is:
+
+```bash
+python -m msmarco_genqa.cli.nfcorpus_video_release reproduce \
+  --cache-dir outputs/reproductions/beir_irds_cache
+```
+
+The command follows
+`artifacts/nfcorpus_video_query_representation_v1.json`, downloads the pinned
+GitHub Release asset, checks its byte size and SHA-256 digest, and validates
+every archived member. It then obtains the public NFCorpus test qrels through
+`ir_datasets`, selects the frozen 102-query video cohort from the run qids, and
+recomputes all six aggregate result rows. It also verifies that each reranked
+candidate set equals the corresponding BM25 top 100 and reruns the published
+10,000-resample paired bootstrap with seed `20260727`.
+
+Checked `metrics.json` and `metrics.md` outputs are written under
+`outputs/reproductions/nfcorpus_video_query_representation_v1/evaluation/`.
+This is an exact-output evidence reproduction: it does not rerun BM25, the
+cross-encoder, or corpus indexing. The archive contains ranked document
+identifiers and scores only; query/document text, qrels mirrors, model weights,
+caches, and machine-local manifests are excluded.
+
 ## Full Pipeline Plan
 
 Print the executable plan:

--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -17,3 +17,5 @@ Current records:
   TREC-DL 2019/2020 ranked runs.
 - `beir_cross_domain_v1.json` — text-only BM25 and BM25-plus-cross-encoder
   NFCorpus/SciFact ranked runs.
+- `nfcorpus_video_query_representation_v1.json` — six text-only NFCorpus
+  test/video query-representation runs plus the pinned evaluation contract.

--- a/artifacts/nfcorpus_video_query_representation_v1.json
+++ b/artifacts/nfcorpus_video_query_representation_v1.json
@@ -1,0 +1,48 @@
+{
+  "schema": "msmarco-genqa.external-artifact-pointer.v1",
+  "artifact_id": "nfcorpus-video-query-representation-bm25-ce-v1",
+  "kind": "nfcorpus_video_query_representation_run_bundle",
+  "release": {
+    "repository": "GioiaZheng/msmarco-genqa",
+    "tag": "v2.3-nfcorpus-video-query-ablation",
+    "asset": "nfcorpus-video-query-ablation-v1.zip"
+  },
+  "download": {
+    "url": "https://github.com/GioiaZheng/msmarco-genqa/releases/download/v2.3-nfcorpus-video-query-ablation/nfcorpus-video-query-ablation-v1.zip",
+    "bytes": 2975679,
+    "sha256": "6d588eef275989e822d12e40afa67396a6226dd6df52246877a312556c64272f"
+  },
+  "source": {
+    "experiment_commits": {
+      "bm25": "119a9c695547",
+      "reranker": "cc6ae1f9ac08"
+    },
+    "record": "reports/generated/artifacts/nfcorpus_video_query_representation.json",
+    "record_sha256": "321d8296518c696f28d1b8d4bd5456fb825853e24fe2be53397e711cf15cd56c",
+    "record_serialization": "canonical-json-utf8-sorted-keys-compact"
+  },
+  "contents": {
+    "dataset": "beir/nfcorpus/test",
+    "subset": "official_test_video",
+    "query_representations": [
+      "title",
+      "description",
+      "title_plus_description"
+    ],
+    "systems": [
+      "bm25",
+      "bm25_ce"
+    ],
+    "run_files": 6,
+    "contains_query_text": false,
+    "contains_document_text": false,
+    "contains_model_weights": false
+  },
+  "reproduce": {
+    "command": "make reproduce-nfcorpus-video-eval",
+    "requires_private_credentials": false,
+    "rebuilds_corpus_indexes": false,
+    "reruns_retrieval": false,
+    "reruns_cross_encoder": false
+  }
+}

--- a/docs/reports/2026-07-28-nfcorpus-video-query-representation.md
+++ b/docs/reports/2026-07-28-nfcorpus-video-query-representation.md
@@ -114,6 +114,24 @@ python -X utf8 scripts/analyze_nfcorpus_query_representations.py \
   --tolerance 1e-12
 ```
 
+## Public exact-output artifact
+
+The six fixed ranked runs are published in the text-only GitHub Release
+`v2.3-nfcorpus-video-query-ablation`. From a configured clone, reproduce the
+reported aggregates and paired comparisons with:
+
+```bash
+make reproduce-nfcorpus-video-eval
+```
+
+This command follows the immutable pointer in
+[`artifacts/nfcorpus_video_query_representation_v1.json`](../../artifacts/nfcorpus_video_query_representation_v1.json),
+verifies the downloaded ZIP and every member hash, recovers public NFCorpus
+qrels through `ir_datasets`, and writes checked `metrics.json` and `metrics.md`
+files. It does not rebuild an index or rerun BM25 or the cross-encoder. The
+bundle contains document identifiers, ranks, and scores only, with no query or
+document text, qrels mirror, model weights, caches, or machine-local manifests.
+
 ## Interpretation
 
 The result supports a narrow conclusion: on the official NFCorpus video

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ rag-eval     = "msmarco_genqa.cli.rag_eval:main"
 mgq-trec-eval = "msmarco_genqa.cli.trec_eval:main"
 mgq-trec-release = "msmarco_genqa.cli.trec_release:main"
 mgq-beir-release = "msmarco_genqa.cli.beir_release:main"
+mgq-nfcorpus-video-release = "msmarco_genqa.cli.nfcorpus_video_release:main"
 
 
 # --------------------------------------------------------------------------- #

--- a/reports/generated/artifacts/nfcorpus_video_query_representation.json
+++ b/reports/generated/artifacts/nfcorpus_video_query_representation.json
@@ -70,6 +70,12 @@
         "bm25_manifest": "bd328a7472e235aa91aeee147751e4616b03bc9d718886e2143fb19326f7770a",
         "rerank_run": "c3b21ad0a93a3b0e89625dad3e5ba81235ba7da1890749caed45f40492196f3c",
         "rerank_manifest": "0e7479338688da77dd1989d62f88777f7dca0c66660458b4f7effcad1216485b"
+      },
+      "artifact_paths": {
+        "bm25_run": "outputs/beir_nfcorpus_video/title/bm25/run.tsv",
+        "bm25_manifest": "outputs/beir_nfcorpus_video/title/bm25/manifest.json",
+        "rerank_run": "outputs/beir_nfcorpus_video/title/cross_encoder_rerank/run.tsv",
+        "rerank_manifest": "outputs/beir_nfcorpus_video/title/cross_encoder_rerank/manifest.json"
       }
     },
     "description": {
@@ -99,6 +105,12 @@
         "bm25_manifest": "3a63c47e62e7dd645a4bc88949a513973fb3ae5c39c4aebf95469ddc220716a2",
         "rerank_run": "d07eeff242e0c9a70a7df3bc5c98731211153e91f2f5d85434ca9ab4c1f37760",
         "rerank_manifest": "0a1df9ddb43a8f9dc9626128e840ed16a6ff6880962def40d000101187e70722"
+      },
+      "artifact_paths": {
+        "bm25_run": "outputs/beir_nfcorpus_video/description/bm25/run.tsv",
+        "bm25_manifest": "outputs/beir_nfcorpus_video/description/bm25/manifest.json",
+        "rerank_run": "outputs/beir_nfcorpus_video/description/cross_encoder_rerank/run.tsv",
+        "rerank_manifest": "outputs/beir_nfcorpus_video/description/cross_encoder_rerank/manifest.json"
       }
     },
     "title_plus_description": {
@@ -152,6 +164,12 @@
         "bm25_manifest": "92d059fd5a289ec57dd1e4687d8def04f7e5f00d319790ec91556207c866645f",
         "rerank_run": "5e7807fb66c5567a1aacebb1410fd80fd24b7e9a4a3e33113065b4d2f3603e9a",
         "rerank_manifest": "82626bbb0c9ec4e4b0f5f966eb4b60d5707e97f37341f2b17a8132e08edaa37e"
+      },
+      "artifact_paths": {
+        "bm25_run": "outputs/beir_nfcorpus_video/title_plus_description/bm25/run.tsv",
+        "bm25_manifest": "outputs/beir_nfcorpus_video/title_plus_description/bm25/manifest.json",
+        "rerank_run": "outputs/beir_nfcorpus_video/title_plus_description/cross_encoder_rerank/run.tsv",
+        "rerank_manifest": "outputs/beir_nfcorpus_video/title_plus_description/cross_encoder_rerank/manifest.json"
       }
     }
   },

--- a/reports/generated/tables/nfcorpus_video_query_representation_bm25.sources.json
+++ b/reports/generated/tables/nfcorpus_video_query_representation_bm25.sources.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "path": "reports/generated/artifacts/nfcorpus_video_query_representation.json",
-      "sha256_16": "8485566947c393a2",
+      "sha256_16": "d5c9a14de462b65e",
       "artifact_schema": "msmarco-genqa.table-artifact.v1",
       "artifact_id": "nfcorpus_video_query_representation",
       "metric_schema": "retrieval.nfcorpus_video_query_representation.v1",

--- a/reports/generated/tables/nfcorpus_video_query_representation_bm25_ce.sources.json
+++ b/reports/generated/tables/nfcorpus_video_query_representation_bm25_ce.sources.json
@@ -5,7 +5,7 @@
   "sources": [
     {
       "path": "reports/generated/artifacts/nfcorpus_video_query_representation.json",
-      "sha256_16": "8485566947c393a2",
+      "sha256_16": "d5c9a14de462b65e",
       "artifact_schema": "msmarco-genqa.table-artifact.v1",
       "artifact_id": "nfcorpus_video_query_representation",
       "metric_schema": "retrieval.nfcorpus_video_query_representation.v1",

--- a/src/msmarco_genqa/cli/nfcorpus_video_release.py
+++ b/src/msmarco_genqa/cli/nfcorpus_video_release.py
@@ -1,0 +1,123 @@
+"""Manage the public NFCorpus video query-representation release bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from msmarco_genqa.reproducibility.nfcorpus_video_release import (
+    ReleaseArtifactError,
+    build_release_bundle,
+    evaluate_release_bundle,
+    fetch_release_bundle,
+    verify_release_archive,
+)
+
+
+DEFAULT_POINTER = Path("artifacts/nfcorpus_video_query_representation_v1.json")
+DEFAULT_OUTPUT = Path("outputs/reproductions/nfcorpus_video_query_representation_v1")
+
+
+def _add_evaluation_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--qrels",
+        type=Path,
+        help="Optional local NFCorpus qrels (format auto-detected); otherwise use ir_datasets.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        help="Optional IR_DATASETS_HOME used to recover the public qrels.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="Build the deterministic release ZIP.")
+    build.add_argument(
+        "--source-record",
+        type=Path,
+        default=Path(
+            "reports/generated/artifacts/nfcorpus_video_query_representation.json"
+        ),
+    )
+    build.add_argument("--project-root", type=Path, default=Path.cwd())
+    build.add_argument("--output", type=Path, required=True)
+
+    verify = subparsers.add_parser("verify", help="Verify an existing release ZIP.")
+    verify.add_argument("archive", type=Path)
+    verify.add_argument("--sha256")
+    verify.add_argument("--bytes", type=int)
+
+    fetch = subparsers.add_parser("fetch", help="Download and extract the pinned release.")
+    fetch.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
+    fetch.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+
+    evaluate = subparsers.add_parser(
+        "evaluate",
+        help="Recompute aggregate and paired metrics from an extracted bundle.",
+    )
+    evaluate.add_argument("--bundle-dir", type=Path, required=True)
+    evaluate.add_argument("--output-dir", type=Path, required=True)
+    _add_evaluation_arguments(evaluate)
+
+    reproduce = subparsers.add_parser(
+        "reproduce",
+        help="Download, verify, and recompute the published ablation.",
+    )
+    reproduce.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
+    reproduce.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+    _add_evaluation_arguments(reproduce)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "build":
+            result = build_release_bundle(
+                source_record_path=args.source_record,
+                project_root=args.project_root,
+                output_archive=args.output,
+            )
+        elif args.command == "verify":
+            result = verify_release_archive(
+                args.archive,
+                expected_sha256=args.sha256,
+                expected_bytes=args.bytes,
+            )
+        elif args.command == "fetch":
+            result = fetch_release_bundle(
+                pointer_path=args.pointer,
+                output_dir=args.output_dir,
+            )
+        elif args.command == "evaluate":
+            result = evaluate_release_bundle(
+                bundle_dir=args.bundle_dir,
+                output_dir=args.output_dir,
+                qrels_path=args.qrels,
+                cache_dir=args.cache_dir,
+            )
+        else:
+            fetched = fetch_release_bundle(
+                pointer_path=args.pointer,
+                output_dir=args.output_dir,
+            )
+            result = evaluate_release_bundle(
+                bundle_dir=fetched["bundle_dir"],
+                output_dir=Path(args.output_dir) / "evaluation",
+                qrels_path=args.qrels,
+                cache_dir=args.cache_dir,
+            )
+    except (OSError, ReleaseArtifactError, ValueError) as exc:
+        parser.exit(2, f"error: {exc}\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/msmarco_genqa/reproducibility/nfcorpus_video_release.py
+++ b/src/msmarco_genqa/reproducibility/nfcorpus_video_release.py
@@ -1,0 +1,840 @@
+"""Build, recover, and re-evaluate the NFCorpus video-query ablation bundle."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from msmarco_genqa.data.benchmark import load_benchmark_queries
+from msmarco_genqa.evaluation.bootstrap import paired_bootstrap_diff
+from msmarco_genqa.evaluation.retrieval import (
+    first_relevant_rank,
+    recall_at_k,
+    reciprocal_rank,
+)
+from msmarco_genqa.evaluation.trec import (
+    evaluate_internal_trec_scope,
+    graded_ndcg_at_k,
+    read_qrels,
+)
+from msmarco_genqa.reproducibility.trec_release import (
+    DEFAULT_TOLERANCE,
+    MANIFEST_NAME,
+    README_NAME,
+    SOURCE_RECORD_SCHEMA,
+    ReleaseArtifactError,
+    _canonical_json_bytes,
+    _expected_metrics,
+    _load_json_object,
+    _manifest_members,
+    _member_record,
+    _verify_extracted_directory,
+    _write_deterministic_zip,
+    fetch_release_bundle as _fetch_release_bundle,
+    sha256_bytes,
+    sha256_file,
+    verify_release_archive as _verify_release_archive,
+)
+from msmarco_genqa.reranking.io import read_run_tsv
+
+
+BUNDLE_SCHEMA = "msmarco-genqa.nfcorpus-video-release-bundle.v1"
+REPRODUCTION_SCHEMA = "msmarco-genqa.nfcorpus-video-reproduction.v1"
+DEFAULT_ARTIFACT_ID = "nfcorpus-video-query-representation-bm25-ce-v1"
+DEFAULT_DATASET_ID = "beir/nfcorpus/test"
+DEFAULT_REL_THRESHOLD = 1
+REPRESENTATIONS = ("title", "description", "title_plus_description")
+SYSTEM_METRICS = {
+    "bm25": ("mrr@10", "ndcg@10", "recall@100", "recall@1000"),
+    "bm25_ce": ("mrr@10", "ndcg@10", "recall@100"),
+}
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    representation: str
+    system: str
+    source_key: str
+    result_key: str
+    archive_path: str
+
+
+RUN_SPECS = tuple(
+    RunSpec(
+        representation=representation,
+        system=system,
+        source_key=source_key,
+        result_key=result_key,
+        archive_path=(
+            f"runs/nfcorpus_video_{representation}_"
+            f"{'bm25_ce' if system == 'bm25_ce' else 'bm25'}.tsv"
+        ),
+    )
+    for representation in REPRESENTATIONS
+    for system, source_key, result_key in (
+        ("bm25", "bm25_run", "bm25"),
+        ("bm25_ce", "rerank_run", "bm25_ce"),
+    )
+)
+
+
+def _qid_sha256(qids: set[str]) -> str:
+    payload = "".join(f"{qid}\n" for qid in sorted(qids)).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _experiment_commits(source_record: Mapping[str, Any]) -> dict[str, str]:
+    experiment = source_record.get("experiment")
+    commits = experiment.get("git_commits") if isinstance(experiment, dict) else None
+    if not isinstance(commits, dict) or not commits:
+        raise ReleaseArtifactError("source record is missing experiment.git_commits")
+    normalized = {
+        str(key): str(value)
+        for key, value in commits.items()
+        if isinstance(key, str) and isinstance(value, str) and value
+    }
+    if len(normalized) != len(commits):
+        raise ReleaseArtifactError("source record contains an invalid experiment commit")
+    return normalized
+
+
+def _bootstrap_record(value: Any, *, label: str) -> dict[str, float]:
+    if not isinstance(value, dict):
+        raise ReleaseArtifactError(f"source record is missing {label}")
+    names = ("mean_delta", "ci_low", "ci_high", "p_two_sided")
+    try:
+        record = {name: float(value[name]) for name in names}
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ReleaseArtifactError(f"source record has invalid {label}") from exc
+    if not all(math.isfinite(number) for number in record.values()):
+        raise ReleaseArtifactError(f"source record has non-finite {label}")
+    return record
+
+
+def _expected_paired_comparisons(results: Mapping[str, Any]) -> dict[str, Any]:
+    description = results.get("description")
+    combined = results.get("title_plus_description")
+    if not isinstance(description, dict) or not isinstance(combined, dict):
+        raise ReleaseArtifactError("source record is missing treatment results")
+    description_paired = description.get("paired_vs_title")
+    combined_paired = combined.get("paired_vs_title")
+    if not isinstance(description_paired, dict) or not isinstance(combined_paired, dict):
+        raise ReleaseArtifactError("source record is missing paired comparisons")
+
+    return {
+        "bm25": {
+            "description_vs_title": {
+                "recall@100": _bootstrap_record(
+                    description_paired.get("recall@100"),
+                    label="results.description.paired_vs_title.recall@100",
+                )
+            },
+            "title_plus_description_vs_title": {
+                "mrr@10": _bootstrap_record(
+                    combined_paired.get("bm25_mrr@10"),
+                    label=(
+                        "results.title_plus_description.paired_vs_title."
+                        "bm25_mrr@10"
+                    ),
+                ),
+                "ndcg@10": _bootstrap_record(
+                    combined_paired.get("bm25_ndcg@10"),
+                    label=(
+                        "results.title_plus_description.paired_vs_title."
+                        "bm25_ndcg@10"
+                    ),
+                ),
+                "recall@100": _bootstrap_record(
+                    combined_paired.get("recall@100"),
+                    label=(
+                        "results.title_plus_description.paired_vs_title."
+                        "recall@100"
+                    ),
+                ),
+            },
+        },
+        "bm25_ce": {
+            "title_plus_description_vs_title": {
+                "mrr@10": _bootstrap_record(
+                    combined_paired.get("bm25_ce_mrr@10"),
+                    label=(
+                        "results.title_plus_description.paired_vs_title."
+                        "bm25_ce_mrr@10"
+                    ),
+                ),
+                "ndcg@10": _bootstrap_record(
+                    combined_paired.get("bm25_ce_ndcg@10"),
+                    label=(
+                        "results.title_plus_description.paired_vs_title."
+                        "bm25_ce_ndcg@10"
+                    ),
+                ),
+            }
+        },
+    }
+
+
+def _bundle_readme(artifact_id: str, experiment_commits: Mapping[str, str]) -> bytes:
+    commits = ", ".join(
+        f"`{key}`: `{value}`" for key, value in sorted(experiment_commits.items())
+    )
+    text = f"""# NFCorpus video query-representation run bundle
+
+Artifact: `{artifact_id}`
+
+Experiment commits: {commits}
+
+This archive contains six exact ranked outputs for the official 102-query
+NFCorpus test/video subset: BM25 top-1,000 and fixed top-100 cross-encoder
+reranking for title, description, and title-plus-description queries.
+
+The payload contains query/document identifiers, ranks, scores, checksums, and
+compact metric expectations. It contains no query text, document text, qrels
+mirror, model weights, caches, or machine-local manifests.
+
+From a clone of `GioiaZheng/msmarco-genqa`, run:
+
+```bash
+make reproduce-nfcorpus-video-eval
+```
+
+The command downloads this archive, verifies its pinned byte size and SHA-256,
+verifies every member digest, obtains the public NFCorpus judgments through
+`ir_datasets`, and recomputes the six aggregate rows plus the paired-bootstrap
+comparisons. It does not rebuild the index or rerun either retrieval stage.
+"""
+    return text.encode("utf-8")
+
+
+def _source_run(
+    *,
+    root: Path,
+    representation_result: Mapping[str, Any],
+    spec: RunSpec,
+) -> tuple[Path, bytes, dict[str, list[tuple[str, float]]]]:
+    artifact_paths = representation_result.get("artifact_paths")
+    artifact_hashes = representation_result.get("artifact_sha256")
+    if not isinstance(artifact_paths, dict) or not isinstance(artifact_hashes, dict):
+        raise ReleaseArtifactError(
+            f"source record has incomplete {spec.representation} artifact metadata"
+        )
+    relative_run = artifact_paths.get(spec.source_key)
+    expected_hash = artifact_hashes.get(spec.source_key)
+    if not isinstance(relative_run, str) or not isinstance(expected_hash, str):
+        raise ReleaseArtifactError(
+            f"source record has no path/hash for {spec.representation} {spec.system}"
+        )
+    run_path = (root / relative_run).resolve()
+    try:
+        run_path.relative_to(root)
+    except ValueError as exc:
+        raise ReleaseArtifactError(f"source path escapes project root: {relative_run}") from exc
+    if not run_path.is_file():
+        raise ReleaseArtifactError(f"missing canonical run: {relative_run}")
+    data = run_path.read_bytes()
+    actual_hash = sha256_bytes(data)
+    if actual_hash != expected_hash.lower():
+        raise ReleaseArtifactError(
+            f"{relative_run}: SHA-256 mismatch; expected {expected_hash}, got {actual_hash}"
+        )
+    return run_path, data, read_run_tsv(run_path)
+
+
+def _validate_candidate_sets(
+    runs: Mapping[tuple[str, str], dict[str, list[tuple[str, float]]]],
+    *,
+    rerank_depth: int,
+) -> int:
+    checks = 0
+    for representation in REPRESENTATIONS:
+        bm25 = runs[(representation, "bm25")]
+        rerank = runs[(representation, "bm25_ce")]
+        if set(bm25) != set(rerank):
+            raise ReleaseArtifactError(
+                f"{representation}: BM25 and reranked qid sets differ"
+            )
+        for qid in sorted(bm25):
+            bm25_candidates = {
+                doc_id for doc_id, _score in bm25[qid][:rerank_depth]
+            }
+            rerank_candidates = {doc_id for doc_id, _score in rerank[qid]}
+            if bm25_candidates != rerank_candidates:
+                raise ReleaseArtifactError(
+                    f"{representation}/{qid}: reranked candidates differ from "
+                    f"BM25 top-{rerank_depth}"
+                )
+            checks += 1
+    return checks
+
+
+def build_release_bundle(
+    *,
+    source_record_path: Path | str,
+    project_root: Path | str,
+    output_archive: Path | str,
+    artifact_id: str = DEFAULT_ARTIFACT_ID,
+) -> dict[str, Any]:
+    """Build a deterministic text-only bundle from the six canonical runs."""
+    root = Path(project_root).resolve()
+    source_path = Path(source_record_path).resolve()
+    try:
+        source_relative = source_path.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ReleaseArtifactError(
+            f"source record must be inside the project root: {source_path}"
+        ) from exc
+    source_record = _load_json_object(source_path)
+    if source_record.get("schema") != SOURCE_RECORD_SCHEMA:
+        raise ReleaseArtifactError(
+            f"{source_path}: expected schema {SOURCE_RECORD_SCHEMA!r}"
+        )
+    canonical_source_record = _canonical_json_bytes(source_record)
+
+    query_set = source_record.get("query_set")
+    experiment = source_record.get("experiment")
+    model = source_record.get("model_revision")
+    results = source_record.get("results")
+    if not all(isinstance(value, dict) for value in (query_set, experiment, model, results)):
+        raise ReleaseArtifactError("source record is missing release metadata")
+    expected_queries = int(query_set.get("n_queries", 0))
+    expected_qid_hash = str(query_set.get("qid_sha256", ""))
+    dataset_id = str(experiment.get("dataset", ""))
+    if expected_queries < 1 or len(expected_qid_hash) != 64:
+        raise ReleaseArtifactError("source record has an invalid query-set contract")
+    if dataset_id != DEFAULT_DATASET_ID:
+        raise ReleaseArtifactError(f"source record dataset must be {DEFAULT_DATASET_ID}")
+
+    bm25_config = experiment.get("bm25")
+    reranker_config = experiment.get("reranker")
+    evaluation = experiment.get("evaluation")
+    if not all(
+        isinstance(value, dict)
+        for value in (bm25_config, reranker_config, evaluation)
+    ):
+        raise ReleaseArtifactError("source record has incomplete experiment metadata")
+    bm25_depth = int(bm25_config.get("retrieval_depth", 0))
+    rerank_depth = int(reranker_config.get("depth", 0))
+    bootstrap_resamples = int(evaluation.get("bootstrap_resamples", 0))
+    bootstrap_seed = int(evaluation.get("bootstrap_seed", 0))
+    if min(bm25_depth, rerank_depth, bootstrap_resamples) < 1:
+        raise ReleaseArtifactError("source record has invalid depth/bootstrap settings")
+
+    members: dict[str, bytes] = {}
+    run_records: list[dict[str, Any]] = []
+    runs: dict[tuple[str, str], dict[str, list[tuple[str, float]]]] = {}
+    reference_qids: set[str] | None = None
+    for spec in RUN_SPECS:
+        representation_result = results.get(spec.representation)
+        if not isinstance(representation_result, dict):
+            raise ReleaseArtifactError(
+                f"source record is missing results.{spec.representation}"
+            )
+        system_result = representation_result.get(spec.result_key)
+        if not isinstance(system_result, dict):
+            raise ReleaseArtifactError(
+                f"source record is missing {spec.representation} {spec.system} metrics"
+            )
+        run_path, data, run = _source_run(
+            root=root,
+            representation_result=representation_result,
+            spec=spec,
+        )
+        expected_depth = bm25_depth if spec.system == "bm25" else rerank_depth
+        qids = set(run)
+        if len(qids) != expected_queries:
+            raise ReleaseArtifactError(
+                f"{run_path}: found {len(qids)} queries; expected {expected_queries}"
+            )
+        if any(len(rows) != expected_depth for rows in run.values()):
+            raise ReleaseArtifactError(
+                f"{run_path}: not every query has depth {expected_depth}"
+            )
+        if reference_qids is None:
+            reference_qids = qids
+        elif qids != reference_qids:
+            raise ReleaseArtifactError("query-id sets differ across the six runs")
+
+        row_count = sum(len(rows) for rows in run.values())
+        members[spec.archive_path] = data
+        runs[(spec.representation, spec.system)] = run
+        run_records.append(
+            _member_record(
+                spec.archive_path,
+                data,
+                kind="nfcorpus_video_run",
+                dataset_id=dataset_id,
+                representation=spec.representation,
+                system=spec.system,
+                query_count=len(qids),
+                row_count=row_count,
+                max_depth=expected_depth,
+                expected_metrics=_expected_metrics(system_result),
+            )
+        )
+
+    if reference_qids is None or _qid_sha256(reference_qids) != expected_qid_hash:
+        raise ReleaseArtifactError("run qids do not match the frozen cohort hash")
+    candidate_checks = _validate_candidate_sets(runs, rerank_depth=rerank_depth)
+    commits = _experiment_commits(source_record)
+    expected_paired = _expected_paired_comparisons(results)
+
+    readme = _bundle_readme(artifact_id, commits)
+    members[README_NAME] = readme
+    manifest = {
+        "schema": BUNDLE_SCHEMA,
+        "artifact_id": artifact_id,
+        "experiment_commits": commits,
+        "source_record": {
+            "repository_path": source_relative,
+            "sha256": sha256_bytes(canonical_source_record),
+            "serialization": "canonical-json-utf8-sorted-keys-compact",
+        },
+        "scope": {
+            "dataset": dataset_id,
+            "subset": str(experiment.get("subset")),
+            "representations": list(REPRESENTATIONS),
+            "systems": ["bm25", "bm25_ce"],
+            "query_count": expected_queries,
+            "qid_sha256": expected_qid_hash,
+            "bm25_depth": bm25_depth,
+            "rerank_depth": rerank_depth,
+            "candidate_set_checks": candidate_checks,
+            "binary_relevance_threshold": DEFAULT_REL_THRESHOLD,
+            "metric_tolerance": DEFAULT_TOLERANCE,
+            "bootstrap_resamples": bootstrap_resamples,
+            "bootstrap_seed": bootstrap_seed,
+            "confidence_level": float(evaluation.get("confidence_level", 0.95)),
+        },
+        "model_revision": model,
+        "expected_paired_comparisons": expected_paired,
+        "redistribution": {
+            "included": "ranked query/document identifiers, ranks, scores, and checksums",
+            "excluded": [
+                "query text",
+                "document text",
+                "qrels mirrors",
+                "model weights and caches",
+                "machine-local paths and manifests",
+            ],
+            "qrels_recovery": "ir_datasets beir/nfcorpus/test",
+        },
+        "members": [
+            _member_record(README_NAME, readme, kind="documentation"),
+            *run_records,
+        ],
+    }
+    members[MANIFEST_NAME] = _canonical_json_bytes(manifest)
+
+    archive = Path(output_archive).resolve()
+    _write_deterministic_zip(archive, members)
+    return {
+        "archive": str(archive),
+        "bytes": archive.stat().st_size,
+        "sha256": sha256_file(archive),
+        "manifest": manifest,
+    }
+
+
+def verify_release_archive(
+    archive_path: Path | str,
+    *,
+    expected_sha256: str | None = None,
+    expected_bytes: int | None = None,
+) -> dict[str, Any]:
+    """Verify the outer archive and every declared text member."""
+    return _verify_release_archive(
+        archive_path,
+        expected_sha256=expected_sha256,
+        expected_bytes=expected_bytes,
+        expected_schema=BUNDLE_SCHEMA,
+    )
+
+
+def fetch_release_bundle(
+    *,
+    pointer_path: Path | str,
+    output_dir: Path | str,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Download, verify, and safely extract the pinned ablation bundle."""
+    return _fetch_release_bundle(
+        pointer_path=pointer_path,
+        output_dir=output_dir,
+        timeout=timeout,
+        expected_schema=BUNDLE_SCHEMA,
+    )
+
+
+def _load_qrels(
+    dataset_id: str,
+    *,
+    qrels_path: Path | None,
+    cache_dir: Path | None,
+) -> tuple[dict[str, dict[str, int]], str]:
+    if qrels_path is not None:
+        return read_qrels(qrels_path, qrels_format="auto"), str(qrels_path)
+    benchmark = load_benchmark_queries(dataset_id, cache_dir=cache_dir)
+    return benchmark.graded_qrels, benchmark.spec.dataset_id
+
+
+def _per_query_scores(
+    run: Mapping[str, list[tuple[str, float]]],
+    qrels: Mapping[str, dict[str, int]],
+    metric: str,
+) -> list[float]:
+    scores: list[float] = []
+    for qid in sorted(qrels):
+        judgments = qrels[qid]
+        relevant = {
+            doc_id
+            for doc_id, relevance in judgments.items()
+            if relevance >= DEFAULT_REL_THRESHOLD
+        }
+        ranked = [doc_id for doc_id, _score in run[qid]]
+        if metric == "mrr@10":
+            value = reciprocal_rank(ranked, relevant, 10)
+        elif metric == "ndcg@10":
+            value = graded_ndcg_at_k(ranked, judgments, k=10)
+        elif metric == "recall@100":
+            value = recall_at_k(ranked, relevant, 100)
+        elif metric == "recall@1000":
+            value = recall_at_k(ranked, relevant, 1000)
+        else:
+            raise ReleaseArtifactError(f"unsupported paired metric: {metric}")
+        scores.append(float(value))
+    return scores
+
+
+def _no_hit_counts(
+    baseline: Mapping[str, list[tuple[str, float]]],
+    treatment: Mapping[str, list[tuple[str, float]]],
+    qrels: Mapping[str, dict[str, int]],
+    *,
+    cutoff: int,
+) -> dict[str, int]:
+    baseline_miss: list[bool] = []
+    treatment_miss: list[bool] = []
+    for qid in sorted(qrels):
+        relevant = {
+            doc_id
+            for doc_id, relevance in qrels[qid].items()
+            if relevance >= DEFAULT_REL_THRESHOLD
+        }
+        baseline_ranked = [doc_id for doc_id, _score in baseline[qid]]
+        treatment_ranked = [doc_id for doc_id, _score in treatment[qid]]
+        baseline_miss.append(
+            first_relevant_rank(baseline_ranked, relevant, cutoff) is None
+        )
+        treatment_miss.append(
+            first_relevant_rank(treatment_ranked, relevant, cutoff) is None
+        )
+    return {
+        "baseline": sum(baseline_miss),
+        "treatment": sum(treatment_miss),
+        "recovered": sum(
+            before and not after
+            for before, after in zip(baseline_miss, treatment_miss)
+        ),
+        "lost": sum(
+            not before and after
+            for before, after in zip(baseline_miss, treatment_miss)
+        ),
+    }
+
+
+def _paired_comparisons(
+    runs: Mapping[tuple[str, str], dict[str, list[tuple[str, float]]]],
+    qrels: Mapping[str, dict[str, int]],
+    *,
+    n_resamples: int,
+    seed: int,
+) -> dict[str, Any]:
+    pairs = (
+        ("description_vs_title", "title", "description"),
+        (
+            "title_plus_description_vs_title",
+            "title",
+            "title_plus_description",
+        ),
+        (
+            "title_plus_description_vs_description",
+            "description",
+            "title_plus_description",
+        ),
+    )
+    comparisons: dict[str, Any] = {}
+    for system, metric_names in SYSTEM_METRICS.items():
+        system_comparisons: dict[str, Any] = {}
+        for label, baseline_name, treatment_name in pairs:
+            baseline_run = runs[(baseline_name, system)]
+            treatment_run = runs[(treatment_name, system)]
+            metrics: dict[str, Any] = {}
+            for metric in metric_names:
+                baseline_scores = _per_query_scores(baseline_run, qrels, metric)
+                treatment_scores = _per_query_scores(treatment_run, qrels, metric)
+                record = paired_bootstrap_diff(
+                    baseline_scores,
+                    treatment_scores,
+                    n_resamples=n_resamples,
+                    seed=seed,
+                )
+                deltas = [
+                    treatment - baseline
+                    for baseline, treatment in zip(
+                        baseline_scores,
+                        treatment_scores,
+                    )
+                ]
+                record["wins"] = sum(delta > 0 for delta in deltas)
+                record["ties"] = sum(delta == 0 for delta in deltas)
+                record["losses"] = sum(delta < 0 for delta in deltas)
+                metrics[metric] = record
+            cutoffs = (100, 1000) if system == "bm25" else (100,)
+            system_comparisons[label] = {
+                "baseline": baseline_name,
+                "treatment": treatment_name,
+                "metrics": metrics,
+                "no_hit_queries": {
+                    f"@{cutoff}": _no_hit_counts(
+                        baseline_run,
+                        treatment_run,
+                        qrels,
+                        cutoff=cutoff,
+                    )
+                    for cutoff in cutoffs
+                },
+            }
+        comparisons[system] = system_comparisons
+    return comparisons
+
+
+def _validate_expected_paired(
+    observed: Mapping[str, Any],
+    expected: Any,
+    *,
+    tolerance: float,
+) -> float:
+    if not isinstance(expected, dict):
+        raise ReleaseArtifactError("bundle manifest has no paired expectations")
+    max_delta = 0.0
+    for system, comparisons in expected.items():
+        if not isinstance(comparisons, dict) or system not in observed:
+            raise ReleaseArtifactError(f"invalid paired expectation stage: {system}")
+        for comparison, metrics in comparisons.items():
+            try:
+                observed_metrics = observed[system][comparison]["metrics"]
+            except (KeyError, TypeError) as exc:
+                raise ReleaseArtifactError(
+                    f"missing reproduced paired comparison: {system}/{comparison}"
+                ) from exc
+            if not isinstance(metrics, dict):
+                raise ReleaseArtifactError("paired metric expectations must be objects")
+            for metric, expected_record in metrics.items():
+                if not isinstance(expected_record, dict) or metric not in observed_metrics:
+                    raise ReleaseArtifactError(
+                        f"invalid paired expectation: {system}/{comparison}/{metric}"
+                    )
+                for field in ("mean_delta", "ci_low", "ci_high", "p_two_sided"):
+                    delta = abs(
+                        float(observed_metrics[metric][field])
+                        - float(expected_record[field])
+                    )
+                    max_delta = max(max_delta, delta)
+                    if delta > tolerance:
+                        raise ReleaseArtifactError(
+                            "paired reproduction drift for "
+                            f"{system}/{comparison}/{metric}/{field}: "
+                            f"{delta:.3g} exceeds {tolerance:g}"
+                        )
+    return max_delta
+
+
+def _write_reproduction_table(path: Path, results: Mapping[str, Any]) -> None:
+    lines = [
+        "# Reproduced NFCorpus video query-representation metrics",
+        "",
+        "| Representation | System | MRR@10 | nDCG@10 | Recall@100 | "
+        "Recall@1000 | Max abs. delta |",
+        "|---|---|---:|---:|---:|---:|---:|",
+    ]
+    labels = {
+        "title": "Title",
+        "description": "Description",
+        "title_plus_description": "Title + description",
+    }
+    for representation in REPRESENTATIONS:
+        for system in ("bm25", "bm25_ce"):
+            record = results[f"{representation}_{system}"]
+            metrics = record["metrics"]
+            recall_1000 = (
+                f"{metrics['recall@1000']:.4f}"
+                if "recall@1000" in metrics
+                else "n/a"
+            )
+            lines.append(
+                f"| {labels[representation]} | {system} | "
+                f"{metrics['mrr@10']:.4f} | {metrics['ndcg@10']:.4f} | "
+                f"{metrics['recall@100']:.4f} | {recall_1000} | "
+                f"{record['max_abs_delta']:.2e} |"
+            )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def evaluate_release_bundle(
+    *,
+    bundle_dir: Path | str,
+    output_dir: Path | str,
+    qrels_path: Path | str | None = None,
+    cache_dir: Path | str | None = None,
+    tolerance: float = DEFAULT_TOLERANCE,
+) -> dict[str, Any]:
+    """Recompute all six aggregate rows and the frozen paired comparisons."""
+    if tolerance < 0 or not math.isfinite(tolerance):
+        raise ReleaseArtifactError("tolerance must be finite and non-negative")
+    source = Path(bundle_dir).resolve()
+    manifest = _load_json_object(source / MANIFEST_NAME)
+    if manifest.get("schema") != BUNDLE_SCHEMA:
+        raise ReleaseArtifactError(f"bundle directory does not use {BUNDLE_SCHEMA}")
+    _verify_extracted_directory(source, manifest)
+
+    scope = manifest.get("scope")
+    if not isinstance(scope, dict):
+        raise ReleaseArtifactError("bundle manifest has no scope")
+    dataset_id = str(scope.get("dataset", ""))
+    expected_queries = int(scope.get("query_count", 0))
+    expected_qid_hash = str(scope.get("qid_sha256", ""))
+    bm25_depth = int(scope.get("bm25_depth", 0))
+    rerank_depth = int(scope.get("rerank_depth", 0))
+    n_resamples = int(scope.get("bootstrap_resamples", 0))
+    seed = int(scope.get("bootstrap_seed", 0))
+    if dataset_id != DEFAULT_DATASET_ID or min(
+        expected_queries,
+        bm25_depth,
+        rerank_depth,
+        n_resamples,
+    ) < 1:
+        raise ReleaseArtifactError("bundle manifest has an invalid scope")
+
+    run_records = [
+        record
+        for record in _manifest_members(manifest).values()
+        if record.get("kind") == "nfcorpus_video_run"
+    ]
+    if len(run_records) != len(RUN_SPECS):
+        raise ReleaseArtifactError("bundle does not contain exactly six run records")
+    runs: dict[tuple[str, str], dict[str, list[tuple[str, float]]]] = {}
+    record_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    reference_qids: set[str] | None = None
+    for record in run_records:
+        representation = str(record.get("representation", ""))
+        system = str(record.get("system", ""))
+        key = (representation, system)
+        if representation not in REPRESENTATIONS or system not in SYSTEM_METRICS:
+            raise ReleaseArtifactError(f"invalid run identity: {key}")
+        if key in runs:
+            raise ReleaseArtifactError(f"duplicate run identity: {key}")
+        run = read_run_tsv(source / str(record["path"]))
+        expected_depth = bm25_depth if system == "bm25" else rerank_depth
+        qids = set(run)
+        row_count = sum(len(rows) for rows in run.values())
+        if (
+            len(qids) != expected_queries
+            or row_count != int(record.get("row_count", -1))
+            or any(len(rows) != expected_depth for rows in run.values())
+        ):
+            raise ReleaseArtifactError(f"{record['path']}: run structure drift")
+        if reference_qids is None:
+            reference_qids = qids
+        elif qids != reference_qids:
+            raise ReleaseArtifactError("query-id sets differ across extracted runs")
+        runs[key] = run
+        record_by_key[key] = record
+
+    if reference_qids is None or _qid_sha256(reference_qids) != expected_qid_hash:
+        raise ReleaseArtifactError("extracted run qids do not match the frozen cohort")
+    candidate_checks = _validate_candidate_sets(runs, rerank_depth=rerank_depth)
+    if candidate_checks != int(scope.get("candidate_set_checks", -1)):
+        raise ReleaseArtifactError("candidate-set check count differs from the manifest")
+
+    resolved_qrels_path = Path(qrels_path).resolve() if qrels_path is not None else None
+    resolved_cache_dir = Path(cache_dir).resolve() if cache_dir is not None else None
+    all_qrels, qrels_source = _load_qrels(
+        dataset_id,
+        qrels_path=resolved_qrels_path,
+        cache_dir=resolved_cache_dir,
+    )
+    missing_qrels = sorted(reference_qids - set(all_qrels))
+    if missing_qrels:
+        raise ReleaseArtifactError(
+            f"public qrels are missing {len(missing_qrels)} frozen query ids"
+        )
+    qrels = {qid: dict(all_qrels[qid]) for qid in sorted(reference_qids)}
+
+    results: dict[str, Any] = {}
+    aggregate_max_delta = 0.0
+    for spec in RUN_SPECS:
+        key = (spec.representation, spec.system)
+        record = record_by_key[key]
+        metrics = evaluate_internal_trec_scope(
+            runs[key],
+            qrels,
+            rel_threshold=DEFAULT_REL_THRESHOLD,
+        )
+        expected_metrics = record.get("expected_metrics")
+        if not isinstance(expected_metrics, dict) or not expected_metrics:
+            raise ReleaseArtifactError(f"{record['path']}: expected metrics are missing")
+        deltas = {
+            name: abs(float(metrics[name]) - float(expected))
+            for name, expected in expected_metrics.items()
+        }
+        max_delta = max(deltas.values(), default=0.0)
+        if max_delta > tolerance:
+            raise ReleaseArtifactError(
+                f"{record['path']}: reproduced metrics drift by {max_delta:.3g}; "
+                f"tolerance is {tolerance:g}"
+            )
+        aggregate_max_delta = max(aggregate_max_delta, max_delta)
+        reproduced = {name: float(metrics[name]) for name in expected_metrics}
+        reproduced["n_queries"] = int(metrics["n_queries"])
+        results[f"{spec.representation}_{spec.system}"] = {
+            "representation": spec.representation,
+            "system": spec.system,
+            "run": record["path"],
+            "metrics": reproduced,
+            "expected_metrics": expected_metrics,
+            "absolute_deltas": deltas,
+            "max_abs_delta": max_delta,
+        }
+
+    paired = _paired_comparisons(
+        runs,
+        qrels,
+        n_resamples=n_resamples,
+        seed=seed,
+    )
+    paired_max_delta = _validate_expected_paired(
+        paired,
+        manifest.get("expected_paired_comparisons"),
+        tolerance=tolerance,
+    )
+    report = {
+        "schema": REPRODUCTION_SCHEMA,
+        "artifact_id": manifest.get("artifact_id"),
+        "experiment_commits": manifest.get("experiment_commits"),
+        "verified": True,
+        "qrels_source": qrels_source,
+        "tolerance": tolerance,
+        "aggregate_max_abs_delta": aggregate_max_delta,
+        "paired_max_abs_delta": paired_max_delta,
+        "candidate_set_checks": candidate_checks,
+        "results": results,
+        "paired_comparisons": paired,
+    }
+    destination = Path(output_dir).resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+    (destination / "metrics.json").write_bytes(_canonical_json_bytes(report))
+    _write_reproduction_table(destination / "metrics.md", results)
+    return report

--- a/tests/test_nfcorpus_video_release.py
+++ b/tests/test_nfcorpus_video_release.py
@@ -1,0 +1,300 @@
+"""Tests for the public NFCorpus video-query ablation release workflow."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from msmarco_genqa.evaluation.trec import evaluate_internal_trec_scope, read_qrels
+from msmarco_genqa.reproducibility.nfcorpus_video_release import (
+    BUNDLE_SCHEMA,
+    REPRESENTATIONS,
+    ReleaseArtifactError,
+    _paired_comparisons,
+    _qid_sha256,
+    build_release_bundle,
+    evaluate_release_bundle,
+    fetch_release_bundle,
+    verify_release_archive,
+)
+from msmarco_genqa.reproducibility.trec_release import (
+    POINTER_SCHEMA,
+    load_release_pointer,
+)
+from msmarco_genqa.reranking.io import read_run_tsv
+
+
+def _write_run(path: Path, rows: dict[str, list[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    for qid in sorted(rows):
+        for rank, doc_id in enumerate(rows[qid], start=1):
+            lines.append(f"{qid}\tQ0\t{doc_id}\t{rank}\t{3-rank}.0\ttest")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _make_release_sources(root: Path) -> tuple[Path, Path]:
+    qrels_path = root / "qrels.trec"
+    qrels_path.write_text(
+        "q1 0 d1 2\nq1 0 d2 1\nq2 0 d3 2\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    qrels = read_qrels(qrels_path, qrels_format="trec")
+    bm25_rows = {
+        "title": {"q1": ["miss1", "d1"], "q2": ["miss2", "d3"]},
+        "description": {"q1": ["d1", "miss1"], "q2": ["d3", "miss2"]},
+        "title_plus_description": {"q1": ["d1", "d2"], "q2": ["d3", "miss2"]},
+    }
+
+    results: dict[str, object] = {}
+    runs: dict[tuple[str, str], dict[str, list[tuple[str, float]]]] = {}
+    for representation in REPRESENTATIONS:
+        root_dir = root / "outputs" / "beir_nfcorpus_video" / representation
+        bm25_path = root_dir / "bm25" / "run.tsv"
+        rerank_path = root_dir / "cross_encoder_rerank" / "run.tsv"
+        _write_run(bm25_path, bm25_rows[representation])
+        _write_run(
+            rerank_path,
+            {
+                qid: [doc_ids[0]]
+                for qid, doc_ids in bm25_rows[representation].items()
+            },
+        )
+        bm25_run = read_run_tsv(bm25_path)
+        rerank_run = read_run_tsv(rerank_path)
+        runs[(representation, "bm25")] = bm25_run
+        runs[(representation, "bm25_ce")] = rerank_run
+        bm25_metrics = evaluate_internal_trec_scope(bm25_run, qrels, rel_threshold=1)
+        rerank_metrics = evaluate_internal_trec_scope(
+            rerank_run,
+            qrels,
+            rel_threshold=1,
+        )
+        rerank_metrics.pop("recall@1000")
+        results[representation] = {
+            "bm25": bm25_metrics,
+            "bm25_ce": rerank_metrics,
+            "artifact_paths": {
+                "bm25_run": bm25_path.relative_to(root).as_posix(),
+                "rerank_run": rerank_path.relative_to(root).as_posix(),
+            },
+            "artifact_sha256": {
+                "bm25_run": _sha256_file(bm25_path),
+                "rerank_run": _sha256_file(rerank_path),
+            },
+        }
+
+    paired = _paired_comparisons(runs, qrels, n_resamples=20, seed=7)
+    description = results["description"]
+    combined = results["title_plus_description"]
+    assert isinstance(description, dict)
+    assert isinstance(combined, dict)
+    description["paired_vs_title"] = {
+        "recall@100": paired["bm25"]["description_vs_title"]["metrics"][
+            "recall@100"
+        ]
+    }
+    combined["paired_vs_title"] = {
+        "recall@100": paired["bm25"]["title_plus_description_vs_title"][
+            "metrics"
+        ]["recall@100"],
+        "bm25_mrr@10": paired["bm25"]["title_plus_description_vs_title"][
+            "metrics"
+        ]["mrr@10"],
+        "bm25_ndcg@10": paired["bm25"]["title_plus_description_vs_title"][
+            "metrics"
+        ]["ndcg@10"],
+        "bm25_ce_mrr@10": paired["bm25_ce"][
+            "title_plus_description_vs_title"
+        ]["metrics"]["mrr@10"],
+        "bm25_ce_ndcg@10": paired["bm25_ce"][
+            "title_plus_description_vs_title"
+        ]["metrics"]["ndcg@10"],
+    }
+
+    source_record = {
+        "schema": "msmarco-genqa.table-artifact.v1",
+        "query_set": {
+            "n_queries": 2,
+            "qid_sha256": _qid_sha256({"q1", "q2"}),
+        },
+        "model_revision": {
+            "first_stage": "test-bm25",
+            "reranker": "test-ce",
+            "reranker_revision": "a" * 40,
+            "candidate_depth": 1,
+        },
+        "experiment": {
+            "git_commits": {"bm25": "a" * 40, "reranker": "b" * 40},
+            "dataset": "beir/nfcorpus/test",
+            "subset": "official_test_video",
+            "bm25": {"retrieval_depth": 2},
+            "reranker": {"depth": 1},
+            "evaluation": {
+                "bootstrap_resamples": 20,
+                "bootstrap_seed": 7,
+                "confidence_level": 0.95,
+            },
+        },
+        "results": results,
+    }
+    source_path = (
+        root
+        / "reports"
+        / "generated"
+        / "artifacts"
+        / "nfcorpus_video_query_representation.json"
+    )
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text(
+        json.dumps(source_record, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return source_path, qrels_path
+
+
+def test_release_build_is_deterministic_and_text_only(tmp_path: Path) -> None:
+    source_record, _qrels = _make_release_sources(tmp_path)
+    first = tmp_path / "first.zip"
+    second = tmp_path / "second.zip"
+
+    first_result = build_release_bundle(
+        source_record_path=source_record,
+        project_root=tmp_path,
+        output_archive=first,
+    )
+    second_result = build_release_bundle(
+        source_record_path=source_record,
+        project_root=tmp_path,
+        output_archive=second,
+    )
+
+    assert first.read_bytes() == second.read_bytes()
+    assert first_result["sha256"] == second_result["sha256"]
+    verified = verify_release_archive(first)
+    with zipfile.ZipFile(first) as archive:
+        assert len(archive.namelist()) == 8
+        assert set(archive.namelist()) == {
+            "README.md",
+            "bundle_manifest.json",
+            "runs/nfcorpus_video_title_bm25.tsv",
+            "runs/nfcorpus_video_title_bm25_ce.tsv",
+            "runs/nfcorpus_video_description_bm25.tsv",
+            "runs/nfcorpus_video_description_bm25_ce.tsv",
+            "runs/nfcorpus_video_title_plus_description_bm25.tsv",
+            "runs/nfcorpus_video_title_plus_description_bm25_ce.tsv",
+        }
+        contents = b"\n".join(archive.read(name) for name in archive.namelist())
+    assert verified["manifest"]["schema"] == BUNDLE_SCHEMA
+    assert verified["manifest"]["source_record"]["serialization"] == (
+        "canonical-json-utf8-sorted-keys-compact"
+    )
+    assert b"query text" in contents
+    assert b"C:\\Users" not in contents
+
+
+def test_fetch_and_evaluate_recomputes_aggregates_and_bootstrap(
+    tmp_path: Path,
+) -> None:
+    source_record, _qrels_path = _make_release_sources(tmp_path)
+    qrels_path = tmp_path / "qrels.irds.tsv"
+    qrels_path.write_text(
+        "query-id\tcorpus-id\tscore\n"
+        "q1\td1\t2\n"
+        "q1\td2\t1\n"
+        "q2\td3\t2\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    archive = tmp_path / "release.zip"
+    built = build_release_bundle(
+        source_record_path=source_record,
+        project_root=tmp_path,
+        output_archive=archive,
+    )
+    pointer = {
+        "schema": POINTER_SCHEMA,
+        "artifact_id": built["manifest"]["artifact_id"],
+        "release": {
+            "repository": "GioiaZheng/msmarco-genqa",
+            "tag": "test",
+            "asset": archive.name,
+        },
+        "download": {
+            "url": archive.as_uri(),
+            "sha256": built["sha256"],
+            "bytes": built["bytes"],
+        },
+    }
+    pointer_path = tmp_path / "pointer.json"
+    pointer_path.write_text(json.dumps(pointer), encoding="utf-8")
+
+    fetched = fetch_release_bundle(
+        pointer_path=pointer_path,
+        output_dir=tmp_path / "recovered",
+    )
+    report = evaluate_release_bundle(
+        bundle_dir=fetched["bundle_dir"],
+        output_dir=tmp_path / "evaluation",
+        qrels_path=qrels_path,
+    )
+
+    assert report["verified"] is True
+    assert report["aggregate_max_abs_delta"] == 0.0
+    assert report["paired_max_abs_delta"] == 0.0
+    assert report["candidate_set_checks"] == 6
+    assert len(report["results"]) == 6
+    assert "recall@1000" not in report["results"]["title_bm25_ce"]["metrics"]
+    assert (tmp_path / "evaluation" / "metrics.json").is_file()
+    table = (tmp_path / "evaluation" / "metrics.md").read_text(encoding="utf-8")
+    assert "Title + description" in table
+
+
+def test_release_build_rejects_run_hash_drift(tmp_path: Path) -> None:
+    source_record, _qrels = _make_release_sources(tmp_path)
+    run = (
+        tmp_path
+        / "outputs"
+        / "beir_nfcorpus_video"
+        / "title"
+        / "bm25"
+        / "run.tsv"
+    )
+    run.write_text(run.read_text(encoding="utf-8") + "q3 Q0 d3 1 1.0 test\n")
+
+    with pytest.raises(ReleaseArtifactError, match="SHA-256 mismatch"):
+        build_release_bundle(
+            source_record_path=source_record,
+            project_root=tmp_path,
+            output_archive=tmp_path / "release.zip",
+        )
+
+
+def test_tracked_release_pointer_is_internally_consistent() -> None:
+    project_root = Path(__file__).parents[1]
+    pointer = load_release_pointer(
+        project_root / "artifacts" / "nfcorpus_video_query_representation_v1.json"
+    )
+    release = pointer["release"]
+    download = pointer["download"]
+
+    assert release["repository"] == "GioiaZheng/msmarco-genqa"
+    assert f"/{release['tag']}/{release['asset']}" in download["url"]
+    assert pointer["contents"]["run_files"] == 6
+    assert pointer["reproduce"] == {
+        "command": "make reproduce-nfcorpus-video-eval",
+        "requires_private_credentials": False,
+        "rebuilds_corpus_indexes": False,
+        "reruns_retrieval": False,
+        "reruns_cross_encoder": False,
+    }


### PR DESCRIPTION
## Summary

This follow-up to #180 makes the exact six text-only runs behind the NFCorpus test/video query-representation ablation independently recoverable:

- three fixed query representations (`title`, `description`, and `title_plus_description`);
- BM25 top-1,000 and the corresponding fixed-candidate cross-encoder top-100 for each representation;
- a deterministic Release ZIP with an immutable Git-tracked pointer;
- one command, `make reproduce-nfcorpus-video-eval`, to download the asset, verify the archive and every member hash, recover public qrels, and recompute all six rows and paired comparisons.

The bundle contains ranked query/document identifiers, ranks, scores, checksums, and compact evaluation metadata only. It excludes query/document text, qrels mirrors, model weights, caches, and machine-local manifests.

## Reproduction contract

The command verifies:

- the pinned asset size and SHA-256;
- all eight ZIP members (README, manifest, and six runs);
- the frozen 102-query cohort and qid hash;
- BM25 depth 1,000 and CE depth 100;
- all 306 fixed-candidate checks;
- aggregate metric drift at tolerance `1e-12`;
- the published paired-bootstrap comparisons with 10,000 resamples and seed `20260727`.

The source-record provenance hash uses canonical JSON serialization so it remains stable across Windows and Linux line-ending conventions.

## Validation

- real six-run local round-trip: aggregate max delta `0.0`, paired max delta `0.0`, 306/306 candidate checks;
- deterministic rebuild: 2,975,679 bytes and SHA-256 `6d588eef275989e822d12e40afa67396a6226dd6df52246877a312556c64272f` on both builds;
- `659 passed, 1 skipped, 1 deselected`;
- full Ruff check passed;
- artifact-boundary and artifact-registry history checks passed;
- staged secret/local-path scan passed.

## Release step

After this PR is reviewed, green, and merged, publish `outputs/releases/nfcorpus-video-query-ablation-v1.zip` under tag `v2.3-nfcorpus-video-query-ablation`, then run the same reproduction command against the public GitHub URL before marking the work complete.