### PR TITLE
docs: link Hugging Face benchmark runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Secret scan](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/secret-scan.yml/badge.svg?branch=main)](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/secret-scan.yml?query=branch%3Amain)
 [![CodeQL](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/GioiaZheng/msmarco-genqa/actions/workflows/codeql.yml?query=branch%3Amain)
 [![Latest release](https://img.shields.io/github/v/release/GioiaZheng/msmarco-genqa?display_name=tag)](https://github.com/GioiaZheng/msmarco-genqa/releases/latest)
+[![Hugging Face dataset](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-benchmark%20runs-FFD21E)](https://huggingface.co/datasets/GioiaZheng/msmarco-genqa-benchmark-runs)
 [![Python](https://img.shields.io/badge/python-%E2%89%A53.10-3776AB?logo=python&logoColor=white)](https://github.com/GioiaZheng/msmarco-genqa/blob/main/pyproject.toml)
 [![License](https://img.shields.io/github/license/GioiaZheng/msmarco-genqa)](https://github.com/GioiaZheng/msmarco-genqa/blob/main/LICENSE)
 
@@ -31,6 +32,13 @@ is [`RESULTS.md`](RESULTS.md); reproducibility entry points are documented in
 [`report.html`](reports/repo_report/report.html) kept alongside it; the compact
 ACL-style findings write-up is
 [`reports/acl_findings/report.pdf`](reports/acl_findings/report.pdf).
+
+The 14 exact TREC-DL, BEIR cross-domain, and NFCorpus video-query ranked
+runs are also published as a
+[Hugging Face Dataset](https://huggingface.co/datasets/GioiaZheng/msmarco-genqa-benchmark-runs),
+with a normalized Parquet preview, raw TREC-format outputs, checksum
+manifests, and the original Release archives. It contains ranked identifiers,
+ranks, and scores only; benchmark text and qrels are not redistributed.
 
 ## Results at a glance
 


### PR DESCRIPTION
## What changed

- add a Hugging Face Dataset badge to the README
- link the public collection of 14 exact TREC-DL, BEIR cross-domain, and NFCorpus video-query runs
- state the published contents and the redistribution boundary next to the project overview

## Why

The benchmark outputs now have a public Dataset Viewer and a second, independently checksummed distribution point. Linking it from the repository makes the result artifacts discoverable without changing any experiment, metric, or architectural claim.

## Impact

Documentation only. No pipeline, dependency, result, or evaluation behavior changes.

## Checks

- `git diff --check`
- Hugging Face PR #1 reviewed and merged
- all 25 Hugging Face payloads independently downloaded and matched against `CHECKSUMS.sha256`
- normalized Parquet verified at 1,128,600 rows
- main Dataset Viewer and card render successfully