### PR TITLE
test: make rag triad path assertions portable

### DIFF
--- a/tests/test_rag_triad.py
+++ b/tests/test_rag_triad.py
@@ -123,5 +123,15 @@ def test_cli_writes_triad_outputs(tmp_path: Path):
     assert (output_dir / "low_score_cases.jsonl").exists()
     assert "RAG triad evaluation" in (output_dir / "report.md").read_text(encoding="utf-8")
     metrics = json.loads((output_dir / "metrics.json").read_text(encoding="utf-8"))
-    assert metrics["inputs"]["predictions"]["bm25"] == str(bm25_path)
-    assert metrics["inputs"]["qrels"] == str(qrels_path)
+    expected_bm25_path = (
+        bm25_path.relative_to(cli.PROJECT_ROOT).as_posix()
+        if bm25_path.is_relative_to(cli.PROJECT_ROOT)
+        else str(bm25_path)
+    )
+    expected_qrels_path = (
+        qrels_path.relative_to(cli.PROJECT_ROOT).as_posix()
+        if qrels_path.is_relative_to(cli.PROJECT_ROOT)
+        else str(qrels_path)
+    )
+    assert metrics["inputs"]["predictions"]["bm25"] == expected_bm25_path
+    assert metrics["inputs"]["qrels"] == expected_qrels_path


### PR DESCRIPTION
﻿## Why

The RAG triad CLI records repo-local input files as repo-relative paths. That keeps generated metrics portable and avoids leaking machine-local absolute paths. The existing test assumed every temporary input path would remain absolute, which fails when pytest uses a repo-local base temp directory.

Closes #184.

## What changed

- Updated the RAG triad CLI test to assert the same display-path contract used by the CLI.
- Kept the production CLI behavior unchanged.

## Validation

- `python -m pytest -q tests\test_rag_triad.py --basetemp outputs\tmp\pytest-target`
- `python -m pytest -q tests --basetemp outputs\tmp\pytest`
- `python -m ruff check src tests experiments scripts`

## Risk / follow-up

Low risk. This is a test-only portability fix.
