### PR TITLE
ci: update setup-python to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
           cache: pip
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
## Why
Update the pinned setup-python action used by CI to the current v7 release.

## What changed
- Replaced the pinned actions/setup-python v6 SHA with the v7.0.0 SHA in CI jobs.

## Validation
- git diff --check
- ruff check src tests experiments scripts
- pytest -q tests --basetemp outputs\\tmp\\pytest

## Risk / follow-up
Low risk. This only changes the workflow action version and does not modify code, dependency locks, or research artifacts.

Supersedes #177.