### PR TITLE
deps: update ruff lockfile pin

### DIFF
--- a/artifacts/registry.json
+++ b/artifacts/registry.json
@@ -4,8 +4,8 @@
   "hash_convention": "sha256_lf normalizes CRLF and CR text newlines to LF before hashing",
   "current_lockfile": {
     "path": "requirements-lock.txt",
-    "sha256_lf": "3b381eb5b4b1024f3424a21e4b74071db6cda49300cad47ffa457e1a54cf7528",
-    "last_dependency_change_commit": "e05230fb79427f98113861df9a6d2fa3e6ff85cd",
+    "sha256_lf": "cfb03be8beaa81fec293c660f5a17289f740b3aaf436533f809809495074902e",
+    "last_dependency_change_commit": "d8decc672ad63dd754c3b83d2533818162a94fdb",
     "reproduction_note": "docs/lockfile_reproduction.md",
     "validation": [
       "python -m pip install --dry-run -r requirements-lock.txt",

--- a/docs/lockfile_reproduction.md
+++ b/docs/lockfile_reproduction.md
@@ -26,6 +26,27 @@ needed.
 | Torch, Transformers, SentenceTransformers, tokenizer, or model revision | Above checks plus `scripts/smoke_model_stack.py`; rerun the affected headline experiment or open a linked follow-up before treating old and new results as comparable. |
 | Security remediation with forced transitive changes | Record the vulnerability and constrained package set, run the affected smoke/evaluation checks, and document any unavoidable reproduction boundary. |
 
+### Tooling refresh: 2026-08-03
+
+The current snapshot updates `ruff` from 0.15.20 to 0.16.0. This is a
+tooling-only dependency refresh for static analysis and does not change the
+runtime retrieval, reranking, generation, or evaluation stack.
+
+This refresh does not rebaseline any published metric. Historical results stay
+attached to the lockfile snapshots recorded by their artifact-registry entries;
+new experiment manifests record the environment used for new runs.
+
+At minimum, run:
+
+```bash
+python -m pip install --dry-run -r requirements-lock.txt
+python scripts/check_fixture_headline_metrics.py
+python scripts/check_artifact_registry.py
+python scripts/export_report_tables.py
+ruff check src tests experiments scripts
+pytest -q
+```
+
 ### Security refresh: 2026-07-21
 
 The current snapshot updates `torch` from 2.12.1 to 2.13.0 and `nltk` from

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -60,4 +60,4 @@ bert-score==0.3.13
 
 # --- Testing / lint ---
 pytest==9.1.1
-ruff==0.15.20
+ruff==0.16.0


### PR DESCRIPTION
## Why
Refresh the pinned lint dependency while keeping the reproducibility registry aligned with the accepted lockfile snapshot.

## What changed
- Updated requirements-lock.txt to ruff 0.16.0.
- Recorded the normalized lockfile hash and dependency-change commit in the artifact registry.
- Documented the 2026-08-03 tooling-only lockfile refresh.

## Validation
- python -m pip install --dry-run -r requirements-lock.txt
- python scripts/check_artifact_registry.py
- PYTHONPATH=src python scripts/check_fixture_headline_metrics.py
- PYTHONPATH=src python scripts/export_report_tables.py
- ruff check src tests experiments scripts
- pytest -q tests --basetemp outputs\\tmp\\pytest

## Risk / follow-up
Low runtime risk. This updates lint tooling only and does not rebaseline any published retrieval, reranking, generation, or evaluation metric.

Supersedes #176.