### PR TITLE
build(deps): refresh Python lockfile snapshot

### DIFF
--- a/artifacts/registry.json
+++ b/artifacts/registry.json
@@ -4,8 +4,8 @@
   "hash_convention": "sha256_lf normalizes CRLF and CR text newlines to LF before hashing",
   "current_lockfile": {
     "path": "requirements-lock.txt",
-    "sha256_lf": "cfb03be8beaa81fec293c660f5a17289f740b3aaf436533f809809495074902e",
-    "last_dependency_change_commit": "d8decc672ad63dd754c3b83d2533818162a94fdb",
+    "sha256_lf": "9a694f7095311d6ce8d294d4719f14ccb9a30d4908724b17645c6353cd3b31dd",
+    "last_dependency_change_commit": "5cbc4980014138ab2f4a1342a2717bff3717a3b2",
     "reproduction_note": "docs/lockfile_reproduction.md",
     "validation": [
       "python -m pip install --dry-run -r requirements-lock.txt",

--- a/docs/lockfile_reproduction.md
+++ b/docs/lockfile_reproduction.md
@@ -26,6 +26,39 @@ needed.
 | Torch, Transformers, SentenceTransformers, tokenizer, or model revision | Above checks plus `scripts/smoke_model_stack.py`; rerun the affected headline experiment or open a linked follow-up before treating old and new results as comparable. |
 | Security remediation with forced transitive changes | Record the vulnerability and constrained package set, run the affected smoke/evaluation checks, and document any unavoidable reproduction boundary. |
 
+### Dependency refresh: 2026-08-25
+
+The current snapshot refreshes five pinned direct dependencies:
+
+- `ir_datasets` from 0.6.1 to 0.6.3;
+- `bm25s` from 0.3.9 to 0.3.10;
+- `transformers` from 5.12.1 to 5.14.1;
+- `sentencepiece` from 0.2.1 to 0.2.2;
+- `ruff` from 0.16.0 to 0.16.1.
+
+The refresh folds together the lockfile-only updates tracked in Dependabot
+PRs #149, #173, #174, #175, and #176. It does not rebaseline any published
+retrieval, reranking, or generation metric. Historical results stay attached
+to the lockfile snapshots recorded by their artifact-registry entries; new
+experiment manifests record the environment used for new runs.
+
+Because the refresh touches lexical retrieval, dataset loading, tokenizer, and
+Transformers pins, treat old and new model-stack results as comparable only
+after the model-stack smoke check and any affected benchmark rerun have been
+reviewed.
+
+At minimum, run:
+
+```bash
+python -m pip install --dry-run -r requirements-lock.txt
+python scripts/check_fixture_headline_metrics.py
+python scripts/check_artifact_registry.py
+python scripts/export_report_tables.py
+python scripts/smoke_model_stack.py
+ruff check src tests experiments scripts
+pytest -q
+```
+
 ### Tooling refresh: 2026-08-03
 
 The current snapshot updates `ruff` from 0.15.20 to 0.16.0. This is a

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -32,11 +32,11 @@ PyYAML==6.0.3
 
 # --- Datasets and IO ---
 datasets==5.0.0
-ir_datasets==0.6.1
+ir_datasets==0.6.3
 lxml==6.1.1
 
 # --- Lexical retrieval ---
-bm25s==0.3.9
+bm25s==0.3.10
 
 # --- Dense retrieval ---
 sentence-transformers==5.6.0
@@ -44,11 +44,11 @@ faiss-cpu==1.14.3
 
 # --- Generation / reranking (transformers stack) ---
 torch==2.13.0
-transformers==5.12.1
+transformers==5.14.1
 # Keep tokenizers on the latest stable 0.22.x pin accepted by the
 # transformers stack; 0.23.0 has no stable release.
 tokenizers==0.22.2
-sentencepiece==0.2.1
+sentencepiece==0.2.2
 safetensors==0.8.0
 
 # --- Evaluation ---
@@ -60,4 +60,4 @@ bert-score==0.3.13
 
 # --- Testing / lint ---
 pytest==9.1.1
-ruff==0.16.0
+ruff==0.16.1


### PR DESCRIPTION
## Why

Dependabot opened five lockfile-only dependency refresh PRs (#149, #173, #174, #175, and #176). Each branch is correctly blocked by the artifact-registry gate because requirements-lock.txt changed without the current lockfile hash and reproduction note being updated. This PR replaces those bot branches with a reviewable manual snapshot.

Closes #194.

## What changed

- Refreshes the pinned direct dependencies for ir_datasets, bm25s, transformers, sentencepiece, and ruff.
- Updates the current lockfile hash and dependency-change anchor in artifacts/registry.json.
- Documents the 2026-08-25 lockfile refresh and keeps published metrics attached to their original artifact snapshots.

## Validation

- python -m pip install --dry-run -r requirements-lock.txt
- python scripts/check_artifact_registry.py
- python scripts/check_artifact_boundaries.py
- python scripts/check_fixture_headline_metrics.py
- python scripts/export_report_tables.py
- ruff check src tests experiments scripts
- pytest -q --basetemp C:\Users\gioia.zheng\Documents\Codex\pytest-msmarco-lock-refresh-20260825 -p no:cacheprovider (666 passed, 3 skipped, 1 deselected)

## Risk / follow-up

This does not rebaseline any retrieval, reranking, or generation metric. Because the snapshot touches retrieval and model-stack pins, use the refreshed lockfile for new headline comparisons only after the affected benchmark or model-stack smoke run has been reviewed under the accepted environment.